### PR TITLE
Implementing centrally-managed content IDs for use in external services

### DIFF
--- a/jenkins-build-driver/src/test/java/org/jboss/pnc/jenkinsbuilddriver/test/JenkinsDriverRemoteTest.java
+++ b/jenkins-build-driver/src/test/java/org/jboss/pnc/jenkinsbuilddriver/test/JenkinsDriverRemoteTest.java
@@ -1,16 +1,5 @@
 package org.jboss.pnc.jenkinsbuilddriver.test;
 
-import java.io.InputStream;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-import java.util.logging.Logger;
-
-import javax.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.pnc.common.Configuration;
@@ -29,14 +18,25 @@ import org.jboss.pnc.spi.environment.RunningEnvironment;
 import org.jboss.pnc.spi.environment.exception.EnvironmentDriverException;
 import org.jboss.pnc.spi.repositorymanager.RepositoryManagerException;
 import org.jboss.pnc.spi.repositorymanager.RepositoryManagerResult;
-import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
 import org.jboss.pnc.spi.repositorymanager.model.RepositoryConnectionInfo;
+import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+import javax.inject.Inject;
 
 /**
  * Created by <a href="mailto:matejonnet@gmail.com">Matej Lazar</a> on 2014-11-23.
@@ -172,11 +172,6 @@ public class JenkinsDriverRemoteTest {
             @Override
             public String getId() {
                 return "mock-config";
-            }
-
-            @Override
-            public String getCollectionId() {
-                return "mock-collection";
             }
 
             @Override

--- a/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenContentIdentifierManager.java
+++ b/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenContentIdentifierManager.java
@@ -1,0 +1,57 @@
+package org.jboss.pnc.mavenrepositorymanager;
+
+import org.jboss.pnc.model.BuildConfiguration;
+import org.jboss.pnc.model.BuildConfigurationSet;
+import org.jboss.pnc.model.ProductVersion;
+import org.jboss.pnc.spi.content.ContentIdentifierManager;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class MavenContentIdentifierManager implements ContentIdentifierManager {
+
+    private static final String PRODUCT_CONTENT_ID_FORMAT = "%s-%s";
+
+    private static final String NAME_AND_DATESTAMP = "%s-%s";
+
+    private static final String BUILD_SET_CONTENT_ID_FORMAT = NAME_AND_DATESTAMP;
+
+    private static final String BUILD_CONTENT_ID_FORMAT = NAME_AND_DATESTAMP;
+
+    private static final String TIMESTAMP_FORMAT = "yyyyMMdd.HHmm";
+
+    @Override
+    public String getProductContentId(ProductVersion productVersion) {
+        if (productVersion == null) {
+            return ContentIdentifierManager.GLOBAL_CONTENT_ID;
+        }
+
+        return String.format(PRODUCT_CONTENT_ID_FORMAT, safeIdPart(productVersion.getProduct().getName()),
+                safeIdPart(productVersion.getVersion()));
+    }
+
+    @Override
+    public String getBuildSetContentId(BuildConfigurationSet buildConfigurationSet) {
+        String timestamp = generateTimestamp();
+        return String.format(BUILD_SET_CONTENT_ID_FORMAT, safeIdPart(buildConfigurationSet.getName()), timestamp);
+    }
+
+    @Override
+    public String getBuildContentId(BuildConfiguration buildConfiguration) {
+        String timestamp = generateTimestamp();
+        return String.format(BUILD_CONTENT_ID_FORMAT, safeIdPart(buildConfiguration.getName()), timestamp);
+    }
+
+    private String generateTimestamp() {
+        return new SimpleDateFormat(TIMESTAMP_FORMAT).format(new Date());
+    }
+
+    /**
+     * Sift out spaces, pipe characters and colons (things that don't play well in URLs) from the project name, and convert them
+     * to dashes. This is only for naming repositories, so an approximate match to the project in question is fine.
+     */
+    private String safeIdPart(String name) {
+        return name.replaceAll("\\W+", "-").replaceAll("[|:]+", "-");
+    }
+
+}

