### PR TITLE
[NCL-543] Use a unique sequence generator for each entity

### DIFF
--- a/pnc-model/src/main/java/org/jboss/pnc/model/Artifact.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/Artifact.java
@@ -6,8 +6,10 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
 
 /**
  * Created by <a href="mailto:matejonnet@gmail.com">Matej Lazar</a> on 2014-11-23.
@@ -37,7 +39,8 @@ public class Artifact implements Serializable {
     private static final long serialVersionUID = -2368833657284575734L;
 
     @Id
-    @GeneratedValue
+    @SequenceGenerator(name="artifact_id_seq", sequenceName="artifact_id_seq", allocationSize=1)    
+    @GeneratedValue(strategy=GenerationType.SEQUENCE, generator="artifact_id_seq")
     private Integer id;
 
     /**

--- a/pnc-model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
@@ -3,9 +3,11 @@ package org.jboss.pnc.model;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Version;
 
 import java.io.Serializable;
@@ -31,7 +33,8 @@ public class BuildConfiguration implements Serializable, Cloneable {
     public static final String DEFAULT_SORTING_FIELD = "name";
 
     @Id
-    @GeneratedValue
+    @SequenceGenerator(name="build_configuration_id_seq", sequenceName="build_configuration_id_seq", allocationSize=1)    
+    @GeneratedValue(strategy=GenerationType.SEQUENCE, generator="build_configuration_id_seq")
     private Integer id;
 
     private String name;

--- a/pnc-model/src/main/java/org/jboss/pnc/model/BuildRecord.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/BuildRecord.java
@@ -6,12 +6,14 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.PreRemove;
+import javax.persistence.SequenceGenerator;
 
 import java.io.Serializable;
 import java.sql.Timestamp;
@@ -36,7 +38,8 @@ public class BuildRecord implements Serializable {
     public static final String DEFAULT_SORTING_FIELD = "id";
 
     @Id
-    @GeneratedValue
+    @SequenceGenerator(name="build_record_id_seq", sequenceName="build_record_id_seq", allocationSize=1)    
+    @GeneratedValue(strategy=GenerationType.SEQUENCE, generator="build_record_id_seq")
     private Integer id;
 
     @ManyToOne(cascade = { CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH }, fetch = FetchType.LAZY)

--- a/pnc-model/src/main/java/org/jboss/pnc/model/BuildRecordSet.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/BuildRecordSet.java
@@ -4,12 +4,14 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.PreRemove;
+import javax.persistence.SequenceGenerator;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -28,7 +30,8 @@ public class BuildRecordSet implements Serializable {
     public static final String DEFAULT_SORTING_FIELD = "id";
 
     @Id
-    @GeneratedValue
+    @SequenceGenerator(name="build_record_set_id_seq", sequenceName="build_record_set_id_seq", allocationSize=1)    
+    @GeneratedValue(strategy=GenerationType.SEQUENCE, generator="build_record_set_id_seq")
     private Integer id;
 
     @Enumerated(EnumType.STRING)

--- a/pnc-model/src/main/java/org/jboss/pnc/model/Environment.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/Environment.java
@@ -15,7 +15,8 @@ public class Environment implements Serializable {
     private static final long serialVersionUID = 8213767399060607637L;
 
     @Id
-    @GeneratedValue
+    @SequenceGenerator(name="environment_id_seq", sequenceName="environment_id_seq", allocationSize=1)    
+    @GeneratedValue(strategy=GenerationType.SEQUENCE, generator="environment_id_seq")
     private Integer id;
 
     @Enumerated(EnumType.STRING)

--- a/pnc-model/src/main/java/org/jboss/pnc/model/License.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/License.java
@@ -6,8 +6,10 @@ import java.util.List;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import javax.persistence.SequenceGenerator;
 
 import org.hibernate.annotations.Type;
 
@@ -22,7 +24,8 @@ public class License implements Serializable {
     public static final String DEFAULT_SORTING_FIELD = "shortName";
 
     @Id
-    @GeneratedValue
+    @SequenceGenerator(name="license_id_seq", sequenceName="license_id_seq", allocationSize=1)    
+    @GeneratedValue(strategy=GenerationType.SEQUENCE, generator="license_id_seq")
     private Integer id;
 
     private String fullName;

--- a/pnc-model/src/main/java/org/jboss/pnc/model/Product.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/Product.java
@@ -35,7 +35,8 @@ public class Product implements Serializable {
     public static final String DEFAULT_SORTING_FIELD = "name";
 
     @Id
-    @GeneratedValue
+    @SequenceGenerator(name="product_id_seq", sequenceName="product_id_seq", allocationSize=1)    
+    @GeneratedValue(strategy=GenerationType.SEQUENCE, generator="product_id_seq")
     private Integer id;
 
     private String name;

--- a/pnc-model/src/main/java/org/jboss/pnc/model/ProductVersionProject.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/ProductVersionProject.java
@@ -20,8 +20,10 @@ package org.jboss.pnc.model;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
 
 import java.io.Serializable;
 
@@ -38,7 +40,8 @@ public class ProductVersionProject implements Serializable {
     private static final long serialVersionUID = 2596901834161647987L;
 
     @Id
-    @GeneratedValue
+    @SequenceGenerator(name="product_version_project_id_seq", sequenceName="product_version_project_id_seq", allocationSize=1)    
+    @GeneratedValue(strategy=GenerationType.SEQUENCE, generator="product_version_project_id_seq")
     private Integer id;
 
     @ManyToOne(cascade = CascadeType.ALL)

--- a/pnc-model/src/main/java/org/jboss/pnc/model/Project.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/Project.java
@@ -21,7 +21,8 @@ public class Project implements Serializable {
     public static final String DEFAULT_SORTING_FIELD = "name";
 
     @Id
-    @GeneratedValue
+    @SequenceGenerator(name="project_id_seq", sequenceName="project_id_seq", allocationSize=1)    
+    @GeneratedValue(strategy=GenerationType.SEQUENCE, generator="project_id_seq")
     private Integer id;
 
     private String name;

--- a/pnc-model/src/main/java/org/jboss/pnc/model/SystemImage.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/SystemImage.java
@@ -2,8 +2,11 @@ package org.jboss.pnc.model;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+
 import java.io.Serializable;
 
 /**
@@ -17,7 +20,8 @@ public class SystemImage implements Serializable {
     private static final long serialVersionUID = 3170247997550146257L;
 
     @Id
-    @GeneratedValue
+    @SequenceGenerator(name="system_image_id_seq", sequenceName="system_image_id_seq", allocationSize=1)    
+    @GeneratedValue(strategy=GenerationType.SEQUENCE, generator="system_image_id_seq")
     private Integer id;
 
     @ManyToOne

--- a/pnc-model/src/main/java/org/jboss/pnc/model/User.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/User.java
@@ -6,8 +6,10 @@ import java.util.List;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 
@@ -25,7 +27,8 @@ public class User implements Serializable {
     public static final String DEFAULT_SORTING_FIELD = "username";
 
     @Id
-    @GeneratedValue
+    @SequenceGenerator(name="user_id_seq", sequenceName="user_id_seq", allocationSize=1)    
+    @GeneratedValue(strategy=GenerationType.SEQUENCE, generator="user_id_seq")
     private Integer id;
 
     @NotNull


### PR DESCRIPTION
Each entity should have it's own sequence generator for the PK ID field