### PR TITLE
Implementing promotion of builds within a chain to chain-level group

### DIFF
--- a/docker-environment-driver/src/test/java/org/jboss/pnc/environment/docker/DockerEnvironmentDriverRemoteTest.java
+++ b/docker-environment-driver/src/test/java/org/jboss/pnc/environment/docker/DockerEnvironmentDriverRemoteTest.java
@@ -238,7 +238,7 @@ public class DockerEnvironmentDriverRemoteTest {
         }
 
         @Override
-        public String getId() {
+        public String getBuildRepositoryId() {
             return null;
         }
 
@@ -271,6 +271,16 @@ public class DockerEnvironmentDriverRemoteTest {
         @Override
         public RepositoryManagerResult extractBuildArtifacts() throws RepositoryManagerException {
             return null;
+        }
+
+        @Override
+        public String getBuildSetRepositoryId() {
+            return null;
+        }
+
+        @Override
+        public void promoteToBuildContentSet() throws RepositoryManagerException {
+            // not triggered because getBuildSetRepositoryId() returns null
         }
 
     }

--- a/jenkins-build-driver/src/test/java/org/jboss/pnc/jenkinsbuilddriver/test/JenkinsDriverRemoteTest.java
+++ b/jenkins-build-driver/src/test/java/org/jboss/pnc/jenkinsbuilddriver/test/JenkinsDriverRemoteTest.java
@@ -170,7 +170,7 @@ public class JenkinsDriverRemoteTest {
             }
 
             @Override
-            public String getId() {
+            public String getBuildRepositoryId() {
                 return "mock-config";
             }
 
@@ -223,6 +223,16 @@ public class JenkinsDriverRemoteTest {
                 artifact.setId(i);
                 artifact.setIdentifier("test" + i);
                 return artifact;
+            }
+
+            @Override
+            public String getBuildSetRepositoryId() {
+                return null;
+            }
+
+            @Override
+            public void promoteToBuildContentSet() throws RepositoryManagerException {
+                // not triggered because getBuildSetRepositoryId() returns null
             }
         };
     }

