### PR TITLE
[NCL-427] Remove patches URL from build configuration

### DIFF
--- a/integration-test/src/test/java/org/jboss/pnc/integration/RestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/RestTest.java
@@ -145,7 +145,6 @@ public class RestTest {
             properties.put("_name", _NAME);
             properties.put("_buildScript", _BUILDSCRIPT);
             properties.put("_scmUrl", _SCMURL);
-            properties.put("_patchesUrl", "");
             properties.put("_creationTime", String.valueOf(1518382545038L));
             properties.put("_lastModificationTime", String.valueOf(155382545038L));
             properties.put("_repositories", "");
@@ -212,8 +211,6 @@ public class RestTest {
                 clonedBuildConfiguration.body().jsonPath().getString("buildScript"));
         Assertions.assertThat(originalBuildConfiguration.body().jsonPath().getString("scmUrl")).isEqualTo(
                 clonedBuildConfiguration.body().jsonPath().getString("scmUrl"));
-        Assertions.assertThat(originalBuildConfiguration.body().jsonPath().getString("patchesUrl")).isEqualTo(
-                clonedBuildConfiguration.body().jsonPath().getString("patchesUrl"));
         Assertions.assertThat(originalBuildConfiguration.body().jsonPath().getString("creationTime")).isEqualTo(
                 clonedBuildConfiguration.body().jsonPath().getString("creationTime"));
         Assertions.assertThat(originalBuildConfiguration.body().jsonPath().getString("lastModificationTime")).isEqualTo(

--- a/integration-test/src/test/resources/buildConfiguration.json
+++ b/integration-test/src/test/resources/buildConfiguration.json
@@ -2,7 +2,6 @@
     "name":"pnc-1.0.0.DR1",
     "buildScript":"mvn clean deploy -Dmaven.test.skip",
     "scmUrl":"https://github.com/project-ncl/pnc.git",
-    "patchesUrl":null,
     "creationTime":1418382545021,
     "lastModificationTime":1418382545038,
     "repositories":null

--- a/integration-test/src/test/resources/buildConfiguration_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_template.json
@@ -3,7 +3,6 @@
     "name": "${_name}",
     "buildScript": "${_buildScript}",
     "scmUrl": "${_scmUrl}",
-    "patchesUrl": "${_patchesUrl}",
     "creationTime": ${_creationTime},
     "lastModificationTime": ${_lastModificationTime},
     "repositories": "${_repositories}"

--- a/pnc-core/src/main/java/org/jboss/pnc/core/builder/DatastoreAdapter.java
+++ b/pnc-core/src/main/java/org/jboss/pnc/core/builder/DatastoreAdapter.java
@@ -36,7 +36,6 @@ public class DatastoreAdapter {
             buildRecord.setBuildConfiguration(buildConfiguration);
             // Additional information needed for historical purpose
             buildRecord.setBuildScript(buildConfiguration.getBuildScript());
-            buildRecord.setPatchesUrl(buildConfiguration.getPatchesUrl());
             buildRecord.setSourceUrl(buildConfiguration.getScmUrl());
 
             log.debugf("Storing results of %s to datastore.", buildConfiguration.getName());
@@ -61,7 +60,6 @@ public class DatastoreAdapter {
         buildRecord.setBuildConfiguration(buildConfiguration);
         // Additional information needed for historical purpose
         buildRecord.setBuildScript(buildConfiguration.getBuildScript());
-        buildRecord.setPatchesUrl(buildConfiguration.getPatchesUrl());
         buildRecord.setSourceUrl(buildConfiguration.getScmUrl());
         log.debugf("Storing ERROR result of %s to datastore. Error: %s", buildConfiguration.getName(), e);
         datastore.storeCompletedBuild(buildRecord);

--- a/pnc-model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
@@ -39,8 +39,6 @@ public class BuildConfiguration implements Serializable {
 
     private String description;
 
-	private String patchesUrl;
-
     @ManyToOne(cascade = CascadeType.ALL)
     private ProductVersion productVersion;
 
@@ -136,20 +134,6 @@ public class BuildConfiguration implements Serializable {
 
     public void setScmBranch(String scmBranch) {
         this.scmBranch = scmBranch;
-    }
-
-    /**
-     * @return the patchesUrl
-     */
-    public String getPatchesUrl() {
-        return patchesUrl;
-    }
-
-    /**
-     * @param patchesUrl the patchesUrl to set
-     */
-    public void setPatchesUrl(String patchesUrl) {
-        this.patchesUrl = patchesUrl;
     }
 
     public String getDescription() {

--- a/pnc-model/src/main/java/org/jboss/pnc/model/BuildRecord.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/BuildRecord.java
@@ -39,8 +39,6 @@ public class BuildRecord implements Serializable {
 
     private String sourceUrl;
 
-    private String patchesUrl;
-
     @Lob
     private String buildLog;
 
@@ -186,24 +184,6 @@ public class BuildRecord implements Serializable {
      */
     public void setSourceUrl(String sourceUrl) {
         this.sourceUrl = sourceUrl;
-    }
-
-    /**
-     * Gets the patches url.
-     *
-     * @return the patches url
-     */
-    public String getPatchesUrl() {
-        return patchesUrl;
-    }
-
-    /**
-     * Sets the patches url.
-     *
-     * @param patchesUrl the new patches url
-     */
-    public void setPatchesUrl(String patchesUrl) {
-        this.patchesUrl = patchesUrl;
     }
 
     /**

--- a/pnc-model/src/main/java/org/jboss/pnc/model/builder/BuildConfigurationBuilder.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/builder/BuildConfigurationBuilder.java
@@ -43,8 +43,6 @@ public class BuildConfigurationBuilder {
 
     private String scmBranch;
 
-    private String patchesUrl;
-
     private String description;
 
     private ProductVersion productVersion;
@@ -80,7 +78,6 @@ public class BuildConfigurationBuilder {
         buildConfiguration.setBuildScript(buildScript);
         buildConfiguration.setScmUrl(scmUrl);
         buildConfiguration.setScmBranch(scmBranch);
-        buildConfiguration.setPatchesUrl(patchesUrl);
         buildConfiguration.setDescription(description);
         buildConfiguration.setProductVersion(productVersion);
 
@@ -126,11 +123,6 @@ public class BuildConfigurationBuilder {
 
     public BuildConfigurationBuilder scmBranch(String scmBranch) {
         this.scmBranch = scmBranch;
-        return this;
-    }
-
-    public BuildConfigurationBuilder patchesUrl(String patchesUrl) {
-        this.patchesUrl = patchesUrl;
         return this;
     }
 
@@ -193,10 +185,6 @@ public class BuildConfigurationBuilder {
 
     public String getScmUrl() {
         return scmUrl;
-    }
-
-    public String getPatchesUrl() {
-        return patchesUrl;
     }
 
     public String getDescription() {

--- a/pnc-model/src/main/java/org/jboss/pnc/model/builder/BuildRecordBuilder.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/builder/BuildRecordBuilder.java
@@ -50,8 +50,6 @@ public class BuildRecordBuilder {
 
     private String sourceUrl;
 
-    private String patchesUrl;
-
     private String buildLog;
 
     private BuildDriverStatus status;
@@ -86,7 +84,6 @@ public class BuildRecordBuilder {
         buildRecord.setBuildConfiguration(buildConfiguration);
         buildRecord.setUser(user);
         buildRecord.setSourceUrl(sourceUrl);
-        buildRecord.setPatchesUrl(patchesUrl);
         buildRecord.setBuildLog(buildLog);
         buildRecord.setStatus(status);
         buildRecord.setBuildDriverId(buildDriverId);
@@ -141,11 +138,6 @@ public class BuildRecordBuilder {
 
     public BuildRecordBuilder sourceUrl(String sourceUrl) {
         this.sourceUrl = sourceUrl;
-        return this;
-    }
-
-    public BuildRecordBuilder patchesUrl(String patchesUrl) {
-        this.patchesUrl = patchesUrl;
         return this;
     }
 
@@ -220,10 +212,6 @@ public class BuildRecordBuilder {
 
     public String getSourceUrl() {
         return sourceUrl;
-    }
-
-    public String getPatchesUrl() {
-        return patchesUrl;
     }
 
     public String getBuildLog() {

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProvider.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProvider.java
@@ -71,7 +71,6 @@ public class BuildConfigurationProvider {
         buildConfiguration.setName(buildConfigurationRest.getName());
         buildConfiguration.setBuildScript(buildConfigurationRest.getBuildScript());
         buildConfiguration.setScmUrl(buildConfigurationRest.getScmUrl());
-        buildConfiguration.setPatchesUrl(buildConfigurationRest.getPatchesUrl());
         buildConfiguration.setCreationTime(buildConfigurationRest.getCreationTime());
         buildConfiguration.setLastModificationTime(buildConfigurationRest.getLastModificationTime());
         buildConfiguration.setRepositories(buildConfigurationRest.getRepositories());
@@ -87,7 +86,6 @@ public class BuildConfigurationProvider {
 
         BuildConfiguration clonedBuildConfiguration = BuildConfigurationBuilder.newBuilder().name("_" + buildConfiguration.getName())
                 .buildScript(buildConfiguration.getBuildScript()).scmUrl(buildConfiguration.getScmUrl())
-                .scmBranch(buildConfiguration.getScmBranch()).patchesUrl(buildConfiguration.getPatchesUrl())
                 .description(buildConfiguration.getDescription()).productVersion(buildConfiguration.getProductVersion())
                 .project(buildConfiguration.getProject()).environment(buildConfiguration.getEnvironment())
                 .creationTime(buildConfiguration.getCreationTime())

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigurationRest.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigurationRest.java
@@ -18,8 +18,6 @@ public class BuildConfigurationRest {
 
     private String scmUrl;
 
-    private String patchesUrl;
-
     private Timestamp creationTime;
 
     private Timestamp lastModificationTime;
@@ -34,7 +32,6 @@ public class BuildConfigurationRest {
         this.name = buildConfiguration.getName();
         this.buildScript = buildConfiguration.getBuildScript();
         this.scmUrl = buildConfiguration.getScmUrl();
-        this.patchesUrl = buildConfiguration.getPatchesUrl();
         this.creationTime = buildConfiguration.getCreationTime();
         this.lastModificationTime = buildConfiguration.getLastModificationTime();
         this.repositories = buildConfiguration.getRepositories();
@@ -72,14 +69,6 @@ public class BuildConfigurationRest {
         this.scmUrl = scmUrl;
     }
 
-    public String getPatchesUrl() {
-        return patchesUrl;
-    }
-
-    public void setPatchesUrl(String patchesUrl) {
-        this.patchesUrl = patchesUrl;
-    }
-
     public Timestamp getCreationTime() {
         return creationTime;
     }
@@ -110,7 +99,6 @@ public class BuildConfigurationRest {
         builder.name(name);
         builder.buildScript(buildScript);
         builder.scmUrl(scmUrl);
-        builder.patchesUrl(patchesUrl);
         builder.creationTime(creationTime);
         builder.lastModificationTime(lastModificationTime);
         builder.repositories(repositories);

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildRecordRest.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildRecordRest.java
@@ -23,8 +23,6 @@ public class BuildRecordRest {
 
     private String sourceUrl;
 
-    private String patchesUrl;
-
     private BuildDriverStatus status;
 
     private Integer buildConfigurationId;
@@ -47,7 +45,6 @@ public class BuildRecordRest {
         performIfNotNull(buildRecord.getUser() != null, () -> userId = buildRecord.getUser().getId());
         performIfNotNull(buildRecord.getSystemImage() != null, () -> systemImageId = buildRecord.getSystemImage().getId());
         this.sourceUrl = buildRecord.getSourceUrl();
-        this.patchesUrl = buildRecord.getPatchesUrl();
         this.status = buildRecord.getStatus();
         this.buildDriverId = buildRecord.getBuildDriverId();
     }
@@ -62,7 +59,6 @@ public class BuildRecordRest {
                         buildConfiguration != null,
                 () -> buildConfigurationId = buildConfiguration.getId());
         this.sourceUrl = buildConfiguration.getScmUrl();
-        this.patchesUrl = buildConfiguration.getPatchesUrl();
         this.status = BuildDriverStatus.BUILDING;
     }
 
@@ -104,14 +100,6 @@ public class BuildRecordRest {
 
     public void setSourceUrl(String sourceUrl) {
         this.sourceUrl = sourceUrl;
-    }
-
-    public String getPatchesUrl() {
-        return patchesUrl;
-    }
-
-    public void setPatchesUrl(String patchesUrl) {
-        this.patchesUrl = patchesUrl;
     }
 
     public BuildDriverStatus getStatus() {

--- a/pnc-ui/app/scripts/pnc-configurations.js
+++ b/pnc-ui/app/scripts/pnc-configurations.js
@@ -66,7 +66,6 @@ $(document).ready(function() {
           { 'data': 'name' },
           { 'data': 'buildScript' },
           { 'data': 'scmUrl' },
-          { 'data': 'patchesUrl' },
           { 'data':
             function(json) {
               if (json.creationTime === null) {
@@ -256,13 +255,11 @@ $(document).ready(function() {
        var name = $('#addConfIdentifier').val();
        var buildScript = $('#addConfBuildScript').val();
        var scmUrl = $('#addConfScmUrl').val();
-       var patchesUrl = $('#addConfPatchesUrl').val();
 
        var JSONObj = {
             'name': name,
             'buildScript': buildScript,
             'scmUrl': scmUrl,
-            'patchesUrl': patchesUrl
        };
 
        var data = JSON.stringify(JSONObj);

--- a/pnc-ui/app/views/configuration_add.html
+++ b/pnc-ui/app/views/configuration_add.html
@@ -87,12 +87,6 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="col-md-2 control-label" for="textInput4">Patches Url</label>
-              <div class="col-md-6">
-                <input type="text" id="addConfPatchesUrl" class="form-control">
-              </div>
-            </div>
-            <div class="form-group">
               <div class="col-md-10 col-md-offset-2">
                 <button type="button" class="saveConfiguration btn btn-primary">Save</button>
                 <button type="button" class="cancelConfiguration btn btn-default">Cancel</button>

--- a/pnc-ui/app/views/configurations.html
+++ b/pnc-ui/app/views/configurations.html
@@ -72,7 +72,6 @@
                 <th>Identifier</th>
                 <th>Build Script</th>
                 <th>Scm Url</th>
-                <th>Patches Url</th>
                 <th>Created</th>
                 <th>Last Modified</th>
                 <th>Action</th>


### PR DESCRIPTION
JBoss product builds under project Newcastle must not use external patches to a build.
All sources should be kept in a single scm repository.