### PR TITLE
Manage version of httpcomponents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,8 @@ target/
 # Eclipse
 .project
 .settings
+.classpath
+
+# DB test file
+maven-repository-manager/derby.log
 

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -13,6 +13,7 @@
   <artifactId>integration-test</artifactId>
 
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <app.server>wildfly</app.server>
     <jboss.version>8.2.0.Final</jboss.version>
     <test.server.unpack.dir>${project.build.directory}</test.server.unpack.dir>

--- a/maven-repository-manager/pom.xml
+++ b/maven-repository-manager/pom.xml
@@ -20,6 +20,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.pnc</groupId>
       <artifactId>pnc-spi</artifactId>
     </dependency>
@@ -33,7 +37,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
@@ -53,7 +56,6 @@
       <artifactId>aprox-client-core-java</artifactId>
       <version>${aproxVersion}</version>
     </dependency>
-    
     <dependency>
       <groupId>org.commonjava.aprox.embed</groupId>
       <artifactId>aprox-embedder-savant</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,14 @@
     <version.jboss.maven.plugin>7.5.Final</version.jboss.maven.plugin>
     <version.jboss.bom>1.0.7.Final</version.jboss.bom>
     <version.jboss.as>7.2.0.Final</version.jboss.as>
+    <version.junit>4.11</version.junit>
     <atlasVersion>0.13.6</atlasVersion>
     <version.assertj-core>1.7.0</version.assertj-core>
     <version.mockito-all>1.10.8</version.mockito-all>
     <version.catch-exception>1.2.0</version.catch-exception>
     <version.guava>13.0.1</version.guava>
+    <version.org.apache.httpcomponents.httpclient>4.3.6</version.org.apache.httpcomponents.httpclient>
+    <version.org.apache.httpcomponents.httpcore>4.3.3</version.org.apache.httpcomponents.httpcore>
 
     <!-- other plugin versions -->
     <version.ejb.plugin>2.3</version.ejb.plugin>
@@ -172,6 +175,18 @@
         <version>${project.version}</version>
       </dependency>
       <!-- END: Project modules -->
+
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${version.org.apache.httpcomponents.httpclient}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>${version.org.apache.httpcomponents.httpcore}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.jboss.arquillian</groupId>
@@ -307,6 +322,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
- Relying on the transitive version of httpclient and httpcore
can cause unpredictable build behaviour.
- Minor additions to .gitignore
- Manage version of JUnit