### PR TITLE
Connect RepositoryManagerDriver with Configuration from common, and finish implementing.

### DIFF
--- a/common/src/main/java/org/jboss/pnc/common/Configuration.java
+++ b/common/src/main/java/org/jboss/pnc/common/Configuration.java
@@ -1,12 +1,13 @@
 package org.jboss.pnc.common;
 
-import javax.enterprise.context.ApplicationScoped;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Properties;
+
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Created by <a href="mailto:matejonnet@gmail.com">Matej Lazar</a> on 2014-12-02.
@@ -20,8 +21,12 @@ public class Configuration {
         readConfigurationFile();
     }
 
+    public Configuration(final Properties properties) {
+        this.properties = properties;
+    }
+
     //TODO return only part containing config for requested module
-    public Properties getModuleConfig(String moduleTag) {
+    public Properties getModuleConfig(final String moduleTag) {
         return properties;
     }
 
@@ -37,7 +42,7 @@ public class Configuration {
         file = new File(configFileName); //try full path
 
         if (!file.exists()) {
-            URL url = getClass().getClassLoader().getResource(configFileName);
+            final URL url = getClass().getClassLoader().getResource(configFileName);
             if (url != null) {
                 file = new File(url.getFile());
             }

--- a/common/src/main/java/org/jboss/pnc/common/util/UrlUtils.java
+++ b/common/src/main/java/org/jboss/pnc/common/util/UrlUtils.java
@@ -1,0 +1,80 @@
+package org.jboss.pnc.common.util;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
+public final class UrlUtils
+{
+
+    private UrlUtils()
+    {
+    }
+
+    public static String buildUrl( final String baseUrl, final String... parts )
+        throws MalformedURLException
+    {
+        return buildUrl( baseUrl, null, parts );
+    }
+
+    public static String buildUrl( final String baseUrl, final Map<String, String> params, final String... parts )
+        throws MalformedURLException
+    {
+        if ( parts == null || parts.length < 1 )
+        {
+            return baseUrl;
+        }
+
+        final StringBuilder urlBuilder = new StringBuilder();
+
+        if ( parts[0] == null || !parts[0].startsWith( baseUrl ) )
+        {
+            urlBuilder.append( baseUrl );
+        }
+
+        for ( String part : parts )
+        {
+            if ( part == null || part.trim()
+                                     .length() < 1 )
+            {
+                continue;
+            }
+
+            if ( part.startsWith( "/" ) )
+            {
+                part = part.substring( 1 );
+            }
+
+            if ( urlBuilder.length() > 0 && urlBuilder.charAt( urlBuilder.length() - 1 ) != '/' )
+            {
+                urlBuilder.append( "/" );
+            }
+
+            urlBuilder.append( part );
+        }
+
+        if ( params != null && !params.isEmpty() )
+        {
+            urlBuilder.append( "?" );
+            boolean first = true;
+            for ( final Map.Entry<String, String> param : params.entrySet() )
+            {
+                if ( first )
+                {
+                    first = false;
+                }
+                else
+                {
+                    urlBuilder.append( "&" );
+                }
+
+                urlBuilder.append( param.getKey() )
+                          .append( "=" )
+                          .append( param.getValue() );
+            }
+        }
+
+        return new URL( urlBuilder.toString() ).toExternalForm();
+    }
+
+}

--- a/jenkins-build-driver/pom.xml
+++ b/jenkins-build-driver/pom.xml
@@ -22,12 +22,10 @@
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>pnc-spi</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>common</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- Remote dependencies -->

--- a/maven-repository-manager/pom.xml
+++ b/maven-repository-manager/pom.xml
@@ -12,7 +12,6 @@
     </parent>
 
     <artifactId>maven-repository-manager</artifactId>
-    <packaging>jar</packaging>
 
     <description>Implementation of pnc-spi:org.jboss.pnc.spi.repositorymanager</description>
 
@@ -20,13 +19,20 @@
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>pnc-spi</artifactId>
-            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.pnc</groupId>
+            <artifactId>common</artifactId>
         </dependency>
 
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.weld.se</groupId>
+          <artifactId>weld-se</artifactId>
         </dependency>
     </dependencies>
 

--- a/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositoryConnectionInfo.java
+++ b/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositoryConnectionInfo.java
@@ -2,32 +2,41 @@ package org.jboss.pnc.mavenrepositorymanager;
 
 import org.jboss.pnc.spi.repositorymanager.RepositoryConnectionInfo;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class MavenRepositoryConnectionInfo implements RepositoryConnectionInfo {
 
+    private static final String ALT_DEPLOY_OPTION = "altDeploymentRepository";
+    private static final String ALT_DEPLOY_FORMAT = "deploy::default::%s";
+
+    private String url;
+
+    public MavenRepositoryConnectionInfo(String url) {
+        this.url = url;
+    }
+
     @Override
     public String getDependencyUrl() {
-        // TODO Auto-generated method stub
-        return null;
+        return url;
     }
 
     @Override
     public String getToolchainUrl() {
-        // TODO Auto-generated method stub
-        return null;
+        return url;
     }
 
     @Override
     public Map<String, String> getProperties() {
-        // TODO Auto-generated method stub
-        return null;
+        Map<String, String> props = new HashMap<>();
+        props.put(ALT_DEPLOY_OPTION, String.format(ALT_DEPLOY_FORMAT, url));
+
+        return props;
     }
 
     @Override
     public String getDeployUrl() {
-        // TODO Auto-generated method stub
-        return null;
+        return url;
     }
 
 }

--- a/maven-repository-manager/src/main/resources/META-INF/beans.xml
+++ b/maven-repository-manager/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://jboss.org/schema/cdi/beans_1_0.xsd"/>

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriverTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriverTest.java
@@ -1,0 +1,90 @@
+package org.jboss.pnc.mavenrepositorymanager;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import org.jboss.pnc.common.Configuration;
+import org.jboss.pnc.model.BuildCollection;
+import org.jboss.pnc.model.Product;
+import org.jboss.pnc.model.ProductVersion;
+import org.jboss.pnc.model.Project;
+import org.jboss.pnc.model.ProjectBuildConfiguration;
+import org.jboss.pnc.spi.repositorymanager.RepositoryConfiguration;
+import org.jboss.pnc.spi.repositorymanager.RepositoryConnectionInfo;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Properties;
+
+public class RepositoryManagerDriverTest {
+
+    private RepositoryManagerDriver driver;
+
+    @Before
+    public void setup() {
+        Properties props = new Properties();
+        props.setProperty("base.url", "http://localhost/");
+        Configuration config = new Configuration(props);
+        driver = new RepositoryManagerDriver(config);
+    }
+
+    @Test
+    public void formatRepositoryURLForSimpleInfo_CheckDependencyURL() throws Exception {
+        ProjectBuildConfiguration pbc = simpleProjectBuildConfiguration();
+
+        BuildCollection bc = new BuildCollection();
+        bc.setProductVersion(pbc.getProductVersion());
+
+        RepositoryConfiguration repositoryConfiguration = driver.createRepository(pbc, bc);
+        assertThat(repositoryConfiguration, notNullValue());
+
+        RepositoryConnectionInfo connectionInfo = repositoryConfiguration.getConnectionInfo();
+        assertThat(connectionInfo, notNullValue());
+
+        String expectedUrlWithoutTstamp = String.format("http://localhost/api/group/build+%s+%s+%s+", pbc.getProductVersion()
+                .getProduct().getName(), pbc.getProductVersion().getVersion(), pbc.getProject().getName());
+
+        assertThat(
+                "Expected URL prefix: " + expectedUrlWithoutTstamp + "\nActual URL was: " + connectionInfo.getDependencyUrl(),
+                connectionInfo.getDependencyUrl().startsWith(expectedUrlWithoutTstamp), equalTo(true));
+    }
+
+    @Test
+    public void formatRepositoryURLForSimpleInfo_AllURLsMatch() throws Exception {
+        ProjectBuildConfiguration pbc = simpleProjectBuildConfiguration();
+
+        BuildCollection bc = new BuildCollection();
+        bc.setProductVersion(pbc.getProductVersion());
+
+        RepositoryConfiguration repositoryConfiguration = driver.createRepository(pbc, bc);
+        assertThat(repositoryConfiguration, notNullValue());
+
+        RepositoryConnectionInfo connectionInfo = repositoryConfiguration.getConnectionInfo();
+        assertThat(connectionInfo, notNullValue());
+
+        String expectedUrl = connectionInfo.getDependencyUrl();
+
+        assertThat(connectionInfo.getToolchainUrl(), equalTo(expectedUrl));
+        assertThat(connectionInfo.getDeployUrl(), equalTo(expectedUrl));
+    }
+
+    private ProjectBuildConfiguration simpleProjectBuildConfiguration() {
+        Project project = new Project();
+        project.setName("myproject");
+
+        Product product = new Product();
+        product.setName("myproduct");
+
+        ProductVersion pv = new ProductVersion();
+        pv.setProduct(product);
+        pv.setVersion("1.0");
+
+        ProjectBuildConfiguration pbc = new ProjectBuildConfiguration();
+        pbc.setProject(project);
+        pbc.setProductVersion(pv);
+
+        return pbc;
+    }
+
+}

--- a/pnc-core/src/main/java/org/jboss/pnc/core/builder/ProjectBuilder.java
+++ b/pnc-core/src/main/java/org/jboss/pnc/core/builder/ProjectBuilder.java
@@ -13,10 +13,12 @@ import org.jboss.pnc.spi.datastore.Datastore;
 import org.jboss.pnc.spi.environment.EnvironmentDriverProvider;
 import org.jboss.pnc.spi.repositorymanager.RepositoryConfiguration;
 import org.jboss.pnc.spi.repositorymanager.RepositoryManager;
+import org.jboss.pnc.spi.repositorymanager.RepositoryManagerException;
 
-import javax.inject.Inject;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
+
+import javax.inject.Inject;
 
 /**
  * Created by <a href="mailto:matejonnet@gmail.com">Matej Lazar</a> on 2014-11-23.
@@ -39,7 +41,7 @@ public class ProjectBuilder {
     private Logger log;
 
     public boolean buildProject(ProjectBuildConfiguration projectBuildConfiguration, BuildCollection buildCollection)
-            throws CoreException, BuildDriverException {
+            throws CoreException, BuildDriverException, RepositoryManagerException {
 
         BuildDriver buildDriver = buildDriverFactory.getBuildDriver(projectBuildConfiguration.getEnvironment().getBuildType());
         RepositoryManager repositoryManager = repositoryManagerFactory.getRepositoryManager(RepositoryType.MAVEN);

--- a/pnc-core/src/test/java/org/jboss/pnc/core/test/BuildProjectsTestCase.java
+++ b/pnc-core/src/test/java/org/jboss/pnc/core/test/BuildProjectsTestCase.java
@@ -2,17 +2,21 @@ package org.jboss.pnc.core.test;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.pnc.common.Configuration;
 import org.jboss.pnc.common.Resources;
 import org.jboss.pnc.core.BuildDriverFactory;
 import org.jboss.pnc.core.RepositoryManagerFactory;
 import org.jboss.pnc.core.builder.ProjectBuilder;
-import org.jboss.pnc.core.exception.CoreException;
 import org.jboss.pnc.core.test.mock.BuildDriverMock;
 import org.jboss.pnc.core.test.mock.DatastoreMock;
 import org.jboss.pnc.mavenrepositorymanager.RepositoryManagerDriver;
-import org.jboss.pnc.model.*;
+import org.jboss.pnc.model.BuildCollection;
+import org.jboss.pnc.model.Environment;
+import org.jboss.pnc.model.Product;
+import org.jboss.pnc.model.ProductVersion;
+import org.jboss.pnc.model.Project;
+import org.jboss.pnc.model.ProjectBuildConfiguration;
 import org.jboss.pnc.model.builder.EnvironmentBuilder;
-import org.jboss.pnc.spi.builddriver.exception.BuildDriverException;
 import org.jboss.pnc.spi.environment.EnvironmentDriverProvider;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -21,8 +25,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import javax.inject.Inject;
 import java.util.logging.Logger;
+
+import javax.inject.Inject;
 
 /**
  * Created by <a href="mailto:matejonnet@gmail.com">Matej Lazar</a> on 2014-11-23.
@@ -34,7 +39,7 @@ public class BuildProjectsTestCase {
     public static JavaArchive createDeployment() {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class).addClass(ProjectBuilder.class)
                 .addClass(BuildDriverFactory.class).addClass(RepositoryManagerFactory.class).addClass(Resources.class)
-                .addClass(EnvironmentBuilder.class).addClass(EnvironmentDriverProvider.class)
+                .addClass(EnvironmentBuilder.class).addClass(EnvironmentDriverProvider.class).addClass(Configuration.class)
                 .addPackage(RepositoryManagerDriver.class.getPackage()).addPackage(BuildDriverMock.class.getPackage())
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").addAsResource("META-INF/logging.properties");
         System.out.println(jar.toString(true));
@@ -51,7 +56,7 @@ public class BuildProjectsTestCase {
     Logger log;
 
     @Test
-    public void createProjectStructure() throws InterruptedException, CoreException, BuildDriverException {
+    public void createProjectStructure() throws Exception {
         Environment javaEnvironment = EnvironmentBuilder.defaultEnvironment().build();
         Environment nativeEnvironment = EnvironmentBuilder.defaultEnvironment().withNative().build();
 

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/trigger/BuildTriggerer.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/trigger/BuildTriggerer.java
@@ -1,15 +1,17 @@
 package org.jboss.pnc.rest.trigger;
 
-import com.google.common.base.Preconditions;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+
 import org.jboss.pnc.core.builder.ProjectBuilder;
 import org.jboss.pnc.core.exception.CoreException;
 import org.jboss.pnc.datastore.repositories.ProjectBuildConfigurationRepository;
 import org.jboss.pnc.model.BuildCollection;
 import org.jboss.pnc.model.ProjectBuildConfiguration;
 import org.jboss.pnc.spi.builddriver.exception.BuildDriverException;
+import org.jboss.pnc.spi.repositorymanager.RepositoryManagerException;
 
-import javax.ejb.Stateless;
-import javax.inject.Inject;
+import com.google.common.base.Preconditions;
 
 @Stateless
 public class BuildTriggerer {
@@ -22,16 +24,18 @@ public class BuildTriggerer {
     }
 
     @Inject
-    public BuildTriggerer(ProjectBuilder projectBuilder, ProjectBuildConfigurationRepository projectBuildConfigurationRepository) {
+    public BuildTriggerer(final ProjectBuilder projectBuilder, final ProjectBuildConfigurationRepository projectBuildConfigurationRepository) {
         this.projectBuilder = projectBuilder;
         this.projectBuildConfigurationRepository = projectBuildConfigurationRepository;
     }
 
-    public void triggerBuilds(Integer configurationId) throws InterruptedException, CoreException, BuildDriverException {
-        ProjectBuildConfiguration configuration = projectBuildConfigurationRepository.findOne(configurationId);
+    public void triggerBuilds( final Integer configurationId )
+        throws InterruptedException, CoreException, BuildDriverException, RepositoryManagerException
+    {
+        final ProjectBuildConfiguration configuration = projectBuildConfigurationRepository.findOne(configurationId);
         Preconditions.checkArgument(configuration != null, "Can't find configuration with given id=" + configurationId);
 
-        BuildCollection buildCollection = new BuildCollection();
+        final BuildCollection buildCollection = new BuildCollection();
         buildCollection.setProductVersion(configuration.getProductVersion());
 
         projectBuilder.buildProject(configuration, buildCollection);

--- a/pnc-spi/src/main/java/org/jboss/pnc/spi/repositorymanager/RepositoryManager.java
+++ b/pnc-spi/src/main/java/org/jboss/pnc/spi/repositorymanager/RepositoryManager.java
@@ -19,7 +19,7 @@ public interface RepositoryManager {
      * @param buildCollection Used to determine which in-progress product repository should be used.
      */
     RepositoryConfiguration createRepository( ProjectBuildConfiguration projectBuildConfiguration,
-                                              BuildCollection buildCollection );
+            BuildCollection buildCollection) throws RepositoryManagerException;
 
     boolean canManage(RepositoryType managerType);
 
@@ -28,5 +28,5 @@ public interface RepositoryManager {
      * @param repository Used during the build, containing input and output artifacts
      * @param buildResult The record of the build, to which records of deployed / input artifacts should be attached
      */
-    void persistArtifacts( RepositoryConfiguration repository, ProjectBuildResult buildResult );
+    void persistArtifacts(RepositoryConfiguration repository, ProjectBuildResult buildResult) throws RepositoryManagerException;
 }

--- a/pnc-spi/src/main/java/org/jboss/pnc/spi/repositorymanager/RepositoryManagerException.java
+++ b/pnc-spi/src/main/java/org/jboss/pnc/spi/repositorymanager/RepositoryManagerException.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Red Hat, Inc..
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/gpl.html
+ * 
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.pnc.spi.repositorymanager;
+
+import java.text.MessageFormat;
+import java.util.IllegalFormatException;
+
+public class RepositoryManagerException
+    extends Exception
+{
+
+    private static final long serialVersionUID = 1L;
+
+    private Object[] params;
+
+    private transient String formatted;
+
+    public RepositoryManagerException( final String format, final Object... params )
+    {
+        super( format );
+        this.params = params;
+    }
+
+    public RepositoryManagerException( final String format, final Throwable error, final Object... params )
+    {
+        super( format, error );
+        this.params = params;
+    }
+
+    @Override
+    public String getMessage()
+    {
+        if ( formatted == null )
+        {
+            formatted = super.getMessage();
+
+            if ( params != null )
+            {
+                try
+                {
+                    formatted = String.format( formatted.replaceAll( "\\{\\}", "%s" ), params );
+                }
+                catch ( final IllegalFormatException ife )
+                {
+                    try
+                    {
+                        formatted = MessageFormat.format( formatted, params );
+                    }
+                    catch ( final IllegalArgumentException iae )
+                    {
+                    }
+                }
+            }
+        }
+
+        return formatted;
+    }
+
+    private Object writeReplace()
+    {
+        final Object[] newParams = new Object[params.length];
+        int i = 0;
+        for ( final Object object : params )
+        {
+            newParams[i] = String.valueOf( object );
+            i++;
+        }
+
+        this.params = newParams;
+        return this;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,86 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Project modules, to support cross-module dependencies -->
+            <dependency>
+              <groupId>org.jboss.pnc</groupId>
+              <artifactId>common</artifactId>
+              <version>1.0-SNAPSHOT</version>
+            </dependency>
+            
+            <dependency>
+              <groupId>org.jboss.pnc</groupId>
+              <artifactId>datastore</artifactId>
+              <version>1.0-SNAPSHOT</version>
+            </dependency>
+            
+            <dependency>
+              <groupId>org.jboss.pnc</groupId>
+              <artifactId>ear-package</artifactId>
+              <version>1.0-SNAPSHOT</version>
+            </dependency>
+            
+            <dependency>
+              <groupId>org.jboss.pnc</groupId>
+              <artifactId>jenkins-build-driver</artifactId>
+              <version>1.0-SNAPSHOT</version>
+            </dependency>
+            
+            <dependency>
+              <groupId>org.jboss.pnc</groupId>
+              <artifactId>maven-repository-manager</artifactId>
+              <version>1.0-SNAPSHOT</version>
+            </dependency>
+            
+            <dependency>
+              <groupId>org.jboss.pnc</groupId>
+              <artifactId>pnc-core</artifactId>
+              <version>1.0-SNAPSHOT</version>
+            </dependency>
+            
+            <dependency>
+              <groupId>org.jboss.pnc</groupId>
+              <artifactId>pnc-model</artifactId>
+              <version>1.0-SNAPSHOT</version>
+            </dependency>
+            
+            <dependency>
+              <groupId>org.jboss.pnc</groupId>
+              <artifactId>pnc-rest</artifactId>
+              <version>1.0-SNAPSHOT</version>
+            </dependency>
+            
+            <dependency>
+              <groupId>org.jboss.pnc</groupId>
+              <artifactId>pnc-spi</artifactId>
+              <version>1.0-SNAPSHOT</version>
+            </dependency>
+            
+            <dependency>
+              <groupId>org.jboss.pnc</groupId>
+              <artifactId>pnc-web</artifactId>
+              <version>1.0-SNAPSHOT</version>
+            </dependency>
+            
+            <dependency>
+              <groupId>org.jboss.pnc</groupId>
+              <artifactId>docker-environment-driver</artifactId>
+              <version>1.0-SNAPSHOT</version>
+            </dependency>
+            
+            <dependency>
+              <groupId>org.jboss.pnc</groupId>
+              <artifactId>integration-test</artifactId>
+              <version>1.0-SNAPSHOT</version>
+            </dependency>
+            
+            <dependency>
+              <groupId>org.jboss.pnc</groupId>
+              <artifactId>demo-data</artifactId>
+              <version>1.0-SNAPSHOT</version>
+            </dependency>
+            <!-- END: Project modules -->
+            
             <dependency>
                 <groupId>org.jboss.bom</groupId>
                 <artifactId>jboss-javaee-6.0-with-tools</artifactId>
@@ -136,6 +216,14 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${version.guava}</version>
+            </dependency>
+            
+            <!-- Test dependencies -->
+            <dependency>
+              <groupId>org.jboss.weld.se</groupId>
+              <artifactId>weld-se</artifactId>
+              <version>2.2.0.SP1</version>
+              <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
- Connect RepositoryManagerDriver with Configuration (from common) so we can configure the repo-manager's base url (for formatting repository URLs)
- Create a new exception type in the repository-manager SPI section to deal with errors that happen in the RepositoryManager, then ripple those up through the layers.
- Add UrlUtils to help concatenating url parts together...added to common. 
- Add ctor to Configuration to enable slimmer unit tests, then do the same with RepositoryManagerDriver, so we don't have to use weld-se or Arq for simple unit tests.
- Refactor inter-module dependency declarations so all modules have a managed dep at the top level and we can keep project.version expressions out of the poms.
- Add some javadocs to the RepositoryManagerDriver
