### PR TITLE
Use 'project.version' variable for sub module dependencies

### DIFF
--- a/datastore/pom.xml
+++ b/datastore/pom.xml
@@ -21,17 +21,14 @@
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>pnc-spi</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>pnc-model</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>common</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
         <!-- Remote dependencies -->

--- a/demo-data/pom.xml
+++ b/demo-data/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>datastore</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>

--- a/docker-environment-driver/pom.xml
+++ b/docker-environment-driver/pom.xml
@@ -23,7 +23,6 @@
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>pnc-spi</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec</groupId>

--- a/ear-package/pom.xml
+++ b/ear-package/pom.xml
@@ -18,58 +18,47 @@
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>common</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>datastore</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>jenkins-build-driver</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>maven-repository-manager</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>pnc-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>pnc-model</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>pnc-rest</artifactId>
-            <version>${project.version}</version>
             <type>ejb</type>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>pnc-spi</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>docker-environment-driver</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>demo-data</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>pnc-web</artifactId>
-            <version>${project.version}</version>
             <type>war</type>
         </dependency>
 

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -24,7 +24,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ear-package</artifactId>
-            <version>${project.version}</version>
             <scope>test</scope>
             <type>ear</type>
         </dependency>
@@ -32,7 +31,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>datastore</artifactId>
-            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pnc-core/pom.xml
+++ b/pnc-core/pom.xml
@@ -21,17 +21,14 @@
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>pnc-spi</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>pnc-model</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>common</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
         <!-- Remote dependencies -->
@@ -45,7 +42,6 @@
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>maven-repository-manager</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pnc-rest/pom.xml
+++ b/pnc-rest/pom.xml
@@ -21,13 +21,11 @@
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>pnc-core</artifactId>
-            <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>datastore</artifactId>
-            <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pnc-spi/pom.xml
+++ b/pnc-spi/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>pnc-model</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/pnc-web/pom.xml
+++ b/pnc-web/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>common</artifactId>
-            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,79 +60,82 @@
             <dependency>
               <groupId>org.jboss.pnc</groupId>
               <artifactId>common</artifactId>
-              <version>1.0-SNAPSHOT</version>
+              <version>${project.version}</version>
             </dependency>
             
             <dependency>
               <groupId>org.jboss.pnc</groupId>
               <artifactId>datastore</artifactId>
-              <version>1.0-SNAPSHOT</version>
+              <version>${project.version}</version>
             </dependency>
             
             <dependency>
               <groupId>org.jboss.pnc</groupId>
               <artifactId>ear-package</artifactId>
-              <version>1.0-SNAPSHOT</version>
+              <version>${project.version}</version>
+	      <type>ear</type>
             </dependency>
             
             <dependency>
               <groupId>org.jboss.pnc</groupId>
               <artifactId>jenkins-build-driver</artifactId>
-              <version>1.0-SNAPSHOT</version>
+              <version>${project.version}</version>
             </dependency>
             
             <dependency>
               <groupId>org.jboss.pnc</groupId>
               <artifactId>maven-repository-manager</artifactId>
-              <version>1.0-SNAPSHOT</version>
+              <version>${project.version}</version>
             </dependency>
             
             <dependency>
               <groupId>org.jboss.pnc</groupId>
               <artifactId>pnc-core</artifactId>
-              <version>1.0-SNAPSHOT</version>
+              <version>${project.version}</version>
             </dependency>
             
             <dependency>
               <groupId>org.jboss.pnc</groupId>
               <artifactId>pnc-model</artifactId>
-              <version>1.0-SNAPSHOT</version>
+              <version>${project.version}</version>
             </dependency>
             
             <dependency>
               <groupId>org.jboss.pnc</groupId>
               <artifactId>pnc-rest</artifactId>
-              <version>1.0-SNAPSHOT</version>
+              <version>${project.version}</version>
+	      <type>ejb</type>
             </dependency>
             
             <dependency>
               <groupId>org.jboss.pnc</groupId>
               <artifactId>pnc-spi</artifactId>
-              <version>1.0-SNAPSHOT</version>
+              <version>${project.version}</version>
             </dependency>
             
             <dependency>
               <groupId>org.jboss.pnc</groupId>
               <artifactId>pnc-web</artifactId>
-              <version>1.0-SNAPSHOT</version>
+              <version>${project.version}</version>
+	      <type>war</type>
             </dependency>
             
             <dependency>
               <groupId>org.jboss.pnc</groupId>
               <artifactId>docker-environment-driver</artifactId>
-              <version>1.0-SNAPSHOT</version>
+              <version>${project.version}</version>
             </dependency>
             
             <dependency>
               <groupId>org.jboss.pnc</groupId>
               <artifactId>integration-test</artifactId>
-              <version>1.0-SNAPSHOT</version>
+              <version>${project.version}</version>
             </dependency>
             
             <dependency>
               <groupId>org.jboss.pnc</groupId>
               <artifactId>demo-data</artifactId>
-              <version>1.0-SNAPSHOT</version>
+              <version>${project.version}</version>
             </dependency>
             <!-- END: Project modules -->
             


### PR DESCRIPTION
Use 'project.version' variable for sub module dependencies  remove versions of cross-modules dependencies from sub modules to be managed by top level pom.xml

 There are <dependencyManagement> section in top level pom.xml, where we defined sub modules versions,  so there won't be necessary to specify <version> of cross-modules dependencies in sub modules at more.