--- a/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver.java
+++ b/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver.java
@@ -35,7 +35,7 @@ import javax.inject.Inject;
  */
 @ApplicationScoped
 public class RepositoryManagerDriver implements RepositoryManager {
-    
+
     public static final String DRIVER_ID = "maven-repo-driver";
 
     public static final String PUBLIC_GROUP_ID = "public";
@@ -100,8 +100,7 @@ public class RepositoryManagerDriver implements RepositoryManager {
      *         (or product, or shared-releases).
      */
     @Override
-    public RepositorySession createBuildRepository(BuildExecution buildExecution)
-            throws RepositoryManagerException {
+    public RepositorySession createBuildRepository(BuildExecution buildExecution) throws RepositoryManagerException {
 
         String topId = buildExecution.getTopContentId();
         if (topId != null) {
@@ -117,8 +116,8 @@ public class RepositoryManagerDriver implements RepositoryManager {
             try {
                 setupBuildSetRepos(setId);
             } catch (AproxClientException e) {
-                throw new RepositoryManagerException("Failed to setup repository group for build configuration set: %s",
-                        e, e.getMessage());
+                throw new RepositoryManagerException("Failed to setup repository group for build configuration set: %s", e,
+                        e.getMessage());
             }
         }
 
@@ -140,9 +139,8 @@ public class RepositoryManagerDriver implements RepositoryManager {
                     e.getMessage());
         }
 
-        return new MavenRepositorySession(aprox, buildId, new MavenRepositoryConnectionInfo(url));
+        return new MavenRepositorySession(aprox, buildId, setId, new MavenRepositoryConnectionInfo(url));
     }
-
 
     /**
      * Create the hosted repository and group necessary to support a single build. The hosted repository holds artifacts
@@ -166,8 +164,7 @@ public class RepositoryManagerDriver implements RepositoryManager {
                 buildArtifacts.setAllowReleases(true);
 
                 aprox.stores().create(buildArtifacts,
-                        "Creating hosted repository for build: " + buildRepoId + " of: " + projectName,
-                        HostedRepository.class);
+                        "Creating hosted repository for build: " + buildRepoId + " of: " + projectName, HostedRepository.class);
             }
 
             Group buildGroup = new Group(buildRepoId);
@@ -188,8 +185,7 @@ public class RepositoryManagerDriver implements RepositoryManager {
             // Global-level repos, for captured/shared artifacts and access to the outside world
             addGlobalConstituents(buildGroup);
 
-            aprox.stores().create(
-                    buildGroup,
+            aprox.stores().create(buildGroup,
                     "Creating repository group for resolving artifacts in build: " + buildRepoId + " of: " + projectName,
                     Group.class);
         }
@@ -227,8 +223,7 @@ public class RepositoryManagerDriver implements RepositoryManager {
         if (!aprox.stores().exists(StoreType.group, productId)) {
             Group productGroup = new Group(productId);
 
-            aprox.stores().create(
-                    productGroup,
+            aprox.stores().create(productGroup,
                     "Creating group: " + productId + " for access to repos of builds related to that product.", Group.class);
         }
     }
@@ -276,11 +271,9 @@ public class RepositoryManagerDriver implements RepositoryManager {
     }
 
     @Override
-    public RunningRepositoryPromotion promoteBuild(BuildRecord buildRecord, BuildRecordSet buildRecordSet)
-            throws RepositoryManagerException {
+    public RunningRepositoryPromotion promoteBuild(BuildRecord buildRecord, String toGroup) throws RepositoryManagerException {
 
-        return new MavenRunningPromotion(StoreType.hosted, buildRecord.getBuildContentId(),
-                buildRecordSet.getBuildSetContentId(), aprox);
+        return new MavenRunningPromotion(StoreType.hosted, buildRecord.getBuildContentId(), toGroup, aprox);
     }
 
     @Override

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver04Test.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver04Test.java
@@ -92,7 +92,7 @@ public class RepositoryManagerDriver04Test
         Aprox aprox = driver.getAprox();
 
         for (String path : new String[] { pomPath, jarPath }) {
-            final String url = aprox.content().contentUrl(StoreType.hosted, rc.getId(), path);
+            final String url = aprox.content().contentUrl(StoreType.hosted, rc.getBuildRepositoryId(), path);
             boolean downloaded = client.execute(new HttpGet(url), new ResponseHandler<Boolean>() {
                 @Override
                 public Boolean handleResponse(HttpResponse response) throws ClientProtocolException, IOException {

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver05Test.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver05Test.java
@@ -21,7 +21,7 @@ public class RepositoryManagerDriver05Test extends AbstractRepositoryManagerDriv
         Aprox aprox = driver.getAprox();
 
         RepositorySession repositoryConfiguration = driver.createBuildRepository(execution);
-        String repoId = repositoryConfiguration.getId();
+        String repoId = repositoryConfiguration.getBuildRepositoryId();
 
         assertThat(repoId, equalTo(execution.getBuildContentId()));
 

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver06Test.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver06Test.java
@@ -21,7 +21,7 @@ public class RepositoryManagerDriver06Test extends AbstractRepositoryManagerDriv
         Aprox aprox = driver.getAprox();
 
         RepositorySession repositoryConfiguration = driver.createBuildRepository(execution);
-        String repoId = repositoryConfiguration.getId();
+        String repoId = repositoryConfiguration.getBuildRepositoryId();
 
         assertThat(repoId, equalTo(execution.getBuildContentId()));
 

--- a/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildCoordinator.java
+++ b/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildCoordinator.java
@@ -302,6 +302,12 @@ public class BuildCoordinator {
             try {
                 if (buildResult != null) {
                     buildTask.setStatus(BuildStatus.STORING_RESULTS);
+                            if (backupRunningEnvironment.getRunningEnvironment() != null
+                                    && backupRunningEnvironment.getRunningEnvironment().getRepositorySession() != null) {
+                                backupRunningEnvironment.getRunningEnvironment().getRepositorySession()
+                                        .promoteToBuildContentSet();
+                            }
+
                     datastoreAdapter.storeResult(buildTask, buildResult);
                     completedOk = true;
                 } else {
@@ -314,6 +320,10 @@ public class BuildCoordinator {
             } catch (DatastoreException de) {
                 log.errorf(e, "Error storing results of build configuration: %s to datastore.", buildTask.getId());
             } 
+ catch (RepositoryManagerException repoE) {
+                        log.warn("Promotion of build output repository: " + buildTask.getBuildContentId()
+                                + " to build-set group: " + buildTask.getBuildSetContentId() + " failed!", repoE);
+                    }
             catch (EnvironmentDriverException envE) {
                 log.warn("Running environment" + backupRunningEnvironment.getRunningEnvironment() 
                         +  " couldn't be destroyed!", envE);

--- a/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildTask.java
+++ b/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildTask.java
@@ -71,7 +71,8 @@ public class BuildTask implements BuildExecution {
     }
 
     public void setStatus(BuildStatus status) {
-        BuildStatusChangedEvent buildStatusChangedEvent = new DefaultBuildStatusChangedEvent(this.status, status, buildConfiguration.getId());
+        BuildStatusChangedEvent buildStatusChangedEvent = new DefaultBuildStatusChangedEvent(this.status, status,
+                buildConfiguration.getId(), this);
         log.debug("Updating build task {} status to {}", this.getId(), buildStatusChangedEvent);
 
         statusUpdateListeners.forEach(consumer -> consumer.accept(buildStatusChangedEvent));

--- a/pnc-core/src/main/java/org/jboss/pnc/core/events/DefaultBuildStatusChangedEvent.java
+++ b/pnc-core/src/main/java/org/jboss/pnc/core/events/DefaultBuildStatusChangedEvent.java
@@ -1,5 +1,6 @@
 package org.jboss.pnc.core.events;
 
+import org.jboss.pnc.spi.BuildExecution;
 import org.jboss.pnc.spi.BuildStatus;
 import org.jboss.pnc.spi.events.BuildStatusChangedEvent;
 
@@ -8,11 +9,14 @@ public class DefaultBuildStatusChangedEvent implements BuildStatusChangedEvent {
     private final BuildStatus oldStatus;
     private final BuildStatus newStatus;
     private final int buildConfigurationId;
+    private final BuildExecution buildExecution;
 
-    public DefaultBuildStatusChangedEvent(BuildStatus oldStatus, BuildStatus newStatus, int buildConfigurationId) {
+    public DefaultBuildStatusChangedEvent(BuildStatus oldStatus, BuildStatus newStatus, int buildConfigurationId,
+            BuildExecution execution) {
         this.oldStatus = oldStatus;
         this.newStatus = newStatus;
         this.buildConfigurationId = buildConfigurationId;
+        this.buildExecution = execution;
     }
 
     @Override
@@ -30,6 +34,11 @@ public class DefaultBuildStatusChangedEvent implements BuildStatusChangedEvent {
         return buildConfigurationId;
     }
 
+    @Override
+    public BuildExecution getBuildExecution() {
+        return buildExecution;
+    }
+
     @Override public String toString() {
         return "DefaultBuildStatusChangedEvent{" +
                 "oldStatus=" + oldStatus +
@@ -37,4 +46,5 @@ public class DefaultBuildStatusChangedEvent implements BuildStatusChangedEvent {
                 ", buildConfigurationId=" + buildConfigurationId +
                 '}';
     }
+
 }

--- a/pnc-core/src/test/java/org/jboss/pnc/core/test/mock/RepositoryManagerMock.java
+++ b/pnc-core/src/test/java/org/jboss/pnc/core/test/mock/RepositoryManagerMock.java
@@ -44,7 +44,7 @@ public class RepositoryManagerMock implements RepositoryManager {
     }
 
     @Override
-    public RunningRepositoryPromotion promoteBuild(BuildRecord buildRecord, BuildRecordSet buildRecordSet)
+    public RunningRepositoryPromotion promoteBuild(BuildRecord buildRecord, String toGroup)
             throws RepositoryManagerException {
         return new RunningRepositoryPromotionMock(promotionSuccess, promotionError);
     }

--- a/pnc-core/src/test/java/org/jboss/pnc/core/test/mock/RepositorySessionMock.java
+++ b/pnc-core/src/test/java/org/jboss/pnc/core/test/mock/RepositorySessionMock.java
@@ -22,7 +22,7 @@ public class RepositorySessionMock implements RepositorySession {
     }
 
     @Override
-    public String getId() {
+    public String getBuildRepositoryId() {
         return "test";
     }
 
@@ -81,5 +81,15 @@ public class RepositorySessionMock implements RepositorySession {
         artifact.setId(i);
         artifact.setIdentifier("test" + i);
         return artifact;
+    }
+
+    @Override
+    public String getBuildSetRepositoryId() {
+        return null;
+    }
+
+    @Override
+    public void promoteToBuildContentSet() throws RepositoryManagerException {
+        // not triggered because getBuildSetRepositoryId() returns null
     }
 }

--- a/pnc-spi/src/main/java/org/jboss/pnc/spi/events/BuildStatusChangedEvent.java
+++ b/pnc-spi/src/main/java/org/jboss/pnc/spi/events/BuildStatusChangedEvent.java
@@ -1,5 +1,6 @@
 package org.jboss.pnc.spi.events;
 
+import org.jboss.pnc.spi.BuildExecution;
 import org.jboss.pnc.spi.BuildStatus;
 
 public interface BuildStatusChangedEvent {
@@ -7,5 +8,7 @@ public interface BuildStatusChangedEvent {
     BuildStatus getOldStatus();
     BuildStatus getNewStatus();
     Integer getBuildConfigurationId();
+
+    BuildExecution getBuildExecution();
 
 }

--- a/pnc-spi/src/main/java/org/jboss/pnc/spi/repositorymanager/RepositoryManager.java
+++ b/pnc-spi/src/main/java/org/jboss/pnc/spi/repositorymanager/RepositoryManager.java
@@ -27,16 +27,16 @@ public interface RepositoryManager {
 
     /**
      * Add the repository containing output associated with the specified {@link BuildRecord} to the membership of the
-     * repository group associated with the specified {@link BuildRecordSet}.
+     * repository group with the given ID.
      * 
-     * @param buildRecord The build output to add to the record-set
-     * @param buildRecordSet The record-set into which the output should be promoted
+     * @param buildRecord The build output to promote
+     * @param toGroup The ID of the repository group where the build output should be promoted
      * 
      * @return An object representing the running promotion process, with a callback method for the result.
      * 
      * @throws RepositoryManagerException
      */
-    RunningRepositoryPromotion promoteBuild(BuildRecord buildRecord, BuildRecordSet buildRecordSet)
+    RunningRepositoryPromotion promoteBuild(BuildRecord buildRecord, String toGroup)
             throws RepositoryManagerException;
 
     /**

--- a/pnc-spi/src/main/java/org/jboss/pnc/spi/repositorymanager/model/RepositorySession.java
+++ b/pnc-spi/src/main/java/org/jboss/pnc/spi/repositorymanager/model/RepositorySession.java
@@ -11,14 +11,22 @@ public interface RepositorySession {
 
     RepositoryType getType();
 
-    String getId();
+    String getBuildRepositoryId();
+
+    String getBuildSetRepositoryId();
 
     RepositoryConnectionInfo getConnectionInfo();
 
     /**
-     * Promote any deployed artifacts and process any uncaptured imports of input artifacts (dependencies, etc.)
+     * Process any uncaptured imports of input artifacts (dependencies, etc.) and return the result containing dependencies and
+     * build output.
      *
      * @throws org.jboss.pnc.spi.repositorymanager.RepositoryManagerException
      */
     RepositoryManagerResult extractBuildArtifacts() throws RepositoryManagerException;
+
+    /**
+     * Promote the build repository containing build output to the content-set group, if it exists.
+     */
+    void promoteToBuildContentSet() throws RepositoryManagerException;
 }


### PR DESCRIPTION
Implementing promotion of build repository to the build-set group (if it exists) after each build in a chain completes. If the build isn't in a chain, build-set ID won't be set, and no promotion will take place.