### PR TITLE
[NCL-666] Allow non-null ID for updates

### DIFF
--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/UserEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/UserEndpoint.java
@@ -5,6 +5,7 @@ import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
 
 import org.jboss.pnc.rest.provider.UserProvider;
+import org.jboss.pnc.rest.restmodel.ProjectRest;
 import org.jboss.pnc.rest.restmodel.UserRest;
 
 import javax.inject.Inject;
@@ -54,6 +55,15 @@ public class UserEndpoint {
         int id = userProvider.store(userRest);
         UriBuilder uriBuilder = UriBuilder.fromUri(uriInfo.getRequestUri()).path("{id}");
         return Response.created(uriBuilder.build(id)).entity(userProvider.getSpecific(id)).build();
+    }
+
+    @ApiOperation(value = "Updates an existing User")
+    @PUT
+    @Path("/{id}")
+    public Response update(@ApiParam(value = "User id", required = true) @PathParam("id") Integer id,
+            @NotNull @Valid UserRest userRest, @Context UriInfo uriInfo) {
+        userProvider.update(id, userRest);
+        return Response.ok().build();
     }
 
 }

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProvider.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProvider.java
@@ -92,15 +92,16 @@ public class BuildConfigurationProvider {
     }
 
     public Integer update(Integer id, BuildConfigurationRest buildConfigurationRest) {
-        Preconditions.checkArgument(buildConfigurationRest.getId() == null, "Id must be null");
         Preconditions.checkArgument(id != null, "Id must not be null");
+        Preconditions.checkArgument(buildConfigurationRest.getId() == null || buildConfigurationRest.getId().equals(id),
+                "Entity id does not match the id to update");
         buildConfigurationRest.setId(id);
         BuildConfiguration buildConfiguration = buildConfigurationRepository.findOne(id);
         Preconditions.checkArgument(buildConfiguration != null, "Couldn't find buildConfiguration with id "
                 + buildConfigurationRest.getId());
         buildConfiguration = buildConfigurationRepository.save(buildConfigurationRest.toBuildConfiguration(buildConfiguration));
         return buildConfiguration.getId();
-    }
+  }
 
     public Integer clone(Integer buildConfigurationId) {
         BuildConfiguration buildConfiguration = buildConfigurationRepository.findOne(buildConfigurationId);

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationSetProvider.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationSetProvider.java
@@ -81,8 +81,9 @@ public class BuildConfigurationSetProvider {
     }
 
     public Integer update(Integer id, BuildConfigurationSetRest buildConfigurationSetRest) {
-        Preconditions.checkArgument(buildConfigurationSetRest.getId() == null, "Id must be null");
         Preconditions.checkArgument(id != null, "Id must not be null");
+        Preconditions.checkArgument(buildConfigurationSetRest.getId() == null || buildConfigurationSetRest.getId().equals(id),
+                "Entity id does not match the id to update");
         buildConfigurationSetRest.setId(id);
         BuildConfigurationSet buildConfigurationSet = buildConfigurationSetRepository.findOne(buildConfigurationSetRest.getId());
         Preconditions.checkArgument(buildConfigurationSet != null, "Couldn't find buildConfigurationSet with id "

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/BuildRecordSetProvider.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/BuildRecordSetProvider.java
@@ -78,8 +78,9 @@ public class BuildRecordSetProvider {
     }
 
     public Integer update(Integer id, BuildRecordSetRest buildRecordSetRest) {
-        Preconditions.checkArgument(buildRecordSetRest.getId() == null, "Id must be null");
         Preconditions.checkArgument(id != null, "Id must not be null");
+        Preconditions.checkArgument(buildRecordSetRest.getId() == null || buildRecordSetRest.getId().equals(id),
+                "Entity id does not match the id to update");
         buildRecordSetRest.setId(id);
         BuildRecordSet buildRecordSet = buildRecordSetRepository.findOne(buildRecordSetRest.getId());
         Preconditions.checkArgument(buildRecordSet != null,

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/EnvironmentProvider.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/EnvironmentProvider.java
@@ -54,8 +54,9 @@ public class EnvironmentProvider {
     }
 
     public void update(Integer id, EnvironmentRest environmentRest) {
-        Preconditions.checkArgument(environmentRest.getId() == null, "Id must be null");
         Preconditions.checkArgument(id != null, "Id must not be null");
+        Preconditions.checkArgument(environmentRest.getId() == null || environmentRest.getId().equals(id),
+                "Entity id does not match the id to update");
         environmentRest.setId(id);
         Environment license = environmentRepository.findOne(environmentRest.getId());
         Preconditions.checkArgument(license != null, "Couldn't find environment with id " + environmentRest.getId());

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/LicenseProvider.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/LicenseProvider.java
@@ -54,8 +54,9 @@ public class LicenseProvider {
     }
 
     public void update(Integer id, LicenseRest licenseRest) {
-        Preconditions.checkArgument(licenseRest.getId() == null, "Id must be null");
         Preconditions.checkArgument(id != null, "Id must not be null");
+        Preconditions.checkArgument(licenseRest.getId() == null || licenseRest.getId().equals(id),
+                "Entity id does not match the id to update");
         licenseRest.setId(id);
         License license = licenseRepository.findOne(licenseRest.getId());
         Preconditions.checkArgument(license != null, "Couldn't find license with id " + licenseRest.getId());

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/ProductProvider.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/ProductProvider.java
@@ -55,8 +55,9 @@ public class ProductProvider {
     }
 
     public Integer update(Integer id, ProductRest productRest) {
-        Preconditions.checkArgument(productRest.getId() == null, "Id must be null");
         Preconditions.checkArgument(id != null, "Id must not be null");
+        Preconditions.checkArgument(productRest.getId() == null || productRest.getId().equals(id),
+                "Entity id does not match the id to update");
         productRest.setId(id);
         Product product = productRepository.findOne(productRest.getId());
         Preconditions.checkArgument(product != null, "Couldn't find product with id " + productRest.getId());

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/ProductVersionProvider.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/ProductVersionProvider.java
@@ -71,8 +71,9 @@ public class ProductVersionProvider {
     }
 
     public void update(Integer id, Integer productId, ProductVersionRest productVersionRest) {
-        Preconditions.checkArgument(productVersionRest.getId() == null, "Id must be null");
         Preconditions.checkArgument(id != null, "Id must not be null");
+        Preconditions.checkArgument(productVersionRest.getId() == null || productVersionRest.getId().equals(id),
+                "Entity id does not match the id to update");
         productVersionRest.setId(id);
         Product product = productRepository.findOne(productId);
         ProductVersion productVersion = productVersionRepository.findOne(productVersionRest.getId());

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/ProjectProvider.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/ProjectProvider.java
@@ -59,8 +59,9 @@ public class ProjectProvider {
     }
 
     public Integer update(Integer id, ProjectRest projectRest) {
-        Preconditions.checkArgument(projectRest.getId() == null, "Id must be null");
         Preconditions.checkArgument(id != null, "Id must not be null");
+        Preconditions.checkArgument(projectRest.getId() == null || projectRest.getId().equals(id),
+                "Entity id does not match the id to update");
         projectRest.setId(id);
         Project project = projectRepository.findOne(projectRest.getId());
         Preconditions.checkArgument(project != null, "Couldn't find project with id " + projectRest.getId());

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/UserProvider.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/provider/UserProvider.java
@@ -1,16 +1,20 @@
 package org.jboss.pnc.rest.provider;
 
 import com.google.common.base.Preconditions;
+
 import org.jboss.pnc.datastore.limits.RSQLPageLimitAndSortingProducer;
 import org.jboss.pnc.datastore.predicates.RSQLPredicate;
 import org.jboss.pnc.datastore.predicates.RSQLPredicateProducer;
 import org.jboss.pnc.datastore.repositories.UserRepository;
+import org.jboss.pnc.model.Project;
 import org.jboss.pnc.model.User;
+import org.jboss.pnc.rest.restmodel.ProjectRest;
 import org.jboss.pnc.rest.restmodel.UserRest;
 import org.springframework.data.domain.Pageable;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
+
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -51,6 +55,17 @@ public class UserProvider {
         Preconditions.checkArgument(userRest.getId() == null, "Id must be null");
         User user = userRest.toUser();
         user = userRepository.save(user);
+        return user.getId();
+    }
+
+    public Integer update(Integer id, UserRest userRest) {
+        Preconditions.checkArgument(id != null, "Id must not be null");
+        Preconditions.checkArgument(userRest.getId() == null || userRest.getId().equals(id),
+                "Entity id does not match the id to update");
+        userRest.setId(id);
+        User user = userRepository.findOne(id);
+        Preconditions.checkArgument(user != null, "Couldn't find user with id " + id);
+        user = userRepository.save(userRest.toUser());
         return user.getId();
     }
 


### PR DESCRIPTION
The id in the entity can be non-null as long as it matches the id provided
in the URL.
Also add update operation for User entity.