### PR TITLE
fixes

### DIFF
--- a/docker-environment-driver/src/main/java/org/jboss/pnc/environment/docker/DockerEnvironmentDriver.java
+++ b/docker-environment-driver/src/main/java/org/jboss/pnc/environment/docker/DockerEnvironmentDriver.java
@@ -219,13 +219,17 @@ public class DockerEnvironmentDriver implements EnvironmentDriver {
     private void destroyContainer(String containerId, boolean isRunning) throws EnvironmentDriverException {
         logger.info("Trying to destroy Docker container with ID: " + containerId);
         try {
-            if (isRunning)
+            if (isRunning) {
                 dockerClient.stopContainer(containerId);
-            dockerClient.removeContainer(containerId);
+            }
         } catch (RuntimeException e) {
             throw new EnvironmentDriverException("Cannot destroy environment.", e);
         }
-        logger.info("Docker container with ID: " + containerId + " was destroyed.");
+        finally{
+            dockerClient.removeContainer(containerId);
+            logger.info("Docker container with ID: " + containerId + " was destroyed.");    
+        }
+        
     }
 
     /**

--- a/docker-environment-driver/src/main/resources/isolatedDockerConfiguration/Dockerfile
+++ b/docker-environment-driver/src/main/resources/isolatedDockerConfiguration/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora
+FROM fedora:21
 MAINTAINER Marek Novotny <mnovotny@redhat.com>
 
 # install java and zip


### PR DESCRIPTION
NCL-642 - using fedora:21 instead of latest in docker image
NCL 737 - fixing destroying of running/stopped docker container 