### PR TITLE
Promote to group for build-set based on BuildExecutionType enum

### DIFF
--- a/docker-environment-driver/src/test/java/org/jboss/pnc/environment/docker/DockerEnvironmentDriverRemoteTest.java
+++ b/docker-environment-driver/src/test/java/org/jboss/pnc/environment/docker/DockerEnvironmentDriverRemoteTest.java
@@ -278,11 +278,6 @@ public class DockerEnvironmentDriverRemoteTest {
             return null;
         }
 
-        @Override
-        public void promoteToBuildContentSet() throws RepositoryManagerException {
-            // not triggered because getBuildSetRepositoryId() returns null
-        }
-
     }
 
 }

--- a/jenkins-build-driver/src/test/java/org/jboss/pnc/jenkinsbuilddriver/test/JenkinsDriverRemoteTest.java
+++ b/jenkins-build-driver/src/test/java/org/jboss/pnc/jenkinsbuilddriver/test/JenkinsDriverRemoteTest.java
@@ -230,10 +230,6 @@ public class JenkinsDriverRemoteTest {
                 return null;
             }
 
-            @Override
-            public void promoteToBuildContentSet() throws RepositoryManagerException {
-                // not triggered because getBuildSetRepositoryId() returns null
-            }
         };
     }
 

--- a/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver.java
+++ b/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver.java
@@ -139,7 +139,8 @@ public class RepositoryManagerDriver implements RepositoryManager {
                     e.getMessage());
         }
 