--- a/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
+++ b/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
@@ -38,15 +38,12 @@ public class MavenRepositorySession implements RepositorySession
 
     private final RepositoryConnectionInfo connectionInfo;
 
-    private String collectionId;
-
     // TODO: Create and pass in suitable parameters to Aprox to create the
     //       proxy repository.
-    public MavenRepositorySession(Aprox aprox, String id, String collectionId, MavenRepositoryConnectionInfo info)
+    public MavenRepositorySession(Aprox aprox, String id, MavenRepositoryConnectionInfo info)
     {
         this.aprox = aprox;
         this.id = id;
-        this.collectionId = collectionId;
         this.connectionInfo = info;
     }
 
@@ -66,11 +63,6 @@ public class MavenRepositorySession implements RepositorySession
     @Override
     public String getId() {
         return id;
-    }
-
-    @Override
-    public String getCollectionId() {
-        return collectionId;
     }
 
     @Override

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AbstractRepositoryManagerDriverTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AbstractRepositoryManagerDriverTest.java
@@ -1,23 +1,20 @@
 package org.jboss.pnc.mavenrepositorymanager;
 
-import java.io.File;
-import java.util.Properties;
-
 import org.commonjava.aprox.boot.BootStatus;
 import org.commonjava.aprox.test.fixture.core.CoreServerFixture;
 import org.jboss.pnc.common.Configuration;
 import org.jboss.pnc.common.json.ModuleConfigJson;
 import org.jboss.pnc.common.json.moduleconfig.MavenRepoDriverModuleConfig;
