### PR TITLE
[NCL-550] Don't delete product version when deleting a build config

### DIFF
--- a/pnc-model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
@@ -46,7 +46,7 @@ public class BuildConfiguration implements Serializable, Cloneable {
 
     private String patchesUrl;
 
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne(cascade = { CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH })
     private ProductVersion productVersion;
 
     @ManyToOne(cascade = { CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH })


### PR DESCRIPTION
For example, when deleting a build configuration, the associated product version
should not also be deleted.