### PR TITLE
[NCL-751] Update rest URLs to match pluralization standards

### DIFF
--- a/auth/src/main/java/org/jboss/pnc/auth/ExternalAuthFacade.java
+++ b/auth/src/main/java/org/jboss/pnc/auth/ExternalAuthFacade.java
@@ -92,7 +92,7 @@ public class ExternalAuthFacade {
     
 
     /**
-     * @param endpoint Must be in the form of /customer or /product/id
+     * @param endpoint Must be in the form of /customers or /products/id
      * @return InputStream for the endpoint
      * @throws Exception if an error occurs
      */

--- a/integration-test/src/test/java/org/jboss/pnc/auth/ExternalAuthFacadeTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/auth/ExternalAuthFacadeTest.java
@@ -16,8 +16,8 @@ import org.junit.Test;
  * Test for External REST endpoints AUTH*
  * Special conditions for test to pass:
  * 1. Valid user able to Authenticate for Keycloak
- * 2. User in role authorized for /product endpoint
- * 3. User in role not authorized for /configuration endpoint
+ * 2. User in role authorized for /products endpoint
+ * 3. User in role not authorized for /build-configurations endpoint
  * 
  *  Note: for internal development use user "testone/****" which
  *  is defined to fulfill all above conditions 
@@ -37,7 +37,7 @@ public class ExternalAuthFacadeTest {
                 log.info("is is: " + is);
                 ExternalAuthFacade externalAuthFacade = new ExternalAuthFacade(is);
                 assertNotNull(externalAuthFacade);
-                InputStream restInput = externalAuthFacade.restEndpoint("/product");
+                InputStream restInput = externalAuthFacade.restEndpoint("/products");
                 assertNotNull(restInput);
                 ExternalAuthFacade.print(restInput);
                 log.info("<<< testProductEndpoint()");
@@ -55,7 +55,7 @@ public class ExternalAuthFacadeTest {
                 log.info(">>> testConfigEndpointUnauthorized()");            
                 InputStream is = this.getClass().getResourceAsStream("/keycloak.json");
                 ExternalAuthFacade externalAuthFacade = new ExternalAuthFacade(is);
-                InputStream restInput = externalAuthFacade.restEndpoint("/configuration");
+                InputStream restInput = externalAuthFacade.restEndpoint("/build-configurations");
                 ExternalAuthFacade.print(restInput);
                 assertNotNull(externalAuthFacade);
             }
@@ -77,7 +77,7 @@ public class ExternalAuthFacadeTest {
                 ExternalAuthFacade externalAuthFacade = 
                         new ExternalAuthFacade("mr.wrong","mr.wrong",is,"http://localhost:8080/pnc-rest/rest");
                 assertNotNull(externalAuthFacade);
-                InputStream restInput = externalAuthFacade.restEndpoint("/product");
+                InputStream restInput = externalAuthFacade.restEndpoint("/products");
                 assertNotNull(restInput);
                 ExternalAuthFacade.print(restInput);
             }

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationRestTest.java
@@ -45,17 +45,17 @@ public class BuildConfigurationRestTest {
 
     public static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private static final String PRODUCT_REST_ENDPOINT = "/pnc-rest/rest/product/";
-    private static final String PRODUCT_VERSION_REST_ENDPOINT = "/pnc-rest/rest/product/%d/version";
-    private static final String PROJECT_REST_ENDPOINT = "/pnc-rest/rest/project/";
-    private static final String PROJECT_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/project/%d";
-    private static final String CONFIGURATION_REST_ENDPOINT = "/pnc-rest/rest/configuration/";
-    private static final String CONFIGURATION_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/configuration/%d";
-    private static final String CONFIGURATION_CLONE_REST_ENDPOINT = "/pnc-rest/rest/configuration/%d/clone";
-    private static final String ENVIRONMENT_REST_ENDPOINT = "/pnc-rest/rest/environment";
-    private static final String SPECIFIC_ENVIRONMENT_REST_ENDPOINT = "/pnc-rest/rest/environment/%d";
-    private static final String CONFIGURATION_SET_REST_ENDPOINT = "/pnc-rest/rest/configuration-set/";
-    private static final String CONFIGURATION_SET_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/configuration-set/%d";
+    private static final String PRODUCT_REST_ENDPOINT = "/pnc-rest/rest/products/";
+    private static final String PRODUCT_VERSION_REST_ENDPOINT = "/pnc-rest/rest/products/%d/product-versions";
+    private static final String PROJECT_REST_ENDPOINT = "/pnc-rest/rest/projects/";
+    private static final String PROJECT_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/projects/%d";
+    private static final String CONFIGURATION_REST_ENDPOINT = "/pnc-rest/rest/build-configurations/";
+    private static final String CONFIGURATION_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/build-configurations/%d";
+    private static final String CONFIGURATION_CLONE_REST_ENDPOINT = "/pnc-rest/rest/build-configurations/%d/clone";
+    private static final String ENVIRONMENT_REST_ENDPOINT = "/pnc-rest/rest/environments";
+    private static final String SPECIFIC_ENVIRONMENT_REST_ENDPOINT = "/pnc-rest/rest/environments/%d";
+    private static final String CONFIGURATION_SET_REST_ENDPOINT = "/pnc-rest/rest/build-configuration-sets/";
+    private static final String CONFIGURATION_SET_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/build-configuration-sets/%d";
 
     private static int productId;
     private static int projectId;
@@ -162,7 +162,7 @@ public class BuildConfigurationRestTest {
     @Test
     public void shouldUpdateBuildConfiguration() throws IOException {
         // given
-        final String updatedScmUrl = "https://github.com/project-ncl/pnc.git";
+        final String updatedScmUrl = "https://github.com/projects-ncl/pnc.git";
         final String updatedBuildScript = "mvn clean deploy -Dmaven.test.skip=true";
         final String updatedName = "pnc-1.0.1.ER1";
         final String updatedProjectId = String.valueOf(projectId);
@@ -230,7 +230,7 @@ public class BuildConfigurationRestTest {
                     .contentType(ContentType.JSON).port(getHttpPort()).when()
                 .get(String.format(CONFIGURATION_SPECIFIC_REST_ENDPOINT, clonedBuildConfigurationId));
 
-        ResponseAssertion.assertThat(response).hasStatus(201).hasLocationMatches(".*\\/pnc-rest\\/rest\\/configuration\\/\\d+");
+        ResponseAssertion.assertThat(response).hasStatus(201).hasLocationMatches(".*\\/pnc-rest\\/rest\\/build-configurations\\/\\d+");
 
         assertThat(originalBuildConfiguration.body().jsonPath().getString("creationTime")).isNotEqualTo(
                 clonedBuildConfiguration.body().jsonPath().getString("creationTime"));
@@ -254,7 +254,7 @@ public class BuildConfigurationRestTest {
     @Test
     public void shouldFailToCreateNewBuildConfiguration() throws IOException {
         // given
-        final String scmUrl = "https://github.com/project-ncl/pnc.git";
+        final String scmUrl = "https://github.com/projects-ncl/pnc.git";
         final String buildScript = "mvn clean deploy -Dmaven.test.skip=true";
         final String name = "Bad Request Example Config";
         final String id = String.valueOf(projectId);

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationSetRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationSetRestTest.java
@@ -49,14 +49,14 @@ public class BuildConfigurationSetRestTest {
 
     public static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private static final String PRODUCT_REST_ENDPOINT = "/pnc-rest/rest/product/";
-    private static final String PRODUCT_VERSION_REST_ENDPOINT = "/pnc-rest/rest/product/%d/version/";
-    private static final String BUILD_CONFIGURATION_REST_ENDPOINT = "/pnc-rest/rest/configuration/";
+    private static final String PRODUCT_REST_ENDPOINT = "/pnc-rest/rest/products/";
+    private static final String PRODUCT_VERSION_REST_ENDPOINT = "/pnc-rest/rest/products/%d/product-versions/";
+    private static final String BUILD_CONFIGURATION_REST_ENDPOINT = "/pnc-rest/rest/build-configurations/";
 
-    private static final String BUILD_CONFIGURATION_SET_REST_ENDPOINT = "/pnc-rest/rest/configuration-set/";
-    private static final String BUILD_CONFIGURATION_SET_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/configuration-set/%d";
-    private static final String BUILD_CONFIGURATION_SET_PRODUCT_VERSION_REST_ENDPOINT = "/pnc-rest/rest/product/%d/version/%d/configuration-set";
-    private static final String BUILD_CONFIGURATION_SET_CONFIGURATIONS_REST_ENDPOINT = "/pnc-rest/rest/configuration-set/%d/configuration";
+    private static final String BUILD_CONFIGURATION_SET_REST_ENDPOINT = "/pnc-rest/rest/build-configuration-sets/";
+    private static final String BUILD_CONFIGURATION_SET_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/build-configuration-sets/%d";
+    private static final String BUILD_CONFIGURATION_SET_PRODUCT_VERSION_REST_ENDPOINT = "/pnc-rest/rest/products/%d/product-versions/%d/build-configuration-sets";
+    private static final String BUILD_CONFIGURATION_SET_CONFIGURATIONS_REST_ENDPOINT = "/pnc-rest/rest/build-configuration-sets/%d/build-configurations";
 
     private static final String BUILD_CONFIGURATION_SET_NAME = "Rest Test Build Config Set 1";
     private static final String BUILD_CONFIGURATION_SET_NAME_UPDATED = "Rest Test Build Config Set 1 Updated";
@@ -143,7 +143,7 @@ public class BuildConfigurationSetRestTest {
                     .body(buildConfSetTemplate.fillTemplate()).contentType(ContentType.JSON)
                 .port(getHttpPort()).when().post(BUILD_CONFIGURATION_SET_REST_ENDPOINT);
 
-        ResponseAssertion.assertThat(response).hasStatus(201).hasLocationMatches(".*\\/pnc-rest\\/rest\\/configuration-set\\/\\d+");
+        ResponseAssertion.assertThat(response).hasStatus(201).hasLocationMatches(".*\\/pnc-rest\\/rest\\/build-configuration-sets\\/\\d+");
 
         String location = response.getHeader("Location");
         newBuildConfSetId = Integer.valueOf(location.substring(location.lastIndexOf("/") + 1));

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildRecordRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildRecordRestTest.java
@@ -34,8 +34,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 
-import javax.inject.Inject;
-
 import static com.jayway.restassured.RestAssured.given;
 import static org.jboss.pnc.integration.env.IntegrationTestEnv.getHttpPort;
 
@@ -45,12 +43,12 @@ public class BuildRecordRestTest {
 
     public static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private static final String BUILD_RECORD_REST_ENDPOINT = "/pnc-rest/rest/record/";
-    private static final String BUILD_RECORD_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/record/%d";
-    private static final String CONFIGURATION_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/configuration/%d";
-    private static final String BUILD_RECORD_NAME_REST_ENDPOINT = "/pnc-rest/rest/record?q=latestBuildConfiguration.name==%s";
-    private static final String BUILD_RECORD_PROJECT_REST_ENDPOINT = "/pnc-rest/rest/record/project/%d";
-    private static final String BUILD_RECORD_PROJECT_BR_NAME_REST_ENDPOINT = "/pnc-rest/rest/record/project/%d?q=latestBuildConfiguration.name==%s";
+    private static final String BUILD_RECORD_REST_ENDPOINT = "/pnc-rest/rest/build-records/";
+    private static final String BUILD_RECORD_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/build-records/%d";
+    private static final String CONFIGURATION_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/build-configurations/%d";
+    private static final String BUILD_RECORD_NAME_REST_ENDPOINT = "/pnc-rest/rest/build-records?q=latestBuildConfiguration.name==%s";
+    private static final String BUILD_RECORD_PROJECT_REST_ENDPOINT = "/pnc-rest/rest/build-records/projects/%d";
+    private static final String BUILD_RECORD_PROJECT_BR_NAME_REST_ENDPOINT = "/pnc-rest/rest/build-records/projects/%d?q=latestBuildConfiguration.name==%s";
 
     private static int buildRecordId;
     private static int configurationId;

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildRecordSetRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildRecordSetRestTest.java
@@ -47,13 +47,13 @@ public class BuildRecordSetRestTest {
 
     public static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private static final String PRODUCT_MILESTONE_REST_ENDPOINT = "/pnc-rest/rest/product-milestone/";
-    private static final String BUILD_RECORD_REST_ENDPOINT = "/pnc-rest/rest/record/";
+    private static final String PRODUCT_MILESTONE_REST_ENDPOINT = "/pnc-rest/rest/product-milestones/";
+    private static final String BUILD_RECORD_REST_ENDPOINT = "/pnc-rest/rest/build-records/";
 
-    private static final String BUILD_RECORD_SET_REST_ENDPOINT = "/pnc-rest/rest/recordset/";
-    private static final String BUILD_RECORD_SET_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/recordset/%d";
-    private static final String BUILD_RECORD_SET_PRODUCT_VERSION_REST_ENDPOINT = "/pnc-rest/rest/recordset/productversion/%d";
-    private static final String BUILD_RECORD_SET_BUILD_RECORD_REST_ENDPOINT = "/pnc-rest/rest/recordset/record/%d";
+    private static final String BUILD_RECORD_SET_REST_ENDPOINT = "/pnc-rest/rest/build-record-sets/";
+    private static final String BUILD_RECORD_SET_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/build-record-sets/%d";
+    private static final String BUILD_RECORD_SET_PRODUCT_VERSION_REST_ENDPOINT = "/pnc-rest/rest/build-record-sets/productversion/%d";
+    private static final String BUILD_RECORD_SET_BUILD_RECORD_REST_ENDPOINT = "/pnc-rest/rest/build-record-sets/build-records/%d";
 
     private static int productMilestoneId;
     private static String productMilestoneVersion;
@@ -131,7 +131,7 @@ public class BuildRecordSetRestTest {
                     .body(buildRecordSetTemplate.fillTemplate()).contentType(ContentType.JSON)
                 .port(getHttpPort()).when().post(BUILD_RECORD_SET_REST_ENDPOINT);
 
-        ResponseAssertion.assertThat(response).hasStatus(201).hasLocationMatches(".*\\/pnc-rest\\/rest\\/recordset\\/\\d+");
+        ResponseAssertion.assertThat(response).hasStatus(201).hasLocationMatches(".*\\/pnc-rest\\/rest\\/build-record-sets\\/\\d+");
 
         String location = response.getHeader("Location");
         newBuildRecordSetId = Integer.valueOf(location.substring(location.lastIndexOf("/") + 1));

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildTest.java
@@ -59,26 +59,26 @@ public class BuildTest {
 
     @Test
     public void shouldTriggerBuildAndFinishWithoutProblems() {
-        int configurationId = extractIdFromRest("/pnc-rest/rest/configuration");
+        int configurationId = extractIdFromRest("/pnc-rest/rest/build-configurations");
 
         given().header("Accept", "application/json").header("Authorization", "Bearer " + access_token)
                     
             .port(getHttpPort())
         .when()
-            .post(String.format("/pnc-rest/rest/configuration/%d/build", configurationId))
+            .post(String.format("/pnc-rest/rest/build-configurations/%d/build", configurationId))
         .then()
             .statusCode(200);
     }
 
     @Test
     public void shouldTriggerBuildSetAndFinishWithoutProblems() {
-        int configurationId = extractIdFromRest("/pnc-rest/rest/configuration-set");
+        int configurationId = extractIdFromRest("/pnc-rest/rest/build-configuration-sets");
 
         given().header("Accept", "application/json").header("Authorization", "Bearer " + access_token)
 
             .port(getHttpPort())
         .when()
-            .post(String.format("/pnc-rest/rest/configuration-set/%d/build", configurationId))
+            .post(String.format("/pnc-rest/rest/build-configuration-sets/%d/build", configurationId))
         .then()
             .statusCode(200);
     }

--- a/integration-test/src/test/java/org/jboss/pnc/integration/EnvironmentRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/EnvironmentRestTest.java
@@ -34,7 +34,7 @@ import static org.jboss.pnc.integration.env.IntegrationTestEnv.getHttpPort;
 @Category(ContainerTest.class)
 public class EnvironmentRestTest {
 
-    private static final String ENVIRONMENT_REST_ENDPOINT = "/pnc-rest/rest/environment/";
+    private static final String ENVIRONMENT_REST_ENDPOINT = "/pnc-rest/rest/environments/";
     private static final String ENVIRONMENT_REST_ENDPOINT_SPECIFIC = ENVIRONMENT_REST_ENDPOINT + "%d";
 
     public static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -66,7 +66,7 @@ public class EnvironmentRestTest {
         environmentId = ResponseUtils.getIdFromLocationHeader(response);
 
         //then
-        ResponseAssertion.assertThat(response).hasStatus(201).hasLocationMatches(".*\\/pnc-rest\\/rest\\/environment\\/\\d+");
+        ResponseAssertion.assertThat(response).hasStatus(201).hasLocationMatches(".*\\/pnc-rest\\/rest\\/environments\\/\\d+");
         assertThat(environmentId).isNotNull();
     }
 

--- a/integration-test/src/test/java/org/jboss/pnc/integration/LicenseRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/LicenseRestTest.java
@@ -32,7 +32,7 @@ import static org.jboss.pnc.integration.env.IntegrationTestEnv.getHttpPort;
 @Category(ContainerTest.class)
 public class LicenseRestTest {
 
-    private static final String LICENSE_REST_ENDPOINT = "/pnc-rest/rest/license/";
+    private static final String LICENSE_REST_ENDPOINT = "/pnc-rest/rest/licenses/";
     private static final String LICENSE_REST_ENDPOINT_SPECIFIC = LICENSE_REST_ENDPOINT + "%d";
 
     public static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -64,7 +64,7 @@ public class LicenseRestTest {
         licenseId = ResponseUtils.getIdFromLocationHeader(response);
 
         //then
-        ResponseAssertion.assertThat(response).hasStatus(201).hasLocationMatches(".*\\/pnc-rest\\/rest\\/license\\/\\d+");
+        ResponseAssertion.assertThat(response).hasStatus(201).hasLocationMatches(".*\\/pnc-rest\\/rest\\/licenses\\/\\d+");
         assertThat(licenseId).isNotNull();
     }
 

--- a/integration-test/src/test/java/org/jboss/pnc/integration/NCL468Test.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/NCL468Test.java
@@ -36,7 +36,7 @@ public class NCL468Test {
     public void shouldGetAllUsers() {
         final String toMatch = "[{\"id\":1,\"email\":\"demo-user@pnc.com\",\"firstName\":\"Demo First Name\",\"lastName\":\"Demo Last Name\",\"username\":\"demo-user\"}]";
 
-        given().contentType(ContentType.JSON).port(getHttpPort()).when().get("/pnc-rest/rest/user")
+        given().contentType(ContentType.JSON).port(getHttpPort()).when().get("/pnc-rest/rest/users")
             .then().assertThat().body(
                 equalTo(StringEscapeUtils.unescapeJava(toMatch)));
     }

--- a/integration-test/src/test/java/org/jboss/pnc/integration/ProductMilestoneRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/ProductMilestoneRestTest.java
@@ -42,9 +42,9 @@ public class ProductMilestoneRestTest {
 
     public static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private static final String PRODUCT_REST_ENDPOINT = "/pnc-rest/rest/product/";
-    private static final String PRODUCT_VERSION_REST_ENDPOINT = "/pnc-rest/rest/product/%d/version/";
-    private static final String PRODUCT_MILESTONE_REST_ENDPOINT = "/pnc-rest/rest/product-milestone/";
+    private static final String PRODUCT_REST_ENDPOINT = "/pnc-rest/rest/products/";
+    private static final String PRODUCT_VERSION_REST_ENDPOINT = "/pnc-rest/rest/products/%d/product-versions/";
+    private static final String PRODUCT_MILESTONE_REST_ENDPOINT = "/pnc-rest/rest/product-milestones/";
     private static final String PRODUCT_MILESTONE_SPECIFIC_REST_ENDPOINT = PRODUCT_MILESTONE_REST_ENDPOINT + "%d";
 
     private static int productId;

--- a/integration-test/src/test/java/org/jboss/pnc/integration/ProductReleaseRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/ProductReleaseRestTest.java
@@ -41,10 +41,10 @@ public class ProductReleaseRestTest {
 
     public static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private static final String PRODUCT_REST_ENDPOINT = "/pnc-rest/rest/product/";
-    private static final String PRODUCT_VERSION_REST_ENDPOINT = "/pnc-rest/rest/product/%d/version/";
-    private static final String PRODUCT_MILESTONE_REST_ENDPOINT = "/pnc-rest/rest/product-milestone/";
-    private static final String PRODUCT_RELEASE_REST_ENDPOINT = "/pnc-rest/rest/product-release/";
+    private static final String PRODUCT_REST_ENDPOINT = "/pnc-rest/rest/products/";
+    private static final String PRODUCT_VERSION_REST_ENDPOINT = "/pnc-rest/rest/products/%d/product-versions/";
+    private static final String PRODUCT_MILESTONE_REST_ENDPOINT = "/pnc-rest/rest/product-milestones/";
+    private static final String PRODUCT_RELEASE_REST_ENDPOINT = "/pnc-rest/rest/product-releases/";
     private static final String PRODUCT_RELEASE_SPECIFIC_REST_ENDPOINT = PRODUCT_RELEASE_REST_ENDPOINT + "%d";
 
     private static int productId;

--- a/integration-test/src/test/java/org/jboss/pnc/integration/ProductVersionRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/ProductVersionRestTest.java
@@ -42,9 +42,9 @@ public class ProductVersionRestTest {
 
     public static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private static final String PRODUCT_REST_ENDPOINT = "/pnc-rest/rest/product/";
-    private static final String PRODUCT_VERSION_REST_ENDPOINT = "/pnc-rest/rest/product/%d/version/";
-    private static final String PRODUCT_VERSION_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/product/%d/version/%d";
+    private static final String PRODUCT_REST_ENDPOINT = "/pnc-rest/rest/products/";
+    private static final String PRODUCT_VERSION_REST_ENDPOINT = "/pnc-rest/rest/products/%d/product-versions/";
+    private static final String PRODUCT_VERSION_SPECIFIC_REST_ENDPOINT = "/pnc-rest/rest/products/%d/product-versions/%d";
 
     private static int productId;
     private static int productVersionId;

--- a/integration-test/src/test/java/org/jboss/pnc/integration/RestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/RestTest.java
@@ -48,8 +48,8 @@ public class RestTest {
     private static Integer newProductId;
     private static Integer newProjectId;
 
-    private static final String PRODUCT_REST_ENDPOINT = "/pnc-rest/rest/product/";
-    private static final String PROJECT_REST_ENDPOINT = "/pnc-rest/rest/project/";
+    private static final String PRODUCT_REST_ENDPOINT = "/pnc-rest/rest/products/";
+    private static final String PROJECT_REST_ENDPOINT = "/pnc-rest/rest/projects/";
     private static final String PROJECT_REST_ENDPOINT_SPECIFIC = PROJECT_REST_ENDPOINT + "%d";
     
     private static AuthenticationProvider authProvider;
@@ -79,7 +79,7 @@ public class RestTest {
     @InSequence(0)
     public void shouldGetAllProducts() {
         given().header("Accept", "application/json").header("Authorization", "Bearer " + access_token)
-                    .contentType(ContentType.JSON).port(getHttpPort()).when().get("/pnc-rest/rest/product").then().statusCode(200)
+                    .contentType(ContentType.JSON).port(getHttpPort()).when().get("/pnc-rest/rest/products").then().statusCode(200)
                 .body(JsonMatcher.containsJsonAttribute("[0].id", value -> productId = Integer.valueOf(value)));
     }
 
@@ -88,7 +88,7 @@ public class RestTest {
     public void shouldGetSpecificProduct() {
         given().header("Accept", "application/json").header("Authorization", "Bearer " + access_token)
                     .contentType(ContentType.JSON).port(getHttpPort()).when()
-                .get(String.format("/pnc-rest/rest/product/%d", productId)).then().statusCode(200)
+                .get(String.format("/pnc-rest/rest/products/%d", productId)).then().statusCode(200)
                 .body(JsonMatcher.containsJsonAttribute("id"));
     }
 
@@ -97,7 +97,7 @@ public class RestTest {
     public void shouldGetAllProductsVersions() {
         given().header("Accept", "application/json").header("Authorization", "Bearer " + access_token)
                     .contentType(ContentType.JSON).port(getHttpPort()).when()
-                .get(String.format("/pnc-rest/rest/product/%d/version", productId)).then().statusCode(200)
+                .get(String.format("/pnc-rest/rest/products/%d/product-versions", productId)).then().statusCode(200)
                 .body(JsonMatcher.containsJsonAttribute("[0].id", value -> productVersionId = Integer.valueOf(value)));
     }
 
@@ -106,7 +106,7 @@ public class RestTest {
     public void shouldSpecificProductsVersions() {
         given().header("Accept", "application/json").header("Authorization", "Bearer " + access_token)
                     .contentType(ContentType.JSON).port(getHttpPort()).when()
-                .get(String.format("/pnc-rest/rest/product/%d/version/%d", productId, productVersionId)).then().statusCode(200)
+                .get(String.format("/pnc-rest/rest/products/%d/product-versions/%d", productId, productVersionId)).then().statusCode(200)
                 .body(JsonMatcher.containsJsonAttribute("id"));
     }
 
@@ -115,7 +115,7 @@ public class RestTest {
     public void shouldGetFirstProject() {
         given().header("Accept", "application/json").header("Authorization", "Bearer " + access_token)
                     .contentType(ContentType.JSON).port(getHttpPort()).when()
-                .get("/pnc-rest/rest/project/").then()
+                .get("/pnc-rest/rest/projects/").then()
                 .statusCode(200).body(JsonMatcher.containsJsonAttribute("[0].id", value -> projectId = Integer.valueOf(value)));
     }
 
@@ -124,7 +124,7 @@ public class RestTest {
     public void shouldGetSpecificProject() {
         given().header("Accept", "application/json").header("Authorization", "Bearer " + access_token)
                     .contentType(ContentType.JSON).port(getHttpPort()).when()
-                .get(String.format("/pnc-rest/rest/project/%d", projectId)).then().statusCode(200)
+                .get(String.format("/pnc-rest/rest/projects/%d", projectId)).then().statusCode(200)
                 .body(JsonMatcher.containsJsonAttribute("id"));
     }
 
@@ -132,7 +132,7 @@ public class RestTest {
     @InSequence(6)
     public void shouldGetAllUsers() {
         given().header("Accept", "application/json").header("Authorization", "Bearer " + access_token)
-                    .contentType(ContentType.JSON).port(getHttpPort()).when().get("/pnc-rest/rest/user").then().statusCode(200)
+                    .contentType(ContentType.JSON).port(getHttpPort()).when().get("/pnc-rest/rest/users").then().statusCode(200)
                 .body(JsonMatcher.containsJsonAttribute("[0].id", value -> userId = Integer.valueOf(value)));
     }
 
@@ -140,7 +140,7 @@ public class RestTest {
     @InSequence(7)
     public void shouldGetSpecificUser() {
         given().header("Accept", "application/json").header("Authorization", "Bearer " + access_token)
-                    .contentType(ContentType.JSON).port(getHttpPort()).when().get(String.format("/pnc-rest/rest/user/%d", userId))
+                    .contentType(ContentType.JSON).port(getHttpPort()).when().get(String.format("/pnc-rest/rest/users/%d", userId))
                 .then().statusCode(200).body(JsonMatcher.containsJsonAttribute("id"));
     }
 
@@ -151,7 +151,7 @@ public class RestTest {
             String rawJson = IoUtils.readFileOrResource("user", "user.json", getClass().getClassLoader());
             logger.info(rawJson);
             given().header("Accept", "application/json").header("Authorization", "Bearer " + access_token)
-                    .body(rawJson).contentType(ContentType.JSON).port(getHttpPort()).when().post("/pnc-rest/rest/user/").then()
+                    .body(rawJson).contentType(ContentType.JSON).port(getHttpPort()).when().post("/pnc-rest/rest/users/").then()
                     .statusCode(201);
 
         } catch (IOException e) {
@@ -168,7 +168,7 @@ public class RestTest {
 
             Response response = given().header("Accept", "application/json").header("Authorization", "Bearer " + access_token)
                     .body(rawJson).contentType(ContentType.JSON).port(getHttpPort()).when()
-                    .post("/pnc-rest/rest/product/");
+                    .post("/pnc-rest/rest/products/");
             Assertions.assertThat(response.statusCode()).isEqualTo(201);
 
             String location = response.getHeader("Location");
@@ -192,7 +192,7 @@ public class RestTest {
 
         Response response = given().header("Accept", "application/json").header("Authorization", "Bearer " + access_token)
                     .contentType(ContentType.JSON).port(getHttpPort()).when()
-                .get(String.format("/pnc-rest/rest/product/%d", newProductId));
+                .get(String.format("/pnc-rest/rest/products/%d", newProductId));
 
         Assertions.assertThat(response.statusCode()).isEqualTo(200);
         Assertions.assertThat(response.body().jsonPath().getInt("id")).isEqualTo(newProductId);
@@ -208,12 +208,12 @@ public class RestTest {
 
         given().header("Accept", "application/json").header("Authorization", "Bearer " + access_token)
                     .body(rawJson).contentType(ContentType.JSON).port(getHttpPort()).when()
-                .put(String.format("/pnc-rest/rest/product/%d", newProductId)).then().statusCode(200);
+                .put(String.format("/pnc-rest/rest/products/%d", newProductId)).then().statusCode(200);
 
         // Reading updated resource
         Response updateResponse = given().header("Accept", "application/json").header("Authorization", "Bearer " + access_token)
                     .contentType(ContentType.JSON).port(getHttpPort()).when()
-                .get(String.format("/pnc-rest/rest/product/%d", newProductId));
+                .get(String.format("/pnc-rest/rest/products/%d", newProductId));
 
         Assertions.assertThat(updateResponse.statusCode()).isEqualTo(200);
         Assertions.assertThat(updateResponse.body().jsonPath().getInt("id")).isEqualTo(newProductId);

--- a/pnc-rest/src/main/auth/web.xml
+++ b/pnc-rest/src/main/auth/web.xml
@@ -8,7 +8,7 @@
     <security-constraint>
         <web-resource-collection>
             <web-resource-name>product-rest-endpoint</web-resource-name>
-            <url-pattern>/rest/product</url-pattern>
+            <url-pattern>/rest/products</url-pattern>
         </web-resource-collection>
         <auth-constraint>
             <role-name>product-manager</role-name>
@@ -18,7 +18,7 @@
     <security-constraint>
         <web-resource-collection>
             <web-resource-name>product-rest-endpoint_all</web-resource-name>
-            <url-pattern>/rest/product/*</url-pattern>
+            <url-pattern>/rest/products/*</url-pattern>
         </web-resource-collection>
         <auth-constraint>
             <role-name>product-manager</role-name>

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
@@ -20,8 +20,8 @@ import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.util.List;
 
-@Api(value = "/configuration", description = "Build Configuration related information")
-@Path("/configuration")
+@Api(value = "/build-configurations", description = "Build configuration entities")
+@Path("/build-configurations")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class BuildConfigurationEndpoint {
@@ -90,7 +90,7 @@ public class BuildConfigurationEndpoint {
     @Path("/{id}/clone")
     public Response clone(@ApiParam(value = "Build Configuration id", required = true) @PathParam("id") Integer id,
             @Context UriInfo uriInfo) {
-        UriBuilder uriBuilder = UriBuilder.fromUri(uriInfo.getBaseUri()).path("/configuration/{id}");
+        UriBuilder uriBuilder = UriBuilder.fromUri(uriInfo.getBaseUri()).path("/build-configurations/{id}");
         int newId = buildConfigurationProvider.clone(id);
         return Response.created(uriBuilder.build(newId)).entity(buildConfigurationProvider.getSpecific(newId)).build();
     }
@@ -117,7 +117,7 @@ public class BuildConfigurationEndpoint {
 
     @ApiOperation(value = "Gets all Build Configurations of a Project")
     @GET
-    @Path("/project/{projectId}")
+    @Path("/projects/{projectId}")
     public List<BuildConfigurationRest> getAllByProjectId(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
             @ApiParam(value = "Pagination size") @DefaultValue("50") @QueryParam("pageSize") int pageSize,
@@ -129,7 +129,7 @@ public class BuildConfigurationEndpoint {
 
     @ApiOperation(value = "Gets all Build Configurations of a Product")
     @GET
-    @Path("/product/{productId}")
+    @Path("/products/{productId}")
     public List<BuildConfigurationRest> getAllByProductId(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
             @ApiParam(value = "Pagination size") @DefaultValue("50") @QueryParam("pageSize") int pageSize,
@@ -141,7 +141,7 @@ public class BuildConfigurationEndpoint {
 
     @ApiOperation(value = "Gets all Build Configurations of the Specified Product Version")
     @GET
-    @Path("/product/{productId}/version/{versionId}")
+    @Path("/products/{productId}/product-versions/{versionId}")
     public List<BuildConfigurationRest> getAllByProductId(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
             @ApiParam(value = "Pagination size") @DefaultValue("50") @QueryParam("pageSize") int pageSize,

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationSetEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationSetEndpoint.java
@@ -32,8 +32,8 @@ import javax.ws.rs.core.UriInfo;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
 
-@Api(value = "/configuration-set", description = "Set of related build configurations")
-@Path("/configuration-set")
+@Api(value = "/build-configuration-sets", description = "Set of related build configurations")
+@Path("/build-configuration-sets")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class BuildConfigurationSetEndpoint {
@@ -98,7 +98,7 @@ public class BuildConfigurationSetEndpoint {
 
     @ApiOperation(value = "Gets the Configurations for the Specified Set")
     @GET
-    @Path("/{id}/configuration")
+    @Path("/{id}/build-configurations")
     public List<BuildConfigurationRest> getConfigurations(
             @ApiParam(value = "Build Configuration Set id", required = true) @PathParam("id") Integer id) {
         return buildConfigurationSetProvider.getBuildConfigurations(id);
@@ -127,7 +127,7 @@ public class BuildConfigurationSetEndpoint {
 
     @ApiOperation(value = "Adds a configuration to the Specified Set")
     @POST
-    @Path("/{id}/configuration")
+    @Path("/{id}/build-configurations")
     public Response addConfiguration(
             @ApiParam(value = "Build Configuration Set id", required = true) @PathParam("id") Integer id,
             BuildConfigurationRest buildConfig) {
@@ -137,7 +137,7 @@ public class BuildConfigurationSetEndpoint {
 
     @ApiOperation(value = "Removes a configuration from the specified config set")
     @DELETE
-    @Path("/{id}/configuration/{configId}")
+    @Path("/{id}/build-configurations/{configId}")
     public Response addConfiguration(
             @ApiParam(value = "Build configuration set id", required = true) @PathParam("id") Integer id,
             @ApiParam(value = "Build configuration id", required = true) @PathParam("configId") Integer configId) {

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildRecordEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildRecordEndpoint.java
@@ -12,8 +12,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
 
-@Api(value = "/record", description = "Records of building process")
-@Path("/record")
+@Api(value = "/build-records", description = "Records of building process")
+@Path("/build-records")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class BuildRecordEndpoint {
@@ -54,7 +54,7 @@ public class BuildRecordEndpoint {
 
     @ApiOperation(value = "Gets the Build Records linked to a specific Build Configuration")
     @GET
-    @Path("/configuration/{configurationId}")
+    @Path("/build-configurations/{configurationId}")
     public List<BuildRecordRest> getAllForBuildConfiguration(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
             @ApiParam(value = "Pagination size") @DefaultValue("50") @QueryParam("pageSize") int pageSize,
@@ -66,7 +66,7 @@ public class BuildRecordEndpoint {
 
     @ApiOperation(value = "Gets the Build Records linked to a specific Project")
     @GET
-    @Path("/project/{projectId}")
+    @Path("/projects/{projectId}")
     public List<BuildRecordRest> getAllForProject(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
             @ApiParam(value = "Pagination size") @DefaultValue("50") @QueryParam("pageSize") int pageSize,

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildRecordSetEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildRecordSetEndpoint.java
@@ -13,8 +13,8 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import java.util.List;
 
-@Api(value = "/recordset", description = "BuildRecordSet collection")
-@Path("/recordset")
+@Api(value = "/build-record-sets", description = "BuildRecordSet collection")
+@Path("/build-record-sets")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class BuildRecordSetEndpoint {
@@ -48,7 +48,7 @@ public class BuildRecordSetEndpoint {
 
     @ApiOperation(value = "Gets all BuildRecordSet of a Product Version")
     @GET
-    @Path("/product-milestone/{versionId}")
+    @Path("/product-milestones/{versionId}")
     public List<BuildRecordSetRest> getAllForProductMilestone(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
             @ApiParam(value = "Pagination size") @DefaultValue("50") @QueryParam("pageSize") int pageSize,
@@ -60,7 +60,7 @@ public class BuildRecordSetEndpoint {
 
     @ApiOperation(value = "Gets all BuildRecordSet of a BuildRecord")
     @GET
-    @Path("/record/{recordId}")
+    @Path("/build-records/{recordId}")
     public List<BuildRecordSetRest> getAllForBuildRecord(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
             @ApiParam(value = "Pagination size") @DefaultValue("50") @QueryParam("pageSize") int pageSize,

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/EnvironmentEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/EnvironmentEndpoint.java
@@ -13,8 +13,8 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import java.util.List;
 
-@Api(value = "/environment", description = "Environment related information")
-@Path("/environment")
+@Api(value = "/environments", description = "Environment related information")
+@Path("/environments")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class EnvironmentEndpoint {

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/LicenseEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/LicenseEndpoint.java
@@ -17,8 +17,8 @@ import java.util.List;
  * Created by avibelli on Feb 5, 2015
  *
  */
-@Api(value = "/license", description = "License related information")
-@Path("/license")
+@Api(value = "/licenses", description = "License related information")
+@Path("/licenses")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class LicenseEndpoint {

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductEndpoint.java
@@ -13,8 +13,8 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import java.util.List;
 
-@Api(value = "/product", description = "Product related information")
-@Path("/product")
+@Api(value = "/products", description = "Product related information")
+@Path("/products")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class ProductEndpoint {

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductMilestoneEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductMilestoneEndpoint.java
@@ -14,8 +14,8 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import java.util.List;
 
-@Api(value = "/product-milestone", description = "Product Milestone related information")
-@Path("/product-milestone")
+@Api(value = "/product-milestones", description = "Product Milestone related information")
+@Path("/product-milestones")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class ProductMilestoneEndpoint {

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductReleaseEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductReleaseEndpoint.java
@@ -15,8 +15,8 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import java.util.List;
 
-@Api(value = "/product-release", description = "Product Release related information")
-@Path("/product-release")
+@Api(value = "/product-releases", description = "Product Release related information")
+@Path("/product-releases")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class ProductReleaseEndpoint {

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductVersionEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductVersionEndpoint.java
@@ -15,8 +15,8 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import java.util.List;
 
-@Api(value = "/product/{productId}/version", description = "Product Version related information")
-@Path("/product/{productId}/version")
+@Api(value = "/products/{productId}/product-versions", description = "Product Version related information")
+@Path("/products/{productId}/product-versions")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class ProductVersionEndpoint {
@@ -72,7 +72,7 @@ public class ProductVersionEndpoint {
 
     @ApiOperation(value = "Gets build configuration sets associated with a product version")
     @GET
-    @Path("/{id}/configuration-set")
+    @Path("/{id}/build-configuration-sets")
     public List<BuildConfigurationSetRest> getBuildConfigurationSets(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
             @ApiParam(value = "Pagination size") @DefaultValue("50") @QueryParam("pageSize") int pageSize,

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/ProjectEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/ProjectEndpoint.java
@@ -13,8 +13,8 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import java.util.List;
 
-@Api(value = "/project", description = "Project related information")
-@Path("/project")
+@Api(value = "/projects", description = "Project related information")
+@Path("/projects")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class ProjectEndpoint {

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/RunningBuildRecordEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/RunningBuildRecordEndpoint.java
@@ -14,8 +14,8 @@ import javax.ws.rs.core.Response;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
 
-@Api(value = "/record/running", description = "Build Records for running builds")
-@Path("/record/running")
+@Api(value = "/running-build-records", description = "Build Records for running builds")
+@Path("/running-build-records")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class RunningBuildRecordEndpoint {

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/UserEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/endpoint/UserEndpoint.java
@@ -15,8 +15,8 @@ import javax.ws.rs.core.*;
 
 import java.util.List;
 
-@Api(value = "/user", description = "User related information")
-@Path("/user")
+@Api(value = "/users", description = "User related information")
+@Path("/users")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class UserEndpoint {

--- a/pnc-rest/src/main/java/org/jboss/pnc/rest/notifications/websockets/NotificationsEndpoint.java
+++ b/pnc-rest/src/main/java/org/jboss/pnc/rest/notifications/websockets/NotificationsEndpoint.java
@@ -19,7 +19,7 @@ import javax.websocket.server.ServerEndpoint;
 @ServerEndpoint(NotificationsEndpoint.ENDPOINT_PATH)
 public class NotificationsEndpoint {
 
-    public static final String ENDPOINT_PATH = "/ws/record/notifications";
+    public static final String ENDPOINT_PATH = "/ws/build-records/notifications";
 
     @Inject
     private OutputConverter outputConverter;

--- a/pnc-ui/app/common/remote/rest-client.js
+++ b/pnc-ui/app/common/remote/rest-client.js
@@ -31,7 +31,7 @@
       }
 
       return {
-        Product: $resource(REST_DEFAULTS.BASE_URL + '/product/:productId', {
+        Product: $resource(REST_DEFAULTS.BASE_URL + '/products/:productId', {
           productId: '@id'
         },{
           update: {
@@ -39,7 +39,7 @@
           }
         }),
 
-        Version: $resource(REST_DEFAULTS.BASE_URL + '/product/:productId/version/:versionId', {
+        Version: $resource(REST_DEFAULTS.BASE_URL + '/products/:productId/product-versions/:versionId', {
           versionId: '@id',
           productId: '@productId'
         },{
@@ -48,12 +48,12 @@
           },
           getAllBuildConfigurationSets: {
             method: 'GET',
-            url: REST_DEFAULTS.BASE_URL + '/product/:productId/version/:versionId/configuration-set',
+            url: REST_DEFAULTS.BASE_URL + '/products/:productId/product-versions/:versionId/build-configuration-sets',
             isArray: true
           },
         }),
 
-        Project: $resource(REST_DEFAULTS.BASE_URL + '/project/:projectId', {
+        Project: $resource(REST_DEFAULTS.BASE_URL + '/projects/:projectId', {
           projectId: '@id'
         },{
           update: {
@@ -62,12 +62,12 @@
           getAllForProductVersion: {
             method: 'GET',
             url: REST_DEFAULTS.BASE_URL +
-            '/project/product/:productId/version/:versionId',
+            '/projects/products/:productId/product-versions/:versionId',
             isArray: true,
           }
         }),
 
-        Environment: $resource(REST_DEFAULTS.BASE_URL + '/environment/:environmentId', {
+        Environment: $resource(REST_DEFAULTS.BASE_URL + '/environments/:environmentId', {
           environmentId: '@id'
         },{
           update: {
@@ -75,7 +75,7 @@
           }
         }),
 
-        Configuration: $resource(REST_DEFAULTS.BASE_URL + '/configuration/:configurationId', {
+        Configuration: $resource(REST_DEFAULTS.BASE_URL + '/build-configurations/:configurationId', {
           configurationId: '@id'
         },{
           update: {
@@ -83,104 +83,104 @@
           },
           clone: {
             method: 'POST',
-            url: REST_DEFAULTS.BASE_URL + '/configuration/:configurationId/clone',
+            url: REST_DEFAULTS.BASE_URL + '/build-configurations/:configurationId/clone',
             isArray: false,
           },
           build: {
             method: 'POST',
-            url: REST_DEFAULTS.BASE_URL + '/configuration/:configurationId/build',
+            url: REST_DEFAULTS.BASE_URL + '/build-configurations/:configurationId/build',
             isArray: false,
           },
           getAllForProduct: {
             method: 'GET',
-            url: REST_DEFAULTS.BASE_URL + '/configuration/product/:productId',
+            url: REST_DEFAULTS.BASE_URL + '/build-configurations/products/:productId',
             isArray: true,
           },
           getAllForProductVersion: {
             method: 'GET',
             url: REST_DEFAULTS.BASE_URL +
-            '/configuration/product/:productId/version/:versionId',
+            '/build-configurations/products/:productId/product-versions/:versionId',
             isArray: true,
           },
           getAllForProject: {
            method: 'GET',
-           url: REST_DEFAULTS.BASE_URL + '/configuration/project/:projectId',
+           url: REST_DEFAULTS.BASE_URL + '/build-configurations/projects/:projectId',
            isArray: true,
           },
         }),
 
-        Record: $resource(REST_DEFAULTS.BASE_URL + '/record/:recordId', {
+        Record: $resource(REST_DEFAULTS.BASE_URL + '/build-records/:recordId', {
           recordId: '@id'
         }, {
           getLog: {
             method: 'GET',
-            url: REST_DEFAULTS.BASE_URL + '/record/:recordId/log',
+            url: REST_DEFAULTS.BASE_URL + '/build-records/:recordId/log',
             isArray: false,
             transformResponse: convertStringResponseToJson
           },
           getAllForConfiguration: {
             method: 'GET',
-            url: REST_DEFAULTS.BASE_URL + '/record/configuration/:configurationId',
+            url: REST_DEFAULTS.BASE_URL + '/build-records/build-configurations/:configurationId',
             isArray: true,
           },
           getAllForProject: {
             method: 'GET',
-            url: REST_DEFAULTS.BASE_URL + 'record/project/:projectId',
+            url: REST_DEFAULTS.BASE_URL + 'record/projects/:projectId',
             isArray: true,
           },
           getLatestForConfiguration: {
             method: 'GET',
-            url: REST_DEFAULTS.BASE_URL + '/record/configuration/:configurationId?pageIndex=0&pageSize=1&sort==desc=id',
+            url: REST_DEFAULTS.BASE_URL + '/build-records/build-configurations/:configurationId?pageIndex=0&pageSize=1&sort==desc=id',
             isArray: true,
           },
         }),
 
-        Running: $resource(REST_DEFAULTS.BASE_URL + '/record/running/:recordId', {
+        Running: $resource(REST_DEFAULTS.BASE_URL + '/running-build-records/:recordId', {
           recordId: '@id'
         }, {
           getLog: {
             method: 'GET',
-            url: REST_DEFAULTS.BASE_URL + '/record/running/:recordId/log',
+            url: REST_DEFAULTS.BASE_URL + '/running-build-records/:recordId/log',
             isArray: false,
             transformResponse: convertStringResponseToJson
           },
         }),
-        ConfigurationSet: $resource(REST_DEFAULTS.BASE_URL + '/configuration-set/:configurationSetId', {
+        ConfigurationSet: $resource(REST_DEFAULTS.BASE_URL + '/build-configuration-sets/:configurationSetId', {
           'configurationSetId': '@id'
         },{
           getConfigurations: {
             method: 'GET',
-            url: REST_DEFAULTS.BASE_URL + '/configuration-set/:configurationSetId/configuration',
+            url: REST_DEFAULTS.BASE_URL + '/build-configuration-sets/:configurationSetId/build-configurations',
             isArray: true
           },
           build: {
             method: 'POST',
-            url: REST_DEFAULTS.BASE_URL + '/configuration-set/:configurationSetId/build',
+            url: REST_DEFAULTS.BASE_URL + '/build-configuration-sets/:configurationSetId/build',
             isArray: false,
           },
           removeConfiguration: {
             method: 'DELETE',
-            url: REST_DEFAULTS.BASE_URL + '/configuration-set/:configurationSetId/configuration/:configurationId',
+            url: REST_DEFAULTS.BASE_URL + '/build-configuration-sets/:configurationSetId/build-configurations/:configurationId',
             isArray: false,
           },
           addConfiguration: {
             method: 'POST',
-            url: REST_DEFAULTS.BASE_URL + '/configuration-set/:configurationSetId/configuration',
+            url: REST_DEFAULTS.BASE_URL + '/build-configuration-sets/:configurationSetId/build-configurations',
             isArray: false,
           },
         }),
 
-        RecordSet: $resource(REST_DEFAULTS.BASE_URL + '/recordset/:recordsetId', {
+        RecordSet: $resource(REST_DEFAULTS.BASE_URL + '/build-record-sets/:recordsetId', {
           recordsetId: '@id'
         },{
           getAllForProductVersion: {
             method: 'GET',
-            url: REST_DEFAULTS.BASE_URL + '/recordset/productversion/:versionId',
+            url: REST_DEFAULTS.BASE_URL + '/build-record-sets/product-versions/:versionId',
             isArray: true
           },
           getRecords: {
             method: 'GET',
-            url: REST_DEFAULTS.BASE_URL + '/recordset/record/:recordId',
+            url: REST_DEFAULTS.BASE_URL + '/build-record-sets/build-records/:recordId',
             isArray: true
           }
         })

--- a/pnc-ui/app/websockets/_websockets.js
+++ b/pnc-ui/app/websockets/_websockets.js
@@ -26,7 +26,7 @@
   }]);
 
   module.factory('MyData', ['$websocket', 'Notifications', function ($websocket, Notifications) {
-    var dataStream = $websocket('ws://localhost:8080/pnc-rest/ws/record/notifications');
+    var dataStream = $websocket('ws://localhost:8080/pnc-rest/ws/build-records/notifications');
     dataStream.onMessage(function(message) {
       Notifications.success('WS response ' + message.data);
     });


### PR DESCRIPTION
Always use a plural noun when returning a collection of entities