### PR TITLE
[NCL-477] Return HTTP 400 when an id is sent for a new build config

### DIFF
--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationRestTest.java
@@ -125,6 +125,30 @@ public class BuildConfigurationRestTest {
         ResponseAssertion.assertThat(response).hasJsonValueNotNullOrEmpty("creationTime").hasJsonValueNotNullOrEmpty("lastModificationTime");
     }
 
+    @Test
+    public void shouldFailToCreateNewBuildConfiguration() throws IOException {
+        // given
+        final String scmUrl = "https://github.com/project-ncl/pnc.git";
+        final String buildScript = "mvn clean deploy -Dmaven.test.skip=true";
+        final String name = "Bad Request Example Config";
+        final String id = String.valueOf(projectId);
+
+        JsonTemplateBuilder configurationTemplate = JsonTemplateBuilder.fromResource("buildConfiguration_update_template");
+        configurationTemplate.addValue("_id", String.valueOf(configurationId));
+        configurationTemplate.addValue("_name", name);
+        configurationTemplate.addValue("_buildScript", buildScript);
+        configurationTemplate.addValue("_scmRepoURL", scmUrl);
+        configurationTemplate.addValue("_patchesUrl", "");
+        configurationTemplate.addValue("_creationTime", String.valueOf(1518382545038L));
+        configurationTemplate.addValue("_lastModificationTime", String.valueOf(155382545038L));
+        configurationTemplate.addValue("_repositories", "");
+        configurationTemplate.addValue("_projectId", id);
+        configurationTemplate.addValue("_environmentId", String.valueOf(environmentId));
+
+        given().body(configurationTemplate.fillTemplate()).contentType(ContentType.JSON).port(getHttpPort()).when().post(CONFIGURATION_REST_ENDPOINT).then()
+        .statusCode(400);
+
+    }
 
     @Test
     public void shouldUpdateBuildConfiguration() throws IOException {

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
@@ -56,6 +56,9 @@ public class BuildConfigurationEndpoint {
     @ApiOperation(value = "Creates a new Build Configuration")
     @POST
     public Response createNew(@NotNull @Valid BuildConfigurationRest buildConfigurationRest, @Context UriInfo uriInfo) {
+        if (buildConfigurationRest.getId() != null) {
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
         UriBuilder uriBuilder = UriBuilder.fromUri(uriInfo.getRequestUri()).path("{id}");
         int id = buildConfigurationProvider.store(buildConfigurationRest);
         return Response.created(uriBuilder.build(id)).entity(buildConfigurationProvider.getSpecific(id)).build();


### PR DESCRIPTION
If the client sends the id in the POST request for a new config we
should return an HTTP 400 (bad request), because we require that
the server generates the correct next id in the sequence.