### PR TITLE
rework of NCL-732 - use config props in auth module

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -67,6 +67,11 @@
     
     <dependency>
       <groupId>org.jboss.pnc</groupId>
+      <artifactId>common</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
       <artifactId>test-common</artifactId>
       <scope>test</scope>
     </dependency>

--- a/auth/src/main/java/org/jboss/pnc/auth/ExternalAuthFacade.java
+++ b/auth/src/main/java/org/jboss/pnc/auth/ExternalAuthFacade.java
@@ -9,6 +9,8 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.jboss.logging.Logger;
+import org.jboss.pnc.common.Configuration;
+import org.jboss.pnc.common.json.moduleconfig.AuthenticationModuleConfig;
 import org.keycloak.adapters.HttpClientBuilder;
 
 /**
@@ -23,7 +25,46 @@ public class ExternalAuthFacade {
     private InputStream keycloakConfiguration;
     private String baseRestURL;
     
-    public ExternalAuthFacade(String username, String password, InputStream keycloakConfiguration, String baseRestURL) throws Exception{
+    Configuration configuration = new Configuration();
+    
+    /**
+     * Load configuration from config json file
+     * 
+     * @param keycloakConfiguration
+     * @throws Exception
+     */
+    public ExternalAuthFacade(InputStream keycloakConfiguration) throws Exception{
+        
+        AuthenticationModuleConfig config = configuration.getModuleConfig(AuthenticationModuleConfig.class);
+        this.pnc_ext_oauth_username = config.getUsername();
+        this.pnc_ext_oauth_password = config.getPassword();
+        this.baseRestURL = config.getBaseAuthUrl(); 
+
+        if(this.pnc_ext_oauth_password == null || 
+            this.pnc_ext_oauth_username == null ||
+            this.pnc_ext_oauth_password.equals("") ||
+            this.pnc_ext_oauth_username.equals("") || 
+            this.baseRestURL == null || 
+            this.baseRestURL.equals("")) {
+                throw new Exception("Wrong keycloak configuration");
+        }
+        // check keycloakConfig
+        this.keycloakConfiguration = keycloakConfiguration;
+        if(this.keycloakConfiguration == null) {
+            throw new Exception("Keycloak configuration were not provided");
+        }
+    }
+    
+    /**
+     * Provide configuration properties directly 
+     * 
+     * @param username
+     * @param password
+     * @param keycloakConfiguration
+     * @param baseRestURL
+     * @throws Exception
+     */
+    ExternalAuthFacade(String username, String password, InputStream keycloakConfiguration, String baseRestURL) throws Exception{
         // get credentials as parameter
         this.pnc_ext_oauth_username = username;
         this.pnc_ext_oauth_password = password;
@@ -32,22 +73,10 @@ public class ExternalAuthFacade {
             this.pnc_ext_oauth_username == null ||
             this.pnc_ext_oauth_password.equals("") ||
             this.pnc_ext_oauth_username.equals("")) {
-            
-            // try to get credentials from System env 
-            this.pnc_ext_oauth_username = System.getenv("PNC_EXT_OAUTH_USERNAME");
-            this.pnc_ext_oauth_password = System.getenv("PNC_EXT_OAUTH_PASSWORD");
-            
-            if(this.pnc_ext_oauth_password == null || 
-                    this.pnc_ext_oauth_username == null ||
-                    this.pnc_ext_oauth_password.equals("") ||
-                    this.pnc_ext_oauth_username.equals("")) {
-                     throw new Exception("Credentials were not provided! + \n"
-                             + "Either, provide those passing ExternalAuthFacade(String username, String password,...) + \n"
-                             + "or provide those as System env props + \n +"
-                             + "like export PNC_EXT_OAUTH_USERNAME=your_username + \n +"
-                             + "export PNC_EXT_OAUTH_PASSWORD=your_password");
-                 }
+            throw new Exception("Credentials were not provided! + \n"
+                     + "Provide those passing ExternalAuthFacade(String username, String password,...) + \n");
         }
+        
         // check keycloakConfig
         this.keycloakConfiguration = keycloakConfiguration;
         if(this.keycloakConfiguration == null) {
@@ -56,16 +85,11 @@ public class ExternalAuthFacade {
         //check base REST URL 
         this.baseRestURL = baseRestURL;
         if(this.baseRestURL == null || this.baseRestURL.equals("")) {
-            this.baseRestURL = System.getenv("PNC_EXT_REST_BASE_URL");
-            if(this.baseRestURL == null || this.baseRestURL.equals("")) { 
-                throw new Exception("Basic URL of REST endpoints were not provided + \n" 
-                            + "Either, provide this one passing ExternalAuthFacade(...,String baseRestURL) + \n"
-                            + "or provide those as System env property + \n +"
-                            + "like export PNC_EXT_REST_BASE_URL=basic_rest_endpoint + \n +"
-                            + "Example: export PNC_EXT_REST_BASE_URL=http://localhost:8080/pnc-rest/rest");
-            }
+            throw new Exception("Basic URL of REST endpoints were not provided + \n" 
+                        + "Provide this one passing ExternalAuthFacade(...,String baseRestURL) + \n");
         }
     }
+    
 
     /**
      * @param endpoint - must be in the form of /customer or /product/id

--- a/common/src/main/java/org/jboss/pnc/common/json/AbstractModuleConfig.java
+++ b/common/src/main/java/org/jboss/pnc/common/json/AbstractModuleConfig.java
@@ -1,5 +1,6 @@
 package org.jboss.pnc.common.json;
 
+import org.jboss.pnc.common.json.moduleconfig.AuthenticationModuleConfig;
 import org.jboss.pnc.common.json.moduleconfig.DockerEnvironmentDriverModuleConfig;
 import org.jboss.pnc.common.json.moduleconfig.JenkinsBuildDriverModuleConfig;
 import org.jboss.pnc.common.json.moduleconfig.MavenRepoDriverModuleConfig;
@@ -14,5 +15,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
     @Type(value = JenkinsBuildDriverModuleConfig.class, name = "jenkins-build-driver"),
     @Type(value = MavenRepoDriverModuleConfig.class, name = "maven-repo-driver"),
     @Type(value = DockerEnvironmentDriverModuleConfig.class, name = "docker-environment-driver"),
+    @Type(value = AuthenticationModuleConfig.class, name = "authentication-config"),
     })
 public abstract class AbstractModuleConfig {}

--- a/common/src/main/java/org/jboss/pnc/common/json/ConfigurationJSONParser.java
+++ b/common/src/main/java/org/jboss/pnc/common/json/ConfigurationJSONParser.java
@@ -31,6 +31,7 @@ public class ConfigurationJSONParser {
             }
             throw new ConfigurationParseException("Config could not be parsed");
         } catch (Exception e) {
+            e.printStackTrace();
             throw new ConfigurationParseException("Config could not be parsed", e);
         }
     }

--- a/common/src/main/java/org/jboss/pnc/common/json/ConfigurationJSONParser.java
+++ b/common/src/main/java/org/jboss/pnc/common/json/ConfigurationJSONParser.java
@@ -1,5 +1,7 @@
 package org.jboss.pnc.common.json;
 
+import org.jboss.logging.Logger;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -9,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 
 public class ConfigurationJSONParser {
+    public final static Logger log = Logger.getLogger(ConfigurationJSONParser.class);
 
     /**
      * Loads JSON configuration to the module configuration object
@@ -31,7 +34,7 @@ public class ConfigurationJSONParser {
             }
             throw new ConfigurationParseException("Config could not be parsed");
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error(e.getMessage());
             throw new ConfigurationParseException("Config could not be parsed", e);
         }
     }

--- a/common/src/main/java/org/jboss/pnc/common/json/moduleconfig/AuthenticationModuleConfig.java
+++ b/common/src/main/java/org/jboss/pnc/common/json/moduleconfig/AuthenticationModuleConfig.java
@@ -1,0 +1,47 @@
+package org.jboss.pnc.common.json.moduleconfig;
+
+import org.jboss.pnc.common.json.AbstractModuleConfig;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class AuthenticationModuleConfig extends AbstractModuleConfig{
+    private String username;
+    private String password;
+    private String baseAuthUrl;
+
+    public AuthenticationModuleConfig(@JsonProperty("username") String username, 
+            @JsonProperty("password")String password, @JsonProperty("baseAuthUrl")String baseAuthUrl) {
+        super();
+        this.username = username;
+        this.password = password;
+        this.baseAuthUrl = baseAuthUrl;
+    }
+    
+    public String getUsername() {
+        return username;
+    }
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    public String getPassword() {
+        return password;
+    }
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getBaseAuthUrl() {
+        return baseAuthUrl;
+    }
+
+    public void setBaseAuthUrl(String baseAuthUrl) {
+        this.baseAuthUrl = baseAuthUrl;
+    }
+    
+    @Override
+    public String toString() {
+        return "AuthenticationModuleConfig [username=HIDDEN, password=" + password + ", baseAuthUrl=" + baseAuthUrl +"]";
+    }
+    
+}

--- a/common/src/main/resources/pnc-config.json
+++ b/common/src/main/resources/pnc-config.json
@@ -17,6 +17,12 @@
             "inContainerUserPassword":"${env.PNC_DOCKER_CONT_PASSWORD}",
             "dockerImageId":"${env.PNC_DOCKER_IMAGE_ID}",
             "firewallAllowedDestinations":"${env.PNC_DOCKER_IMAGE_FIREWALL_ALLOWED}"
+          },
+          {
+            "@module-config":"authentication-config",
+            "username":"${env.PNC_EXT_OAUTH_USERNAME}",
+            "password":"${env.PNC_EXT_OAUTH_PASSWORD}",
+            "baseAuthUrl":"${env.PNC_EXT_REST_BASE_URL}"
           }
         ]
 }

--- a/integration-test/src/test/java/org/jboss/pnc/auth/ExternalAuthFacadeTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/auth/ExternalAuthFacadeTest.java
@@ -35,11 +35,7 @@ public class ExternalAuthFacadeTest {
                 log.info(">>> testProductEndpoint()");            
                 InputStream is = this.getClass().getResourceAsStream("/keycloak.json");
                 log.info("is is: " + is);
-                ExternalAuthFacade externalAuthFacade = 
-                        new ExternalAuthFacade(System.getenv("PNC_EXT_OAUTH_USERNAME"), 
-                                System.getenv("PNC_EXT_OAUTH_PASSWORD"), 
-                                is, 
-                                System.getenv("PNC_EXT_REST_BASE_URL"));
+                ExternalAuthFacade externalAuthFacade = new ExternalAuthFacade(is);
                 assertNotNull(externalAuthFacade);
                 InputStream restInput = externalAuthFacade.restEndpoint("/product");
                 assertNotNull(restInput);
@@ -58,11 +54,7 @@ public class ExternalAuthFacadeTest {
             if(AuthResource.authEnabled()) {
                 log.info(">>> testConfigEndpointUnauthorized()");            
                 InputStream is = this.getClass().getResourceAsStream("/keycloak.json");
-                ExternalAuthFacade externalAuthFacade = 
-                        new ExternalAuthFacade(System.getenv("PNC_EXT_OAUTH_USERNAME"), 
-                                System.getenv("PNC_EXT_OAUTH_PASSWORD"), 
-                                is, 
-                                System.getenv("PNC_EXT_REST_BASE_URL"));
+                ExternalAuthFacade externalAuthFacade = new ExternalAuthFacade(is);
                 InputStream restInput = externalAuthFacade.restEndpoint("/configuration");
                 ExternalAuthFacade.print(restInput);
                 assertNotNull(externalAuthFacade);
@@ -83,9 +75,7 @@ public class ExternalAuthFacadeTest {
             if(AuthResource.authEnabled()) {
                 InputStream is = this.getClass().getResourceAsStream("/keycloak.json");
                 ExternalAuthFacade externalAuthFacade = 
-                        new ExternalAuthFacade("mr.wrong","mr.wrong", 
-                                is, 
-                                System.getenv("PNC_EXT_REST_BASE_URL"));
+                        new ExternalAuthFacade("mr.wrong","mr.wrong",is,"http://localhost:8080/pnc-rest/rest");
                 assertNotNull(externalAuthFacade);
                 InputStream restInput = externalAuthFacade.restEndpoint("/product");
                 assertNotNull(restInput);

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationRestTest.java
@@ -1,14 +1,22 @@
 package org.jboss.pnc.integration;
 
-import com.jayway.restassured.http.ContentType;
-import com.jayway.restassured.response.Response;
+import static com.jayway.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jboss.pnc.integration.env.IntegrationTestEnv.getHttpPort;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.pnc.auth.AuthenticationProvider;
 import org.jboss.pnc.auth.ExternalAuthentication;
-import org.jboss.pnc.common.util.IoUtils;
+import org.jboss.pnc.common.Configuration;
+import org.jboss.pnc.common.json.ConfigurationParseException;
+import org.jboss.pnc.common.json.moduleconfig.AuthenticationModuleConfig;
 import org.jboss.pnc.integration.Utils.AuthResource;
 import org.jboss.pnc.integration.assertions.ResponseAssertion;
 import org.jboss.pnc.integration.deployments.Deployments;
@@ -28,14 +36,8 @@ import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.invoke.MethodHandles;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static com.jayway.restassured.RestAssured.given;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.jboss.pnc.integration.env.IntegrationTestEnv.getHttpPort;
+import com.jayway.restassured.http.ContentType;
+import com.jayway.restassured.response.Response;
 
 @RunWith(Arquillian.class)
 @Category(ContainerTest.class)
@@ -81,11 +83,13 @@ public class BuildConfigurationRestTest {
     }
 
     @BeforeClass
-    public static void setupAuth() throws IOException {
+    public static void setupAuth() throws IOException, ConfigurationParseException {
         if(AuthResource.authEnabled()) {
+            Configuration configuration = new Configuration();
+            AuthenticationModuleConfig config = configuration.getModuleConfig(AuthenticationModuleConfig.class);
             InputStream is = BuildRecordRestTest.class.getResourceAsStream("/keycloak.json");
             ExternalAuthentication ea = new ExternalAuthentication(is);
-            authProvider = ea.authenticate(System.getenv("PNC_EXT_OAUTH_USERNAME"), System.getenv("PNC_EXT_OAUTH_PASSWORD"));
+            authProvider = ea.authenticate(config.getUsername(), config.getPassword());
             access_token = authProvider.getTokenString();
         }
     }

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationSetRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationSetRestTest.java
@@ -9,6 +9,9 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.pnc.auth.AuthenticationProvider;
 import org.jboss.pnc.auth.ExternalAuthentication;
+import org.jboss.pnc.common.Configuration;
+import org.jboss.pnc.common.json.ConfigurationParseException;
+import org.jboss.pnc.common.json.moduleconfig.AuthenticationModuleConfig;
 import org.jboss.pnc.integration.Utils.AuthResource;
 import org.jboss.pnc.integration.assertions.ResponseAssertion;
 import org.jboss.pnc.integration.deployments.Deployments;
@@ -34,6 +37,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
+
+import javax.inject.Inject;
 
 import static com.jayway.restassured.RestAssured.given;
 import static org.jboss.pnc.integration.env.IntegrationTestEnv.getHttpPort;
@@ -85,11 +90,13 @@ public class BuildConfigurationSetRestTest {
     }
 
     @BeforeClass
-    public static void setupAuth() throws IOException {
+    public static void setupAuth() throws IOException, ConfigurationParseException {
         if(AuthResource.authEnabled()) {
+            Configuration configuration = new Configuration();
+            AuthenticationModuleConfig config = configuration.getModuleConfig(AuthenticationModuleConfig.class);
             InputStream is = BuildRecordRestTest.class.getResourceAsStream("/keycloak.json");
             ExternalAuthentication ea = new ExternalAuthentication(is);
-            authProvider = ea.authenticate(System.getenv("PNC_EXT_OAUTH_USERNAME"), System.getenv("PNC_EXT_OAUTH_PASSWORD"));
+            authProvider = ea.authenticate(config.getUsername(), config.getPassword());
             access_token = authProvider.getTokenString();
         }
     }

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildRecordRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildRecordRestTest.java
@@ -8,6 +8,9 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.pnc.auth.AuthenticationProvider;
 import org.jboss.pnc.auth.ExternalAuthentication;
+import org.jboss.pnc.common.Configuration;
+import org.jboss.pnc.common.json.ConfigurationParseException;
+import org.jboss.pnc.common.json.moduleconfig.AuthenticationModuleConfig;
 import org.jboss.pnc.integration.Utils.AuthResource;
 import org.jboss.pnc.integration.assertions.ResponseAssertion;
 import org.jboss.pnc.integration.deployments.Deployments;
@@ -30,6 +33,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
+
+import javax.inject.Inject;
 
 import static com.jayway.restassured.RestAssured.given;
 import static org.jboss.pnc.integration.env.IntegrationTestEnv.getHttpPort;
@@ -73,11 +78,13 @@ public class BuildRecordRestTest {
     }
 
     @BeforeClass
-    public static void setupAuth() throws IOException {
+    public static void setupAuth() throws IOException, ConfigurationParseException {
         if(AuthResource.authEnabled()) {
+            Configuration configuration = new Configuration();
+            AuthenticationModuleConfig config = configuration.getModuleConfig(AuthenticationModuleConfig.class);
             InputStream is = BuildRecordRestTest.class.getResourceAsStream("/keycloak.json");
             ExternalAuthentication ea = new ExternalAuthentication(is);
-            authProvider = ea.authenticate(System.getenv("PNC_EXT_OAUTH_USERNAME"), System.getenv("PNC_EXT_OAUTH_PASSWORD"));
+            authProvider = ea.authenticate(config.getUsername(), config.getPassword());
             access_token = authProvider.getTokenString();
         }
     }

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildRecordSetRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildRecordSetRestTest.java
@@ -8,6 +8,9 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.pnc.auth.AuthenticationProvider;
 import org.jboss.pnc.auth.ExternalAuthentication;
+import org.jboss.pnc.common.Configuration;
+import org.jboss.pnc.common.json.ConfigurationParseException;
+import org.jboss.pnc.common.json.moduleconfig.AuthenticationModuleConfig;
 import org.jboss.pnc.integration.Utils.AuthResource;
 import org.jboss.pnc.integration.assertions.ResponseAssertion;
 import org.jboss.pnc.integration.deployments.Deployments;
@@ -32,6 +35,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
+
+import javax.inject.Inject;
 
 import static com.jayway.restassured.RestAssured.given;
 import static org.jboss.pnc.integration.env.IntegrationTestEnv.getHttpPort;
@@ -77,11 +82,13 @@ public class BuildRecordSetRestTest {
     }
 
     @BeforeClass
-    public static void setupAuth() throws IOException {
+    public static void setupAuth() throws IOException, ConfigurationParseException {
         if(AuthResource.authEnabled()) {
+            Configuration configuration = new Configuration();
+            AuthenticationModuleConfig config = configuration.getModuleConfig(AuthenticationModuleConfig.class);
             InputStream is = BuildRecordRestTest.class.getResourceAsStream("/keycloak.json");
             ExternalAuthentication ea = new ExternalAuthentication(is);
-            authProvider = ea.authenticate(System.getenv("PNC_EXT_OAUTH_USERNAME"), System.getenv("PNC_EXT_OAUTH_PASSWORD"));
+            authProvider = ea.authenticate(config.getUsername(), config.getPassword());
             access_token = authProvider.getTokenString();
         }
     }

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildTest.java
@@ -4,6 +4,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.pnc.auth.AuthenticationProvider;
 import org.jboss.pnc.auth.ExternalAuthentication;
+import org.jboss.pnc.common.Configuration;
+import org.jboss.pnc.common.json.ConfigurationParseException;
+import org.jboss.pnc.common.json.moduleconfig.AuthenticationModuleConfig;
 import org.jboss.pnc.integration.Utils.AuthResource;
 import org.jboss.pnc.integration.deployments.Deployments;
 import org.jboss.pnc.test.category.ContainerTest;
@@ -21,6 +24,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
+
+import javax.inject.Inject;
 
 import static org.jboss.pnc.integration.env.IntegrationTestEnv.getHttpPort;
 import static com.jayway.restassured.RestAssured.given;
@@ -45,11 +50,13 @@ public class BuildTest {
     }
     
     @BeforeClass
-    public static void setupAuth() throws IOException {
+    public static void setupAuth() throws IOException, ConfigurationParseException {
         if(AuthResource.authEnabled()) {
+            Configuration configuration = new Configuration();
+            AuthenticationModuleConfig config = configuration.getModuleConfig(AuthenticationModuleConfig.class);
             InputStream is = BuildRecordRestTest.class.getResourceAsStream("/keycloak.json");
             ExternalAuthentication ea = new ExternalAuthentication(is);
-            authProvider = ea.authenticate(System.getenv("PNC_EXT_OAUTH_USERNAME"), System.getenv("PNC_EXT_OAUTH_PASSWORD"));
+            authProvider = ea.authenticate(config.getUsername(), config.getPassword());
             access_token = authProvider.getTokenString();
         }
     }

--- a/integration-test/src/test/java/org/jboss/pnc/integration/ProductMilestoneRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/ProductMilestoneRestTest.java
@@ -9,6 +9,9 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.pnc.auth.AuthenticationProvider;
 import org.jboss.pnc.auth.ExternalAuthentication;
+import org.jboss.pnc.common.Configuration;
+import org.jboss.pnc.common.json.ConfigurationParseException;
+import org.jboss.pnc.common.json.moduleconfig.AuthenticationModuleConfig;
 import org.jboss.pnc.common.util.IoUtils;
 import org.jboss.pnc.integration.matchers.JsonMatcher;
 import org.jboss.pnc.integration.template.JsonTemplateBuilder;
@@ -27,6 +30,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
+
+import javax.inject.Inject;
 
 import static com.jayway.restassured.RestAssured.given;
 import static org.jboss.pnc.integration.env.IntegrationTestEnv.getHttpPort;
@@ -59,11 +64,13 @@ public class ProductMilestoneRestTest {
     }
 
     @BeforeClass
-    public static void setupAuth() throws IOException {
+    public static void setupAuth() throws IOException, ConfigurationParseException {
         if(AuthResource.authEnabled()) {
+            Configuration configuration = new Configuration();
+            AuthenticationModuleConfig config = configuration.getModuleConfig(AuthenticationModuleConfig.class);
             InputStream is = BuildRecordRestTest.class.getResourceAsStream("/keycloak.json");
             ExternalAuthentication ea = new ExternalAuthentication(is);
-            authProvider = ea.authenticate(System.getenv("PNC_EXT_OAUTH_USERNAME"), System.getenv("PNC_EXT_OAUTH_PASSWORD"));
+            authProvider = ea.authenticate(config.getUsername(), config.getPassword());
             access_token = authProvider.getTokenString();
         }
     }

--- a/integration-test/src/test/java/org/jboss/pnc/integration/ProductReleaseRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/ProductReleaseRestTest.java
@@ -7,12 +7,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 
+import javax.inject.Inject;
+
 import org.assertj.core.api.Assertions;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.pnc.auth.AuthenticationProvider;
 import org.jboss.pnc.auth.ExternalAuthentication;
+import org.jboss.pnc.common.Configuration;
+import org.jboss.pnc.common.json.ConfigurationParseException;
+import org.jboss.pnc.common.json.moduleconfig.AuthenticationModuleConfig;
 import org.jboss.pnc.common.util.IoUtils;
 import org.jboss.pnc.integration.Utils.AuthResource;
 import org.jboss.pnc.integration.deployments.Deployments;
@@ -60,11 +65,13 @@ public class ProductReleaseRestTest {
     }
 
     @BeforeClass
-    public static void setupAuth() throws IOException {
+    public static void setupAuth() throws IOException, ConfigurationParseException {
         if(AuthResource.authEnabled()) {
+            Configuration configuration = new Configuration();
+            AuthenticationModuleConfig config = configuration.getModuleConfig(AuthenticationModuleConfig.class);
             InputStream is = BuildRecordRestTest.class.getResourceAsStream("/keycloak.json");
             ExternalAuthentication ea = new ExternalAuthentication(is);
-            authProvider = ea.authenticate(System.getenv("PNC_EXT_OAUTH_USERNAME"), System.getenv("PNC_EXT_OAUTH_PASSWORD"));
+            authProvider = ea.authenticate(config.getUsername(), config.getPassword());
             access_token = authProvider.getTokenString();
         }
     }

--- a/integration-test/src/test/java/org/jboss/pnc/integration/ProductVersionRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/ProductVersionRestTest.java
@@ -9,7 +9,11 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.pnc.auth.AuthenticationProvider;
 import org.jboss.pnc.auth.ExternalAuthentication;
+import org.jboss.pnc.common.Configuration;
+import org.jboss.pnc.common.json.ConfigurationParseException;
+import org.jboss.pnc.common.json.moduleconfig.AuthenticationModuleConfig;
 import org.jboss.pnc.common.util.IoUtils;
+import org.jboss.pnc.integration.BuildRecordRestTest;
 import org.jboss.pnc.integration.matchers.JsonMatcher;
 import org.jboss.pnc.integration.Utils.AuthResource;
 import org.jboss.pnc.integration.deployments.Deployments;
@@ -26,6 +30,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
+
+import javax.inject.Inject;
 
 import static com.jayway.restassured.RestAssured.given;
 import static org.jboss.pnc.integration.env.IntegrationTestEnv.getHttpPort;
@@ -56,11 +62,13 @@ public class ProductVersionRestTest {
     }
 
     @BeforeClass
-    public static void setupAuth() throws IOException {
+    public static void setupAuth() throws IOException, ConfigurationParseException {
         if(AuthResource.authEnabled()) {
+            Configuration configuration = new Configuration();
+            AuthenticationModuleConfig config = configuration.getModuleConfig(AuthenticationModuleConfig.class);
             InputStream is = BuildRecordRestTest.class.getResourceAsStream("/keycloak.json");
             ExternalAuthentication ea = new ExternalAuthentication(is);
-            authProvider = ea.authenticate(System.getenv("PNC_EXT_OAUTH_USERNAME"), System.getenv("PNC_EXT_OAUTH_PASSWORD"));
+            authProvider = ea.authenticate(config.getUsername(), config.getPassword());
             access_token = authProvider.getTokenString();
         }
     }

--- a/integration-test/src/test/java/org/jboss/pnc/integration/RestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/RestTest.java
@@ -7,12 +7,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 
+import javax.inject.Inject;
+
 import org.assertj.core.api.Assertions;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.pnc.auth.AuthenticationProvider;
 import org.jboss.pnc.auth.ExternalAuthentication;
+import org.jboss.pnc.common.Configuration;
+import org.jboss.pnc.common.json.ConfigurationParseException;
+import org.jboss.pnc.common.json.moduleconfig.AuthenticationModuleConfig;
 import org.jboss.pnc.common.util.IoUtils;
 import org.jboss.pnc.integration.Utils.AuthResource;
 import org.jboss.pnc.integration.deployments.Deployments;
@@ -59,11 +64,13 @@ public class RestTest {
     }
     
     @BeforeClass
-    public static void setupAuth() throws IOException {
+    public static void setupAuth() throws IOException, ConfigurationParseException {
         if(AuthResource.authEnabled()) {
+            Configuration configuration = new Configuration();
+            AuthenticationModuleConfig config = configuration.getModuleConfig(AuthenticationModuleConfig.class);
             InputStream is = BuildRecordRestTest.class.getResourceAsStream("/keycloak.json");
             ExternalAuthentication ea = new ExternalAuthentication(is);
-            authProvider = ea.authenticate(System.getenv("PNC_EXT_OAUTH_USERNAME"), System.getenv("PNC_EXT_OAUTH_PASSWORD"));
+            authProvider = ea.authenticate(config.getUsername(), config.getPassword());
             access_token = authProvider.getTokenString();
         }
     }

--- a/integration-test/src/test/resources/pnc-config.json
+++ b/integration-test/src/test/resources/pnc-config.json
@@ -1,0 +1,11 @@
+{
+"@class":"ModuleConfigJson","name":"pnc-config",
+        "configs":[
+          {
+            "@module-config":"authentication-config",
+            "username":"${env.PNC_EXT_OAUTH_USERNAME}",
+            "password":"${env.PNC_EXT_OAUTH_PASSWORD}",
+            "baseAuthUrl":"${env.PNC_EXT_REST_BASE_URL}"
+          }
+        ]
+}


### PR DESCRIPTION
Conflicts:
	integration-test/src/test/java/org/jboss/pnc/auth/ExternalAuthFacadeTest.java

rework propertis loading from json instead of System.getEnv()

NCL-732