### PR TITLE
[NCL-404] Update build configuration name and description fields

### DIFF
--- a/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
+++ b/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
@@ -120,7 +120,6 @@ public class DatabaseDataInitializer {
             /*
              * All the bi-directional mapping settings are managed inside the Builders
              */
-
             Product product = ProductBuilder.newBuilder().name(PNC_PRODUCT_NAME).description("Project Newcastle Product")
                     .build();
             ProductVersion productVersion = ProductVersionBuilder.newBuilder().version(PNC_PRODUCT_VERSION).product(product)
@@ -135,21 +134,22 @@ public class DatabaseDataInitializer {
                     .productVersion(productVersion).build();
             BuildConfiguration buildConfiguration = BuildConfigurationBuilder.newBuilder()
                     .buildScript("mvn clean deploy -Dmaven.test.skip")
-                    .environment(EnvironmentBuilder.defaultEnvironment().build()).id(1).identifier(PNC_PROJECT_BUILD_CFG_ID)
+                    .environment(EnvironmentBuilder.defaultEnvironment().build()).id(1).name(PNC_PROJECT_BUILD_CFG_ID)
                     .productVersion(productVersion).project(project).scmUrl("https://github.com/project-ncl/pnc.git")
-                    .scmBranch("*/v0.2").build();
+                    .scmBranch("*/v0.2").description("Test build config for project newcastle").build();
 
             // Additional configurations
             BuildConfiguration buildConfiguration2 = BuildConfigurationBuilder.newBuilder()
                     .buildScript("mvn clean deploy -Dmaven.test.skip")
-                    .environment(EnvironmentBuilder.defaultEnvironment().build()).id(2).identifier("jboss-modules-1.5.0")
-                    .productVersion(productVersion).project(project)
+                    .environment(EnvironmentBuilder.defaultEnvironment().build()).id(2).name("jboss-modules-1.5.0")
+                    .productVersion(productVersion).project(project).description("Test config for JBoss modules build master branch.")
                     .scmUrl("https://github.com/jboss-modules/jboss-modules.git").build();
             BuildConfiguration buildConfiguration3 = BuildConfigurationBuilder.newBuilder()
                     .buildScript("mvn clean deploy -Dmaven.test.skip")
                     .environment(EnvironmentBuilder.defaultEnvironment().build()).id(3)
-                    .identifier("jboss-servlet-spec-api-1.0.1").productVersion(productVersion).project(project)
-                    .scmUrl("https://github.com/jboss/jboss-servlet-api_spec.git").dependency(buildConfiguration2).build();
+                    .name("jboss-servlet-spec-api-1.0.1").productVersion(productVersion).project(project)
+                    .scmUrl("https://github.com/jboss/jboss-servlet-api_spec.git").dependency(buildConfiguration2)
+                    .description("Test build for jboss java servlet api").build();
 
             User demoUser = UserBuilder.newBuilder().username("demo-user").firstName("Demo First Name")
                     .lastName("Demo Last Name").email("demo-user@pnc.com").build();

--- a/integration-test/src/test/java/org/jboss/pnc/integration/RestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/RestTest.java
@@ -147,7 +147,7 @@ public class RestTest {
     @InSequence(8)
     public void shouldCreateNewProjectConfiguration() {
         String rawJson = "{\n" +
-                "                \"identifier\": \"pnc-1.0.0.DR1\",\n" +
+                "                \"name\": \"pnc-1.0.0.DR1\",\n" +
                 "                \"buildScript\": \"mvn clean deploy -Dmaven.test.skip\",\n" +
                 "                \"scmUrl\": \"https://github.com/project-ncl/pnc.git\",\n" +
                 "                \"patchesUrl\": null,\n" +

--- a/jenkins-build-driver/src/main/java/org/jboss/pnc/jenkinsbuilddriver/BuildJob.java
+++ b/jenkins-build-driver/src/main/java/org/jboss/pnc/jenkinsbuilddriver/BuildJob.java
@@ -63,7 +63,7 @@ class BuildJob {
     }
 
     public String getJobName() {
-        return buildConfiguration.getIdentifier();
+        return buildConfiguration.getName();
     }
 
     public int start() throws BuildDriverException {

--- a/jenkins-build-driver/src/test/java/org/jboss/pnc/jenkinsbuilddriver/test/JenkinsDriverRemoteTest.java
+++ b/jenkins-build-driver/src/test/java/org/jboss/pnc/jenkinsbuilddriver/test/JenkinsDriverRemoteTest.java
@@ -179,7 +179,7 @@ public class JenkinsDriverRemoteTest {
         BuildConfiguration pbc = new BuildConfiguration();
         pbc.setScmUrl("https://github.com/project-ncl/pnc.git");
         pbc.setBuildScript("mvn clean install -Dmaven.test.skip");
-        pbc.setIdentifier("PNC-executed-from-jenkins-driver-test");
+        pbc.setName("PNC-executed-from-jenkins-driver-test");
         Project project = new Project();
         project.setName("PNC-executed-from-jenkins-driver-test");
         pbc.setProject(project);

--- a/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildCoordinator.java
+++ b/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildCoordinator.java
@@ -256,7 +256,7 @@ public class BuildCoordinator {
 
     public BuildTask getBuild(String identifier) {
         List<BuildTask> buildsFilteredTask = buildTasks.stream()
-                .filter(b -> identifier.equals(b.buildConfiguration.getIdentifier())).collect(Collectors.toList());
+                .filter(b -> identifier.equals(b.buildConfiguration.getName())).collect(Collectors.toList());
         return buildsFilteredTask.get(0); //TODO validate that there is exactly one ?
     }
 

--- a/pnc-core/src/main/java/org/jboss/pnc/core/builder/DatastoreAdapter.java
+++ b/pnc-core/src/main/java/org/jboss/pnc/core/builder/DatastoreAdapter.java
@@ -33,7 +33,7 @@ public class DatastoreAdapter {
             buildRecord.setBuildLog(completedBuild.getBuildLog());
             buildRecord.setStatus(completedBuild.getBuildDriverStatus());
             buildRecord.setBuildConfiguration(buildConfiguration);
-            log.debugf("Storing results of %s to datastore.", buildConfiguration.getIdentifier());
+            log.debugf("Storing results of %s to datastore.", buildConfiguration.getName());
             datastore.storeCompletedBuild(buildRecord);
         } catch (Exception e) {
             throw new DatastoreException("Error storing the result to datastore.", e);
@@ -47,7 +47,7 @@ public class DatastoreAdapter {
         StringWriter stackTraceWriter = new StringWriter();
         buildRecord.setStatus(BuildDriverStatus.UNKNOWN); //TODO set error status
         buildRecord.setBuildLog(stackTraceWriter.toString());
-        log.debugf("Storing ERROR result of %s to datastore. Error: %s", buildConfiguration.getIdentifier(), e);
+        log.debugf("Storing ERROR result of %s to datastore. Error: %s", buildConfiguration.getName(), e);
         datastore.storeCompletedBuild(buildRecord);
     }
 

--- a/pnc-core/src/test/java/org/jboss/pnc/core/test/buildCoordinator/ProjectBuilder.java
+++ b/pnc-core/src/test/java/org/jboss/pnc/core/test/buildCoordinator/ProjectBuilder.java
@@ -62,7 +62,7 @@ public class ProjectBuilder {
     }
 
     void buildProject(BuildConfiguration buildConfiguration, BuildCollection buildCollection) throws InterruptedException, CoreException {
-        log.info("Building project " + buildConfiguration.getIdentifier());
+        log.info("Building project " + buildConfiguration.getName());
         List<BuildStatus> receivedStatuses = new ArrayList();
 
         int nStatusUpdates = 7;

--- a/pnc-core/src/test/java/org/jboss/pnc/core/test/configurationBuilders/TestProjectConfigurationBuilder.java
+++ b/pnc-core/src/test/java/org/jboss/pnc/core/test/configurationBuilders/TestProjectConfigurationBuilder.java
@@ -51,7 +51,7 @@ public class TestProjectConfigurationBuilder {
         project.setName(name);
         BuildConfiguration buildConfiguration = new BuildConfiguration();
         buildConfiguration.setId(id);
-        buildConfiguration.setIdentifier(id + "");
+        buildConfiguration.setName(id + "");
         buildConfiguration.setEnvironment(javaEnvironment);
         buildConfiguration.setProject(project);
         project.addBuildConfiguration(buildConfiguration);

--- a/pnc-model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
@@ -31,13 +31,15 @@ public class BuildConfiguration implements Serializable {
     @GeneratedValue
     private Integer id;
 
-    private String identifier;
+    private String name;
 
     private String buildScript;
 
     private String scmUrl;
 
-    private String patchesUrl;
+    private String description;
+
+	private String patchesUrl;
 
     @ManyToOne(cascade = CascadeType.ALL)
     private ProductVersion productVersion;
@@ -89,15 +91,15 @@ public class BuildConfiguration implements Serializable {
     /**
      * @return the identifier
      */
-    public String getIdentifier() {
-        return identifier;
+    public String getName() {
+        return name;
     }
 
     /**
      * @param identifier the identifier to set
      */
-    public void setIdentifier(String identifier) {
-        this.identifier = identifier;
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**
@@ -149,6 +151,14 @@ public class BuildConfiguration implements Serializable {
     public void setPatchesUrl(String patchesUrl) {
         this.patchesUrl = patchesUrl;
     }
+
+    public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
 
     /**
      * @return the project
@@ -276,7 +286,7 @@ public class BuildConfiguration implements Serializable {
 
     @Override
     public String toString() {
-        return "BuildConfiguration [project=" + project + ", identifier=" + identifier + "]";
+        return "BuildConfiguration [project=" + project + ", identifier=" + name + "]";
     }
 
     @Override

--- a/pnc-model/src/main/java/org/jboss/pnc/model/builder/BuildConfigurationBuilder.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/builder/BuildConfigurationBuilder.java
@@ -35,7 +35,7 @@ public class BuildConfigurationBuilder {
 
     private Integer id;
 
-    private String identifier;
+    private String name;
 
     private String buildScript;
 
@@ -44,6 +44,8 @@ public class BuildConfigurationBuilder {
     private String scmBranch;
 
     private String patchesUrl;
+
+    private String description;
 
     private ProductVersion productVersion;
 
@@ -74,11 +76,12 @@ public class BuildConfigurationBuilder {
 
         BuildConfiguration buildConfiguration = new BuildConfiguration();
         buildConfiguration.setId(id);
-        buildConfiguration.setIdentifier(identifier);
+        buildConfiguration.setName(name);
         buildConfiguration.setBuildScript(buildScript);
         buildConfiguration.setScmUrl(scmUrl);
         buildConfiguration.setScmBranch(scmBranch);
         buildConfiguration.setPatchesUrl(patchesUrl);
+        buildConfiguration.setDescription(description);
         buildConfiguration.setProductVersion(productVersion);
 
         // Set the bi-directional mapping
@@ -106,8 +109,8 @@ public class BuildConfigurationBuilder {
         return this;
     }
 
-    public BuildConfigurationBuilder identifier(String identifier) {
-        this.identifier = identifier;
+    public BuildConfigurationBuilder name(String name) {
+        this.name = name;
         return this;
     }
 
@@ -128,6 +131,11 @@ public class BuildConfigurationBuilder {
 
     public BuildConfigurationBuilder patchesUrl(String patchesUrl) {
         this.patchesUrl = patchesUrl;
+        return this;
+    }
+
+    public BuildConfigurationBuilder description(String description) {
+        this.description = description;
         return this;
     }
 
@@ -175,8 +183,8 @@ public class BuildConfigurationBuilder {
         return id;
     }
 
-    public String getIdentifier() {
-        return identifier;
+    public String getName() {
+        return name;
     }
 
     public String getBuildScript() {
@@ -189,6 +197,10 @@ public class BuildConfigurationBuilder {
 
     public String getPatchesUrl() {
         return patchesUrl;
+    }
+
+    public String getDescription() {
+        return description;
     }
 
     public ProductVersion getProductVersion() {

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigurationRest.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigurationRest.java
@@ -12,7 +12,7 @@ public class BuildConfigurationRest {
 
     private Integer id;
 
-    private String identifier;
+    private String name;
 
     private String buildScript;
 
@@ -31,7 +31,7 @@ public class BuildConfigurationRest {
 
     public BuildConfigurationRest(BuildConfiguration buildConfiguration) {
         this.id = buildConfiguration.getId();
-        this.identifier = buildConfiguration.getIdentifier();
+        this.name = buildConfiguration.getName();
         this.buildScript = buildConfiguration.getBuildScript();
         this.scmUrl = buildConfiguration.getScmUrl();
         this.patchesUrl = buildConfiguration.getPatchesUrl();
@@ -48,12 +48,12 @@ public class BuildConfigurationRest {
         this.id = id;
     }
 
-    public String getIdentifier() {
-        return identifier;
+    public String getName() {
+        return name;
     }
 
-    public void setIdentifier(String identifier) {
-        this.identifier = identifier;
+    public void setName(String name) {
+        this.name = name;
     }
 
     public String getBuildScript() {
@@ -107,7 +107,7 @@ public class BuildConfigurationRest {
     public BuildConfiguration getBuildConfiguration(Project project) {
         BuildConfigurationBuilder builder = BuildConfigurationBuilder.newBuilder();
         builder.project(project);
-        builder.identifier(identifier);
+        builder.name(name);
         builder.buildScript(buildScript);
         builder.scmUrl(scmUrl);
         builder.patchesUrl(patchesUrl);


### PR DESCRIPTION
Change the build config field "identifier" to "name" to avoid confusion with the "id" field.
Add description field for better usability.