### PR TITLE
[Issue-17] integration-test collides with other services on port 8080

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -21,6 +21,8 @@
         <arquillian.container.groupId>org.wildfly</arquillian.container.groupId>
         <arquillian.container.artifactId>wildfly-arquillian-container-managed</arquillian.container.artifactId>
         <arquillian.container.version>8.2.0.Final</arquillian.container.version>
+        <jboss.port.offset>0</jboss.port.offset>
+        <default.management.port>9990</default.management.port>
     </properties>
 
 
@@ -84,6 +86,39 @@
                 <filtering>true</filtering>
             </testResource>
         </testResources>
+       <plugins>
+	       <plugin>
+		 <groupId>org.codehaus.gmavenplus</groupId>
+		 <artifactId>gmavenplus-plugin</artifactId>
+		 <version>1.2</version>
+		 <executions>
+		   <execution>
+		     <id>calculate-jboss-port-offset</id>
+		     <goals>
+		       <goal>execute</goal>
+		     </goals>
+		     <phase>validate</phase>
+		     <configuration>
+		       <scripts>
+			 <script>
+			   offset = Integer.valueOf(System.getProperty("jboss.port.offset", "0"))
+			   manPort = Integer.valueOf(project.properties["default.management.port"])
+			   project.properties['jboss.management.port'] = "${manPort + offset}".trim()
+			 </script>
+		       </scripts>
+		     </configuration>
+		   </execution>
+		 </executions>
+		 <dependencies>
+		   <dependency>
+		     <groupId>org.codehaus.groovy</groupId>
+		     <artifactId>groovy-all</artifactId>
+		     <version>2.3.7</version>
+		     <scope>runtime</scope>
+		   </dependency>
+		 </dependencies>
+	       </plugin>
+       </plugins>
     </build>
 
 
@@ -140,6 +175,7 @@
                     <arquillian.container.groupId>org.jboss.as</arquillian.container.groupId>
                     <arquillian.container.artifactId>jboss-as-arquillian-container-managed</arquillian.container.artifactId>
 		    <arquillian.container.version>${version.jboss.as}</arquillian.container.version>
+                    <default.management.port>9999</default.management.port>
 		</properties>
 	        <build>
                   <plugins>

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildTest.java
@@ -12,7 +12,8 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 
-import static com.jayway.restassured.RestAssured.get;
+import static org.jboss.pnc.integration.env.IntegrationTestEnv.getHttpPort;
+
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.path.json.JsonPath.from;
 
@@ -33,9 +34,11 @@ public class BuildTest {
     //@Ignore //FIXME TEST fails with 500
     @Test
     public void shouldTriggerBuildAndFinishWithoutProblems() {
-        Integer notNullId = from(get("/pnc-web/rest/configuration").asString()).get("[0].id");
+        Integer notNullId = from(given()
+                .port(getHttpPort()).get("/pnc-web/rest/configuration").asString()).get("[0].id");
 
         given()
+        .port(getHttpPort())
         .when()
             .post("/pnc-web/rest/configuration/" + notNullId + "/build")
         .then()

--- a/integration-test/src/test/java/org/jboss/pnc/integration/RestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/RestTest.java
@@ -12,11 +12,14 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 
+import static org.jboss.pnc.integration.env.IntegrationTestEnv.getHttpPort;
+
 import static com.jayway.restassured.RestAssured.get;
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.path.json.JsonPath.from;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
+
 
 @RunWith(Arquillian.class)
 public class RestTest {
@@ -35,7 +38,8 @@ public class RestTest {
     @Test
     public void shouldReturnListOfConfigurations() {
         //given
-        String allConfigurations = get("/pnc-web/rest/configuration").asString();
+        String allConfigurations = given()
+                .port(getHttpPort()).get("/pnc-web/rest/configuration").asString();
 
         //when
         Integer notNullId = from(allConfigurations).get("[0].id");
@@ -46,9 +50,11 @@ public class RestTest {
 
     @Test
     public void shouldReturnSpecificConfiguration() {
-        Integer notNullId = from(get("/pnc-web/rest/configuration").asString()).get("[0].id");
+        Integer notNullId = from(given()
+                .port(getHttpPort()).get("/pnc-web/rest/configuration").asString()).get("[0].id");
 
         given().
+        port(getHttpPort()).
         when().
             get("/pnc-web/rest/configuration/" + notNullId).
         then().

--- a/integration-test/src/test/java/org/jboss/pnc/integration/env/IntegrationTestEnv.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/env/IntegrationTestEnv.java
@@ -1,0 +1,28 @@
+package org.jboss.pnc.integration.env;
+
+
+/**
+ * This is the Util class to get test environment, like the http-port, etc.
+ *
+ * @author <a href="mailto:lgao@redhat.com">Lin Gao</a>
+ *
+ *
+ */
+public final class IntegrationTestEnv {
+
+	private IntegrationTestEnv(){
+		// static utils methods only.
+	}
+
+	/**
+	 * Gets Test Http Port.
+	 * 
+	 * @return the http port for REST end points, default to 8080.
+	 */
+	public static int getHttpPort() {
+		int defaultHttpPort = Integer.getInteger("jboss.http.port", 8080);
+		int offset = Integer.getInteger("jboss.port.offset", 0);
+		return defaultHttpPort + offset;
+	}
+
+}

--- a/integration-test/src/test/resources/arquillian.xml
+++ b/integration-test/src/test/resources/arquillian.xml
@@ -10,6 +10,8 @@
     <container qualifier="wf" default="true">
         <configuration>
             <property name="jbossHome">${test.server.build.dir}</property>
+            <property name="managementPort">${jboss.management.port}</property>
+            <property name="javaVmArguments">-Xmx512m -Djboss.socket.binding.port-offset=${jboss.port.offset}</property>
         </configuration>
     </container>
 


### PR DESCRIPTION
This is for https://github.com/project-ncl/pnc/issues/17.

JBoss EAP 6 and WildFly has a system property: 'jboss.socket.binding.port-offset', which can be used to set ports offset, Arquillian managed container for EAP 6 or WildFly provides this feature also.

The side effects of this change for integration tests are that all http request test cases should consider the http port, instead of use the default '8080' blindly. 

A new util class: 'IntegrationTestEnv' is created to get these environment information, each test case can 'static' import the 'IntegrationTestEnv.getHttpPort()' method.

> mvn -Djboss.port.offset=100 clean install