-import org.jboss.pnc.model.BuildConfiguration;
-import org.jboss.pnc.model.Product;
-import org.jboss.pnc.model.ProductVersion;
-import org.jboss.pnc.model.Project;
+import org.jboss.pnc.spi.BuildExecution;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.File;
+import java.util.Properties;
 
 public class AbstractRepositoryManagerDriverTest {
 
@@ -39,11 +36,10 @@ public class AbstractRepositoryManagerDriverTest {
 
         url = fixture.getUrl();
         File configFile = temp.newFile("pnc-config.json");
-        ModuleConfigJson moduleConfigJson =  new ModuleConfigJson("pnc-config");
-        MavenRepoDriverModuleConfig mavenRepoDriverModuleConfig = 
-                new MavenRepoDriverModuleConfig(fixture.getUrl());
+        ModuleConfigJson moduleConfigJson = new ModuleConfigJson("pnc-config");
+        MavenRepoDriverModuleConfig mavenRepoDriverModuleConfig = new MavenRepoDriverModuleConfig(fixture.getUrl());
         moduleConfigJson.addConfig(mavenRepoDriverModuleConfig);
-        
+
         ObjectMapper mapper = new ObjectMapper();
         mapper.writeValue(configFile, moduleConfigJson);
 
@@ -79,22 +75,27 @@ public class AbstractRepositoryManagerDriverTest {
         if (fixture != null) {
             fixture.stop();
         }
-    }    protected BuildConfiguration simpleBuildConfiguration() {
-        Project project = new Project();
-        project.setName("myproject");
+    }
 
-        Product product = new Product();
-        product.setName("myproduct");
+    protected BuildExecution simpleBuildExecution() {
+        return new BuildExecution() {
 
-        ProductVersion pv = new ProductVersion();
-        pv.setProduct(product);
-        pv.setVersion("1.0");
+            @Override
+            public String getTopContentId() {
+                return "myproduct-1.0";
+            }
 
-        BuildConfiguration pbc = new BuildConfiguration();
-        pbc.setProject(project);
-        pbc.setProductVersion(pv);
+            @Override
+            public String getBuildSetContentId() {
+                return null;
+            }
 
-        return pbc;
+            @Override
+            public String getBuildContentId() {
+                return "myproject-12345";
+            }
+
+        };
     }
 
 }

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver01Test.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver01Test.java
@@ -4,10 +4,9 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
-import org.jboss.pnc.model.BuildRecordSet;
-import org.jboss.pnc.model.BuildConfiguration;
-import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
+import org.jboss.pnc.spi.BuildExecution;
 import org.jboss.pnc.spi.repositorymanager.model.RepositoryConnectionInfo;
+import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
 import org.junit.Test;
 
 public class RepositoryManagerDriver01Test 
@@ -16,20 +15,17 @@ public class RepositoryManagerDriver01Test
 
     @Test
     public void formatRepositoryURLForSimpleInfo_CheckDependencyURL() throws Exception {
-        BuildConfiguration pbc = simpleBuildConfiguration();
+        BuildExecution execution = simpleBuildExecution();
 
-        BuildRecordSet bc = new BuildRecordSet();
-        bc.setProductVersion(pbc.getProductVersion());
-
-        RepositorySession repositoryConfiguration = driver.createBuildRepository(pbc, bc);
+        RepositorySession repositoryConfiguration = driver.createBuildRepository(execution);
 
         assertThat(repositoryConfiguration, notNullValue());
 
         RepositoryConnectionInfo connectionInfo = repositoryConfiguration.getConnectionInfo();
         assertThat(connectionInfo, notNullValue());
 
-        String expectedUrlPrefix = String.format("%sfolo/track/build+%s", url, pbc.getProject().getName());
-        String expectedGroupPathPrefix = String.format("/group/build+%s", pbc.getProject().getName());
+        String expectedUrlPrefix = String.format("%sfolo/track/%s", url, execution.getBuildContentId());
+        String expectedGroupPathPrefix = String.format("/group/%s", execution.getBuildContentId());
 
         assertThat("Expected URL prefix: " + expectedUrlPrefix + "\nActual URL was: " + connectionInfo.getDependencyUrl(),
                 connectionInfo.getDependencyUrl().startsWith(expectedUrlPrefix), equalTo(true));

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver02Test.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver02Test.java
@@ -4,10 +4,9 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
-import org.jboss.pnc.model.BuildRecordSet;
-import org.jboss.pnc.model.BuildConfiguration;
-import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
+import org.jboss.pnc.spi.BuildExecution;
 import org.jboss.pnc.spi.repositorymanager.model.RepositoryConnectionInfo;
+import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
 import org.junit.Test;
 
 public class RepositoryManagerDriver02Test 
@@ -16,12 +15,9 @@ public class RepositoryManagerDriver02Test
 
     @Test
     public void formatRepositoryURLForSimpleInfo_AllURLsMatch() throws Exception {
-        BuildConfiguration pbc = simpleBuildConfiguration();
+        BuildExecution execution = simpleBuildExecution();
 
-        BuildRecordSet bc = new BuildRecordSet();
-        bc.setProductVersion(pbc.getProductVersion());
-
-        RepositorySession repositoryConfiguration = driver.createBuildRepository(pbc, bc);
+        RepositorySession repositoryConfiguration = driver.createBuildRepository(execution);
         assertThat(repositoryConfiguration, notNullValue());
 
         RepositoryConnectionInfo connectionInfo = repositoryConfiguration.getConnectionInfo();

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver03Test.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver03Test.java
@@ -18,8 +18,7 @@ import org.commonjava.aprox.model.core.StoreType;
 import org.commonjava.maven.atlas.ident.ref.ArtifactRef;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.jboss.pnc.model.Artifact;
-import org.jboss.pnc.model.BuildConfiguration;
-import org.jboss.pnc.model.BuildRecordSet;
+import org.jboss.pnc.spi.BuildExecution;
 import org.jboss.pnc.spi.repositorymanager.RepositoryManagerResult;
 import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
 import org.junit.Test;
@@ -35,12 +34,9 @@ public class RepositoryManagerDriver03Test
 
     @Test
     public void extractBuildArtifacts_ContainsTwoDownloads() throws Exception {
-        BuildConfiguration pbc = simpleBuildConfiguration();
+        BuildExecution execution = simpleBuildExecution();
 
-        BuildRecordSet bc = new BuildRecordSet();
-        bc.setProductVersion(pbc.getProductVersion());
-
-        RepositorySession rc = driver.createBuildRepository(pbc, bc);
+        RepositorySession rc = driver.createBuildRepository(execution);
         assertThat(rc, notNullValue());
 
         String baseUrl = rc.getConnectionInfo().getDependencyUrl();

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver04Test.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver04Test.java
@@ -20,8 +20,7 @@ import org.commonjava.aprox.model.core.StoreType;
 import org.commonjava.maven.atlas.ident.ref.ArtifactRef;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.jboss.pnc.model.Artifact;
-import org.jboss.pnc.model.BuildConfiguration;
-import org.jboss.pnc.model.BuildRecordSet;
+import org.jboss.pnc.spi.BuildExecution;
 import org.jboss.pnc.spi.repositorymanager.RepositoryManagerResult;
 import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
 import org.junit.Test;
@@ -37,12 +36,9 @@ public class RepositoryManagerDriver04Test
 
     @Test
     public void extractBuildArtifacts_ContainsTwoUploads() throws Exception {
-        BuildConfiguration pbc = simpleBuildConfiguration();
+        BuildExecution execution = simpleBuildExecution();
 
-        BuildRecordSet bc = new BuildRecordSet();
-        bc.setProductVersion(pbc.getProductVersion());
-
-        RepositorySession rc = driver.createBuildRepository(pbc, bc);
+        RepositorySession rc = driver.createBuildRepository(execution);
         assertThat(rc, notNullValue());
 
         String baseUrl = rc.getConnectionInfo().getDeployUrl();

--- a/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildTask.java
+++ b/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildTask.java
@@ -3,6 +3,7 @@ package org.jboss.pnc.core.builder;
 import org.jboss.pnc.core.events.DefaultBuildStatusChangedEvent;
 import org.jboss.pnc.core.exception.CoreException;
 import org.jboss.pnc.model.BuildConfiguration;
+import org.jboss.pnc.spi.BuildExecution;
 import org.jboss.pnc.spi.BuildStatus;
 import org.jboss.pnc.spi.events.BuildStatusChangedEvent;
 import org.jboss.util.collection.WeakSet;
@@ -17,7 +18,7 @@ import java.util.function.Consumer;
 /**
 * Created by <a href="mailto:matejonnet@gmail.com">Matej Lazar</a> on 2014-12-23.
 */
-public class BuildTask {
+public class BuildTask implements BuildExecution {
 
     public static final Logger log = LoggerFactory.getLogger(BuildTask.class);
 
@@ -35,16 +36,28 @@ public class BuildTask {
     private List<BuildTask> requiredBuilds;
     private BuildCoordinator buildCoordinator;
 
-    BuildTask(BuildCoordinator buildCoordinator, BuildConfiguration buildConfiguration) {
+    private String topContentId;
+
+    private String buildSetContentId;
+
+    private String buildContentId;
+
+    BuildTask(BuildCoordinator buildCoordinator, BuildConfiguration buildConfiguration, String topContentId,
+            String buildSetContentId, String buildContentId) {
         this.buildCoordinator = buildCoordinator;
         this.buildConfiguration = buildConfiguration;
+        this.topContentId = topContentId;
+        this.buildSetContentId = buildSetContentId;
+        this.buildContentId = buildContentId;
         statusUpdateListeners = new WeakSet();
         logConsumers = new WeakSet();
         waiting = new HashSet<>();
     }
 
-    BuildTask(BuildCoordinator buildCoordinator, BuildConfiguration buildConfiguration, Set<Consumer<BuildStatusChangedEvent>> statusUpdateListeners, Set<Consumer<String>> logConsumers) {
-        this(buildCoordinator, buildConfiguration);
+    BuildTask(BuildCoordinator buildCoordinator, BuildConfiguration buildConfiguration, String topContentId,
+            String buildSetContentId, String buildContentId, Set<Consumer<BuildStatusChangedEvent>> statusUpdateListeners,
+            Set<Consumer<String>> logConsumers) {
+        this(buildCoordinator, buildConfiguration, topContentId, buildSetContentId, buildContentId);
         this.statusUpdateListeners.addAll(statusUpdateListeners);
         this.logConsumers.addAll(logConsumers);
     }
@@ -102,14 +115,33 @@ public class BuildTask {
         return buildConfiguration;
     }
 
+    @Override
+    public String getTopContentId() {
+        return topContentId;
+    }
+
+    @Override
+    public String getBuildSetContentId() {
+        return buildSetContentId;
+    }
+
+    @Override
+    public String getBuildContentId() {
+        return buildContentId;
+    }
+
     void addWaiting(BuildTask buildTask) {
         waiting.add(buildTask);
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         BuildTask buildTask = (BuildTask) o;
 

--- a/pnc-core/src/test/java/org/jboss/pnc/core/test/buildCoordinator/ReadDependenciesTest.java
+++ b/pnc-core/src/test/java/org/jboss/pnc/core/test/buildCoordinator/ReadDependenciesTest.java
@@ -4,6 +4,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.pnc.core.builder.BuildTask;
 import org.jboss.pnc.core.builder.BuildTasksTree;
 import org.jboss.pnc.core.test.configurationBuilders.TestProjectConfigurationBuilder;
+import org.jboss.pnc.core.test.mock.MockContentIdentifierManager;
 import org.jboss.pnc.model.BuildConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
@@ -18,8 +19,9 @@ public class ReadDependenciesTest extends ProjectBuilder {
     @Test
     public void createDependencyTreeTestCase() {
         TestProjectConfigurationBuilder configurationBuilder = new TestProjectConfigurationBuilder();
+        MockContentIdentifierManager contentIdentifierManager = new MockContentIdentifierManager();
 
-        BuildTasksTree buildTasksTree = new BuildTasksTree(buildCoordinator);
+        BuildTasksTree buildTasksTree = new BuildTasksTree(buildCoordinator, contentIdentifierManager);
         BuildConfiguration buildConfiguration = configurationBuilder.buildConfigurationWithDependencies();
         BuildTask buildTask = buildTasksTree.getOrCreateSubmittedBuild(buildConfiguration);
 

--- a/pnc-core/src/test/java/org/jboss/pnc/core/test/mock/MockContentIdentifierManager.java
+++ b/pnc-core/src/test/java/org/jboss/pnc/core/test/mock/MockContentIdentifierManager.java
@@ -1,0 +1,25 @@
+package org.jboss.pnc.core.test.mock;
+
+import org.jboss.pnc.model.BuildConfiguration;
+import org.jboss.pnc.model.BuildConfigurationSet;
+import org.jboss.pnc.model.ProductVersion;
+import org.jboss.pnc.spi.content.ContentIdentifierManager;
+
+public class MockContentIdentifierManager implements ContentIdentifierManager {
+
+    @Override
+    public String getProductContentId(ProductVersion productVersion) {
+        return productVersion.getProduct().getName() + "-" + productVersion.getVersion();
+    }
+
+    @Override
+    public String getBuildSetContentId(BuildConfigurationSet buildConfigurationSet) {
+        return buildConfigurationSet.getName();
+    }
+
+    @Override
+    public String getBuildContentId(BuildConfiguration buildConfiguration) {
+        return buildConfiguration.getName();
+    }
+
+}

--- a/pnc-core/src/test/java/org/jboss/pnc/core/test/mock/RepositoryManagerMock.java
+++ b/pnc-core/src/test/java/org/jboss/pnc/core/test/mock/RepositoryManagerMock.java
@@ -1,9 +1,9 @@
 package org.jboss.pnc.core.test.mock;
 
-import org.jboss.pnc.model.BuildConfiguration;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.BuildRecordSet;
 import org.jboss.pnc.model.RepositoryType;
+import org.jboss.pnc.spi.BuildExecution;
 import org.jboss.pnc.spi.repositorymanager.RepositoryManager;
 import org.jboss.pnc.spi.repositorymanager.RepositoryManagerException;
 import org.jboss.pnc.spi.repositorymanager.model.CompletedRepositoryPromotion;
@@ -32,7 +32,7 @@ public class RepositoryManagerMock implements RepositoryManager {
     }
 
     @Override
-    public RepositorySession createBuildRepository(BuildConfiguration buildConfiguration, BuildRecordSet buildRecordSet) throws RepositoryManagerException {
+    public RepositorySession createBuildRepository(BuildExecution buildExecution) throws RepositoryManagerException {
 
         RepositorySession repositoryConfiguration = new RepositorySessionMock();
         return repositoryConfiguration;
@@ -44,7 +44,13 @@ public class RepositoryManagerMock implements RepositoryManager {
     }
 
     @Override
-    public RunningRepositoryPromotion promoteRepository(BuildRecord buildRecord, BuildRecordSet buildRecordSet)
+    public RunningRepositoryPromotion promoteBuild(BuildRecord buildRecord, BuildRecordSet buildRecordSet)
+            throws RepositoryManagerException {
+        return new RunningRepositoryPromotionMock(promotionSuccess, promotionError);
+    }
+
+    @Override
+    public RunningRepositoryPromotion promoteBuildSet(BuildRecordSet buildRecordSet, String toGroup)
             throws RepositoryManagerException {
         return new RunningRepositoryPromotionMock(promotionSuccess, promotionError);
     }

--- a/pnc-core/src/test/java/org/jboss/pnc/core/test/mock/RepositorySessionMock.java
+++ b/pnc-core/src/test/java/org/jboss/pnc/core/test/mock/RepositorySessionMock.java
@@ -4,8 +4,8 @@ import org.jboss.pnc.model.Artifact;
 import org.jboss.pnc.model.RepositoryType;
 import org.jboss.pnc.spi.repositorymanager.RepositoryManagerException;
 import org.jboss.pnc.spi.repositorymanager.RepositoryManagerResult;
-import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
 import org.jboss.pnc.spi.repositorymanager.model.RepositoryConnectionInfo;
+import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -24,11 +24,6 @@ public class RepositorySessionMock implements RepositorySession {
     @Override
     public String getId() {
         return "test";
-    }
-
-    @Override
-    public String getCollectionId() {
-        return "test-collection";
     }
 
     @Override

--- a/pnc-model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
@@ -84,6 +84,7 @@ public class BuildConfiguration implements Serializable, Cloneable {
     private Set<BuildConfiguration> dependencies;
 
     // TODO: What data format does Aprox need?
+    // [jdcasey] I'm not sure what this is supposed to do in the repository manager...so hard to say what format is required.
     // @Column(name = "repositories")
     private String repositories;
 

--- a/pnc-model/src/main/java/org/jboss/pnc/model/BuildRecord.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/BuildRecord.java
@@ -1,5 +1,11 @@
 package org.jboss.pnc.model;
 
+import java.io.Serializable;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -15,12 +21,6 @@ import javax.persistence.OneToMany;
 import javax.persistence.PreRemove;
 import javax.persistence.SequenceGenerator;
 import javax.validation.constraints.NotNull;
-
-import java.io.Serializable;
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Created by <a href="mailto:matejonnet@gmail.com">Matej Lazar</a> on 2014-11-23.
@@ -50,6 +50,8 @@ public class BuildRecord implements Serializable {
     private String buildScript;
 
     private String name;
+
+    private String buildContentId;
 
     private String description;
 
@@ -417,6 +419,17 @@ public class BuildRecord implements Serializable {
         this.buildRecordSets = buildRecordSets;
     }
 
+    public String getBuildContentId() {
+        return buildContentId;
+    }
+
+    /**
+     * @param buildContentId The identifier to use when accessing repository or other content stored via external services.
+     */
+    public void setBuildContentId(String buildContentId) {
+        this.buildContentId = buildContentId;
+    }
+
     @Override
     public String toString() {
         return "BuildRecord [id=" + id + ", project=" + buildConfiguration.getProject().getName() + ", buildConfiguration="
@@ -426,6 +439,8 @@ public class BuildRecord implements Serializable {
     public static class Builder {
 
         private Integer id;
+
+        private String buildContentId;
 
         private String buildScript;
 
@@ -475,6 +490,7 @@ public class BuildRecord implements Serializable {
         public BuildRecord build() {
             BuildRecord buildRecord = new BuildRecord();
             buildRecord.setId(id);
+            buildRecord.setBuildContentId(buildContentId);
             buildRecord.setBuildScript(buildScript);
             buildRecord.setName(name);
             buildRecord.setDescription(description);
@@ -513,6 +529,11 @@ public class BuildRecord implements Serializable {
 
         public Builder id(Integer id) {
             this.id = id;
+            return this;
+        }
+
+        public Builder buildContentId(String buildContentId) {
+            this.buildContentId = buildContentId;
             return this;
         }
 

--- a/pnc-model/src/main/java/org/jboss/pnc/model/BuildRecordSet.java
+++ b/pnc-model/src/main/java/org/jboss/pnc/model/BuildRecordSet.java
@@ -1,5 +1,9 @@
 package org.jboss.pnc.model;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -12,10 +16,6 @@ import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.PreRemove;
 import javax.persistence.SequenceGenerator;
-
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * The Class BuildRecordSet, that encapsulates the set of buildRecords that compose a specific version of a Product.
@@ -33,6 +33,8 @@ public class BuildRecordSet implements Serializable {
     @SequenceGenerator(name="build_record_set_id_seq", sequenceName="build_record_set_id_seq", allocationSize=1)    
     @GeneratedValue(strategy=GenerationType.SEQUENCE, generator="build_record_set_id_seq")
     private Integer id;
+
+    private String buildSetContentId;
 
     @Enumerated(EnumType.STRING)
     private ProductMilestone milestone;
@@ -120,6 +122,18 @@ public class BuildRecordSet implements Serializable {
         this.buildRecord = record;
     }
 
+    public String getBuildSetContentId() {
+        return this.buildSetContentId;
+    }
+
+    /**
+     * @param buildSetContentId The identifier to use when aggregating and retrieving content related to this record set which
+     *        is stored via external services.
+     */
+    public void setBuildSetContentId(String buildSetContentId) {
+        this.buildSetContentId = buildSetContentId;
+    }
+
     @Override
     public String toString() {
         return "BuildRecordSet [productName=" + productVersion.getProduct().getName() + ", productVersion=" + productVersion
@@ -129,6 +143,8 @@ public class BuildRecordSet implements Serializable {
     public static class Builder {
 
         private Integer id;
+
+        private String buildSetContentId;
 
         private ProductMilestone milestone;
 
@@ -147,6 +163,7 @@ public class BuildRecordSet implements Serializable {
         public BuildRecordSet build() {
             BuildRecordSet buildRecordSet = new BuildRecordSet();
             buildRecordSet.setId(id);
+            buildRecordSet.setBuildSetContentId(buildSetContentId);
             buildRecordSet.setMilestone(milestone);
 
             if (productVersion != null) {
@@ -166,6 +183,11 @@ public class BuildRecordSet implements Serializable {
 
         public Builder id(Integer id) {
             this.id = id;
+            return this;
+        }
+
+        public Builder buildSetContentId(String buildSetContentId) {
+            this.buildSetContentId = buildSetContentId;
             return this;
         }
 

--- a/pnc-spi/src/main/java/org/jboss/pnc/spi/BuildExecution.java
+++ b/pnc-spi/src/main/java/org/jboss/pnc/spi/BuildExecution.java
@@ -1,0 +1,10 @@
+package org.jboss.pnc.spi;
+
+public interface BuildExecution {
+
+    String getTopContentId();
+
+    String getBuildSetContentId();
+
+    String getBuildContentId();
+}

--- a/pnc-spi/src/main/java/org/jboss/pnc/spi/content/ContentIdentifierManager.java
+++ b/pnc-spi/src/main/java/org/jboss/pnc/spi/content/ContentIdentifierManager.java
@@ -1,0 +1,17 @@
+package org.jboss.pnc.spi.content;
+
+import org.jboss.pnc.model.BuildConfiguration;
+import org.jboss.pnc.model.BuildConfigurationSet;
+import org.jboss.pnc.model.ProductVersion;
+
+public interface ContentIdentifierManager {
+
+    String GLOBAL_CONTENT_ID = "global";
+
+    String getProductContentId(ProductVersion productVersion);
+
+    String getBuildSetContentId(BuildConfigurationSet buildConfigurationSet);
+
+    String getBuildContentId(BuildConfiguration buildConfiguration);
+
+}

--- a/pnc-spi/src/main/java/org/jboss/pnc/spi/repositorymanager/RepositoryManager.java
+++ b/pnc-spi/src/main/java/org/jboss/pnc/spi/repositorymanager/RepositoryManager.java
@@ -1,9 +1,9 @@
 package org.jboss.pnc.spi.repositorymanager;
 
-import org.jboss.pnc.model.BuildConfiguration;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.BuildRecordSet;
 import org.jboss.pnc.model.RepositoryType;
+import org.jboss.pnc.spi.BuildExecution;
 import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
 import org.jboss.pnc.spi.repositorymanager.model.RunningRepositoryPromotion;
 
@@ -22,7 +22,7 @@ public interface RepositoryManager {
      * @param buildRecordSet Used to determine which in-progress product repository should be used.
      * @throws RepositoryManagerException
      */
-    RepositorySession createBuildRepository(BuildConfiguration buildConfiguration, BuildRecordSet buildRecordSet)
+    RepositorySession createBuildRepository(BuildExecution buildExecution)
             throws RepositoryManagerException;
 
     /**
@@ -36,7 +36,21 @@ public interface RepositoryManager {
      * 
      * @throws RepositoryManagerException
      */
-    RunningRepositoryPromotion promoteRepository(BuildRecord buildRecord, BuildRecordSet buildRecordSet)
+    RunningRepositoryPromotion promoteBuild(BuildRecord buildRecord, BuildRecordSet buildRecordSet)
+            throws RepositoryManagerException;
+
+    /**
+     * Add the repository group containing output associated with the specified {@link BuildRecordSet} to the membership of the
+     * repository group with the given ID.
+     * 
+     * @param buildRecordSet The record-set that should be promoted
+     * @param toGroup The group into which the record-set should be promoted
+     * 
+     * @return An object representing the running promotion process, with a callback method for the result.
+     * 
+     * @throws RepositoryManagerException
+     */
+    RunningRepositoryPromotion promoteBuildSet(BuildRecordSet buildRecordSet, String toGroup)
             throws RepositoryManagerException;
 
     boolean canManage(RepositoryType managerType);

--- a/pnc-spi/src/main/java/org/jboss/pnc/spi/repositorymanager/model/RepositorySession.java
+++ b/pnc-spi/src/main/java/org/jboss/pnc/spi/repositorymanager/model/RepositorySession.java
@@ -13,8 +13,6 @@ public interface RepositorySession {
 
     String getId();
 
-    String getCollectionId();
-
     RepositoryConnectionInfo getConnectionInfo();
 
     /**


### PR DESCRIPTION
(eg. repo manager)

Also implemented centrally-managed content IDs for product and build-config-set levels, and promotion of build record sets to arbitrary (pre-existing) groups.