### PR TITLE
Redirect surefire and failsafe test output to a file by default.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1070,6 +1070,7 @@
               <value>org.jboss.pnc.test.listener.PrintTestNameListener</value>
             </property>
           </properties>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
         </configuration>
         <executions>
           <execution>
@@ -1113,6 +1114,7 @@
             </property>
           </properties>
           <skip>${failsafe.test.skip}</skip>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
This makes the CLI output easier to read, and organizes test output by test.