### PR TITLE
Integrate JClouds library

### DIFF
--- a/docker-environment-driver/pom.xml
+++ b/docker-environment-driver/pom.xml
@@ -19,6 +19,8 @@
 
 
   <dependencies>
+  
+    <!-- Project dependencies -->
     <dependency>
       <groupId>org.jboss.pnc</groupId>
       <artifactId>pnc-model</artifactId>
@@ -27,6 +29,8 @@
       <groupId>org.jboss.pnc</groupId>
       <artifactId>pnc-spi</artifactId>
     </dependency>
+    
+    <!-- Remote dependencies -->
     <dependency>
       <groupId>org.jboss.spec</groupId>
       <artifactId>jboss-javaee-6.0</artifactId>
@@ -38,6 +42,44 @@
       <artifactId>cdi-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>org.jboss.spec.javax.ejb</groupId>
+      <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    
+    <!-- JClouds -->
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-core</artifactId>
+    </dependency>
+        
+    <dependency>
+      <groupId>org.apache.jclouds.labs</groupId>
+      <artifactId>docker</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-compute</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.apache.jclouds.driver</groupId>
+      <artifactId>jclouds-sshj</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.apache.jclouds.driver</groupId>
+      <artifactId>jclouds-slf4j</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    
   </dependencies>
 
 </project>

--- a/jenkins-build-driver/pom.xml
+++ b/jenkins-build-driver/pom.xml
@@ -15,6 +15,19 @@
 
   <description>Implementation of pnc-spi:org.jboss.pnc.spi.builddriver.</description>
 
+  <dependencyManagement>
+    <dependencies>
+    
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>13.0.1</version>
+        <scope>test</scope>
+      </dependency>
+  
+    </dependencies>
+  </dependencyManagement>
+  
   <dependencies>
 
     <!-- Project dependencies -->
@@ -56,6 +69,12 @@
       </dependency>
 
     <!-- Test dependencies -->
+    
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/pnc-core/pom.xml
+++ b/pnc-core/pom.xml
@@ -15,6 +15,19 @@
 
   <description>Contains implementations of action-controllers, which include the business logic for orchestrating builds, test runs, etc. Action controllers are used to isolate logic from the REST API, so it can be reused in embedded scenarios.</description>
 
+  <dependencyManagement>
+    <dependencies>
+    
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>13.0.1</version>
+        <scope>test</scope>
+      </dependency>
+  
+    </dependencies>
+  </dependencyManagement>
+  
   <dependencies>
     <!-- Project dependencies -->
     <dependency>
@@ -58,7 +71,12 @@
       <artifactId>maven-repository-manager</artifactId>
       <scope>test</scope>
     </dependency>
-
+    
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,13 +55,14 @@
     <version.assertj-core>1.7.0</version.assertj-core>
     <version.mockito-all>1.10.8</version.mockito-all>
     <version.catch-exception>1.2.0</version.catch-exception>
-    <version.guava>13.0.1</version.guava>
+    <version.guava>17.0</version.guava>
     <version.org.apache.httpcomponents.httpclient>4.3.6</version.org.apache.httpcomponents.httpclient>
     <version.org.apache.httpcomponents.httpcore>4.3.3</version.org.apache.httpcomponents.httpcore>
     <version.org.postgresql>9.3-1102-jdbc41</version.org.postgresql>
     <version.querydsl>3.6.1</version.querydsl>
     <version.jackson>2.4.4</version.jackson>
     <version.jackson.annotations>2.4.1</version.jackson.annotations>
+    <version.jclouds>1.8.1</version.jclouds>
 
     <!-- maven-compiler-plugin -->
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -329,6 +330,36 @@
         <groupId>org.springframework.data</groupId>
         <artifactId>spring-data-commons</artifactId>
         <version>1.9.2.RELEASE</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.jclouds.labs</groupId>
+        <artifactId>docker</artifactId>
+        <version>${version.jclouds}</version>
+      </dependency>
+		
+      <dependency>
+        <groupId>org.apache.jclouds.driver</groupId>
+        <artifactId>jclouds-sshj</artifactId>
+        <version>${version.jclouds}</version>
+      </dependency>
+	  
+      <dependency>
+        <groupId>org.apache.jclouds</groupId>
+        <artifactId>jclouds-core</artifactId>
+        <version>${version.jclouds}</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>org.apache.jclouds</groupId>
+        <artifactId>jclouds-compute</artifactId>
+        <version>${version.jclouds}</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>org.apache.jclouds.driver</groupId>
+        <artifactId>jclouds-slf4j</artifactId>
+        <version>${version.jclouds}</version>
       </dependency>
 
       <!-- Test dependencies -->


### PR DESCRIPTION
Update Guava library to version 17.0, because it is needed by JClouds. But for the tests there is still Guava version 13.0.1, because of Weld dependency. Weld cannot run with higher version of Guava than 14.