-        return new MavenRepositorySession(aprox, buildId, setId, new MavenRepositoryConnectionInfo(url));
+        return new MavenRepositorySession(aprox, buildId, setId, buildExecution.getBuildExecutionType(),
+                new MavenRepositoryConnectionInfo(url));
     }
 
     /**

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AbstractRepositoryManagerDriverTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AbstractRepositoryManagerDriverTest.java
@@ -23,6 +23,8 @@ import java.util.Properties;
 
 public class AbstractRepositoryManagerDriverTest {
 
+    protected static final String CONFIG_SYSPROP = "pnc-config-file";
+
     @Rule
     public TemporaryFolder temp = new TemporaryFolder();
 
@@ -37,7 +39,7 @@ public class AbstractRepositoryManagerDriverTest {
         fixture = new CoreServerFixture(temp);
 
         Properties sysprops = System.getProperties();
-        oldIni = sysprops.getProperty(Configuration.CONFIG_SYSPROP);
+        oldIni = sysprops.getProperty(CONFIG_SYSPROP);
 
         url = fixture.getUrl();
         File configFile = temp.newFile("pnc-config.json");
@@ -48,7 +50,7 @@ public class AbstractRepositoryManagerDriverTest {
         ObjectMapper mapper = new ObjectMapper();
         mapper.writeValue(configFile, moduleConfigJson);
 
-        sysprops.setProperty(Configuration.CONFIG_SYSPROP, configFile.getAbsolutePath());
+        sysprops.setProperty(CONFIG_SYSPROP, configFile.getAbsolutePath());
         System.setProperties(sysprops);
 
         fixture.start();
@@ -71,9 +73,9 @@ public class AbstractRepositoryManagerDriverTest {
     public void teardown() throws Exception {
         Properties sysprops = System.getProperties();
         if (oldIni == null) {
-            sysprops.remove(Configuration.CONFIG_SYSPROP);
+            sysprops.remove(CONFIG_SYSPROP);
         } else {
-            sysprops.setProperty(Configuration.CONFIG_SYSPROP, oldIni);
+            sysprops.setProperty(CONFIG_SYSPROP, oldIni);
         }
         System.setProperties(sysprops);
 

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver05Test.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver05Test.java
@@ -10,6 +10,7 @@ import org.commonjava.aprox.model.core.StoreKey;
 import org.commonjava.aprox.model.core.StoreType;
 import org.jboss.pnc.mavenrepositorymanager.fixture.TestBuildExecution;
 import org.jboss.pnc.spi.BuildExecution;
+import org.jboss.pnc.spi.BuildExecutionType;
 import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
 import org.junit.Test;
 
@@ -17,7 +18,8 @@ public class RepositoryManagerDriver05Test extends AbstractRepositoryManagerDriv
 
     @Test
     public void verifyGroupComposition_ProjectVersion_NoConfSet() throws Exception {
-        BuildExecution execution = new TestBuildExecution("product+myproduct+1.0", null, "build+myproject+12345");
+        BuildExecution execution = new TestBuildExecution("product+myproduct+1.0", null, "build+myproject+12345",
+                BuildExecutionType.STANDALONE_BUILD);
         Aprox aprox = driver.getAprox();
 
         RepositorySession repositoryConfiguration = driver.createBuildRepository(execution);

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver06Test.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver06Test.java
@@ -10,6 +10,7 @@ import org.commonjava.aprox.model.core.StoreKey;
 import org.commonjava.aprox.model.core.StoreType;
 import org.jboss.pnc.mavenrepositorymanager.fixture.TestBuildExecution;
 import org.jboss.pnc.spi.BuildExecution;
+import org.jboss.pnc.spi.BuildExecutionType;
 import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
 import org.junit.Test;
 
@@ -17,7 +18,8 @@ public class RepositoryManagerDriver06Test extends AbstractRepositoryManagerDriv
 
     @Test
     public void verifyGroupComposition_ProjectVersion_WithConfSet() throws Exception {
-        BuildExecution execution = new TestBuildExecution("product+myproduct+1.1", "my-build-conf-set", "build+myproject+67890");
+        BuildExecution execution = new TestBuildExecution("product+myproduct+1.1", "my-build-conf-set",
+                "build+myproject+67890", BuildExecutionType.COMPOSED_BUILD);
         Aprox aprox = driver.getAprox();
 
         RepositorySession repositoryConfiguration = driver.createBuildRepository(execution);

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/fixture/TestBuildExecution.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/fixture/TestBuildExecution.java
@@ -1,6 +1,7 @@
 package org.jboss.pnc.mavenrepositorymanager.fixture;
 
 import org.jboss.pnc.spi.BuildExecution;
+import org.jboss.pnc.spi.BuildExecutionType;
 
 public class TestBuildExecution implements BuildExecution {
 
@@ -12,14 +13,17 @@ public class TestBuildExecution implements BuildExecution {
 
     private String projectName = "my project";
 
-    public TestBuildExecution(String topId, String setId, String buildId) {
+    private BuildExecutionType buildExecutionType;
+
+    public TestBuildExecution(String topId, String setId, String buildId, BuildExecutionType type) {
         this.topContentId = topId;
         this.buildSetContentId = setId;
         this.buildContentId = buildId;
+        this.buildExecutionType = type;
     }
 
     public TestBuildExecution() {
-        this("product+myproduct+1-0", null, "build+myproject+12345");
+        this("product+myproduct+1-0", null, "build+myproject+12345", BuildExecutionType.STANDALONE_BUILD);
     }
 
     @Override
@@ -56,6 +60,11 @@ public class TestBuildExecution implements BuildExecution {
 
     public void setProjectName(String projectName) {
         this.projectName = projectName;
+    }
+
+    @Override
+    public BuildExecutionType getBuildExecutionType() {
+        return buildExecutionType;
     }
 
 }

--- a/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildCoordinator.java
+++ b/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildCoordinator.java
@@ -15,6 +15,7 @@ import org.jboss.pnc.model.BuildDriverStatus;
 import org.jboss.pnc.model.RepositoryType;
 import org.jboss.pnc.spi.BuildResult;
 import org.jboss.pnc.spi.BuildStatus;
+import org.jboss.pnc.spi.BuildExecutionType;
 import org.jboss.pnc.spi.builddriver.BuildDriver;
 import org.jboss.pnc.spi.builddriver.BuildDriverResult;
 import org.jboss.pnc.spi.builddriver.CompletedBuild;
@@ -35,6 +36,7 @@ import org.jboss.util.graph.Vertex;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -91,14 +93,14 @@ public class BuildCoordinator {
         BuildConfigurationSet buildConfigurationSet = new BuildConfigurationSet();
         buildConfigurationSet.setName(buildConfiguration.getName());
         buildConfigurationSet.addBuildConfiguration(buildConfiguration);
-        BuildSetTask buildSetTask = new BuildSetTask(buildConfigurationSet, BuildTaskType.STANDALONE_BUILD);
+        BuildSetTask buildSetTask = new BuildSetTask(buildConfigurationSet, BuildExecutionType.STANDALONE_BUILD);
         build(buildSetTask);
         BuildTask buildTask = buildSetTask.getBuildTasks().stream().collect(StreamCollectors.singletonCollector());
         return buildTask;
     }
 
     public BuildSetTask build(BuildConfigurationSet buildConfigurationSet) throws CoreException {
-        BuildSetTask buildSetTask = new BuildSetTask(buildConfigurationSet, BuildTaskType.COMPOSED_BUILD);
+        BuildSetTask buildSetTask = new BuildSetTask(buildConfigurationSet, BuildExecutionType.COMPOSED_BUILD);
         build(buildSetTask);
         return buildSetTask;
     }

--- a/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildSetTask.java
+++ b/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildSetTask.java
@@ -2,6 +2,7 @@ package org.jboss.pnc.core.builder;
 
 import org.jboss.pnc.model.BuildConfigurationSet;
 import org.jboss.pnc.spi.BuildStatus;
+import org.jboss.pnc.spi.BuildExecutionType;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -13,14 +14,14 @@ public class BuildSetTask {
 
     private BuildConfigurationSet buildConfigurationSet;
 
-    private final BuildTaskType buildTaskType;
+    private final BuildExecutionType buildTaskType;
 
     private BuildStatus status;
 
     private String statusDescription;
     private Set<BuildTask> buildTasks = new HashSet<>();
 
-    public BuildSetTask(BuildConfigurationSet buildConfigurationSet, BuildTaskType buildTaskType) {
+    public BuildSetTask(BuildConfigurationSet buildConfigurationSet, BuildExecutionType buildTaskType) {
         this.buildConfigurationSet = buildConfigurationSet;
         this.buildTaskType = buildTaskType;
     }
@@ -57,7 +58,7 @@ public class BuildSetTask {
         return buildConfigurationSet.getId();
     }
 
-    public BuildTaskType getBuildTaskType() {
+    public BuildExecutionType getBuildTaskType() {
         return buildTaskType;
     }
 }

--- a/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildTask.java
+++ b/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildTask.java
@@ -5,11 +5,13 @@ import org.jboss.pnc.core.exception.CoreException;
 import org.jboss.pnc.model.BuildConfiguration;
 import org.jboss.pnc.spi.BuildExecution;
 import org.jboss.pnc.spi.BuildStatus;
+import org.jboss.pnc.spi.BuildExecutionType;
 import org.jboss.pnc.spi.events.BuildStatusChangedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.enterprise.event.Event;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -22,7 +24,7 @@ public class BuildTask implements BuildExecution {
     public static final Logger log = LoggerFactory.getLogger(BuildTask.class);
 
     public BuildConfiguration buildConfiguration;
-    private BuildTaskType buildTaskType;
+    private BuildExecutionType buildTaskType;
     BuildStatus status = BuildStatus.NEW;
     private String statusDescription;
 
@@ -42,7 +44,7 @@ public class BuildTask implements BuildExecution {
     private String buildContentId;
 
     BuildTask(BuildCoordinator buildCoordinator, BuildConfiguration buildConfiguration, String topContentId,
-              String buildSetContentId, String buildContentId, BuildTaskType buildTaskType) {
+              String buildSetContentId, String buildContentId, BuildExecutionType buildTaskType) {
         this.buildCoordinator = buildCoordinator;
         this.buildConfiguration = buildConfiguration;
         this.buildTaskType = buildTaskType;
@@ -154,7 +156,7 @@ public class BuildTask implements BuildExecution {
         return buildConfiguration.getProject().getName();
     }
 
-    public BuildTaskType getBuildTaskType() {
+    public BuildExecutionType getBuildExecutionType() {
         return buildTaskType;
     }
 }

--- a/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildTasksTree.java
+++ b/pnc-core/src/main/java/org/jboss/pnc/core/builder/BuildTasksTree.java
@@ -5,6 +5,7 @@ import org.jboss.pnc.core.content.ContentIdentityManager;
 import org.jboss.pnc.model.BuildConfiguration;
 import org.jboss.pnc.model.BuildConfigurationSet;
 import org.jboss.pnc.spi.BuildStatus;
+import org.jboss.pnc.spi.BuildExecutionType;
 import org.jboss.util.graph.Edge;
 import org.jboss.util.graph.Graph;
 import org.jboss.util.graph.Vertex;
@@ -78,7 +79,7 @@ public class BuildTasksTree {
             BuildCoordinator buildCoordinator,
             String topContentId,
             String buildSetContentId,
-            BuildTaskType buildTaskType) {
+            BuildExecutionType buildTaskType) {
 
         ContentIdentityManager contentIdentityManager = new ContentIdentityManager();
         Vertex<BuildTask> buildVertex = getVertexByBuildConfiguration(buildConfiguration);

--- a/pnc-core/src/test/java/org/jboss/pnc/core/test/buildCoordinator/ReadDependenciesTest.java
+++ b/pnc-core/src/test/java/org/jboss/pnc/core/test/buildCoordinator/ReadDependenciesTest.java
@@ -2,10 +2,10 @@ package org.jboss.pnc.core.test.buildCoordinator;
 
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.pnc.core.builder.BuildSetTask;
-import org.jboss.pnc.core.builder.BuildTaskType;
 import org.jboss.pnc.core.builder.BuildTasksTree;
 import org.jboss.pnc.core.test.configurationBuilders.TestProjectConfigurationBuilder;
 import org.jboss.pnc.model.BuildConfigurationSet;
+import org.jboss.pnc.spi.BuildExecutionType;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,7 +20,7 @@ public class ReadDependenciesTest extends ProjectBuilder {
     public void createDependencyTreeTestCase() {
         TestProjectConfigurationBuilder configurationBuilder = new TestProjectConfigurationBuilder();
         BuildConfigurationSet buildConfigurationSet = configurationBuilder.buildConfigurationSet();
-        BuildSetTask buildSetTask = new BuildSetTask(buildConfigurationSet, BuildTaskType.COMPOSED_BUILD);
+        BuildSetTask buildSetTask = new BuildSetTask(buildConfigurationSet, BuildExecutionType.COMPOSED_BUILD);
         BuildTasksTree buildTasksTree = BuildTasksTree.newInstance(buildCoordinator, buildSetTask);
 
         Assert.assertEquals("Missing projects in tree structure.", 5, buildTasksTree.getBuildTasks().size());

--- a/pnc-core/src/test/java/org/jboss/pnc/core/test/mock/RepositorySessionMock.java
+++ b/pnc-core/src/test/java/org/jboss/pnc/core/test/mock/RepositorySessionMock.java
@@ -87,9 +87,4 @@ public class RepositorySessionMock implements RepositorySession {
     public String getBuildSetRepositoryId() {
         return null;
     }
-
-    @Override
-    public void promoteToBuildContentSet() throws RepositoryManagerException {
-        // not triggered because getBuildSetRepositoryId() returns null
-    }
 }

--- a/pnc-spi/src/main/java/org/jboss/pnc/spi/BuildExecution.java
+++ b/pnc-spi/src/main/java/org/jboss/pnc/spi/BuildExecution.java
@@ -9,4 +9,6 @@ public interface BuildExecution {
     String getBuildContentId();
 
     String getProjectName();
+
+    BuildExecutionType getBuildExecutionType();
 }

--- a/pnc-spi/src/main/java/org/jboss/pnc/spi/BuildExecutionType.java
+++ b/pnc-spi/src/main/java/org/jboss/pnc/spi/BuildExecutionType.java
@@ -1,9 +1,9 @@
-package org.jboss.pnc.core.builder;
+package org.jboss.pnc.spi;
 
 /**
  * Created by <a href="mailto:matejonnet@gmail.com">Matej Lazar</a> on 2015-03-27.
  */
-public enum BuildTaskType {
+public enum BuildExecutionType {
     STANDALONE_BUILD,
     COMPOSED_BUILD;
 }

--- a/pnc-spi/src/main/java/org/jboss/pnc/spi/repositorymanager/model/RepositorySession.java
+++ b/pnc-spi/src/main/java/org/jboss/pnc/spi/repositorymanager/model/RepositorySession.java
@@ -24,9 +24,4 @@ public interface RepositorySession {
      * @throws org.jboss.pnc.spi.repositorymanager.RepositoryManagerException
      */
     RepositoryManagerResult extractBuildArtifacts() throws RepositoryManagerException;
-
-    /**
-     * Promote the build repository containing build output to the content-set group, if it exists.
-     */
-    void promoteToBuildContentSet() throws RepositoryManagerException;
 }


### PR DESCRIPTION
...not based on  presence or absence of buildSetId.

Also, moved BuildTaskType enum in pnc-core to BuildExecutionType in pnc-spi, to break the dep cycle between pnc-core and maven-repository-manager modules.