### PR TITLE
modify artifactIds to reflect new module refactor

### DIFF
--- a/build-coordinator/pom.xml
+++ b/build-coordinator/pom.xml
@@ -50,11 +50,11 @@
     <!-- Project dependencies -->
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-spi</artifactId>
+      <artifactId>spi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-model</artifactId>
+      <artifactId>model</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>

--- a/datastore/pom.xml
+++ b/datastore/pom.xml
@@ -37,11 +37,11 @@
     <!-- Project dependencies -->
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-spi</artifactId>
+      <artifactId>spi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-model</artifactId>
+      <artifactId>model</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>

--- a/demo-data/pom.xml
+++ b/demo-data/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-model</artifactId>
+      <artifactId>model</artifactId>
     </dependency>
 
     <dependency>

--- a/docker-environment-driver/pom.xml
+++ b/docker-environment-driver/pom.xml
@@ -38,7 +38,7 @@
     <!-- Project dependencies -->
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-model</artifactId>
+      <artifactId>model</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-spi</artifactId>
+      <artifactId>spi</artifactId>
     </dependency>
 
     <!-- Remote dependencies -->

--- a/ear-package/pom.xml
+++ b/ear-package/pom.xml
@@ -55,20 +55,20 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-core</artifactId>
+      <artifactId>build-coordinator</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-model</artifactId>
+      <artifactId>model</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-rest</artifactId>
+      <artifactId>rest</artifactId>
       <type>war</type>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-spi</artifactId>
+      <artifactId>spi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
@@ -80,7 +80,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-web</artifactId>
+      <artifactId>web</artifactId>
       <type>war</type>
     </dependency>
 
@@ -123,19 +123,19 @@
             </jarModule>
             <jarModule>
               <groupId>org.jboss.pnc</groupId>
-              <artifactId>pnc-core</artifactId>
+              <artifactId>build-coordinator</artifactId>
               <includeInApplicationXml>true</includeInApplicationXml>
               <bundleDir>/</bundleDir>
             </jarModule>
             <jarModule>
               <groupId>org.jboss.pnc</groupId>
-              <artifactId>pnc-model</artifactId>
+              <artifactId>model</artifactId>
               <includeInApplicationXml>true</includeInApplicationXml>
               <bundleDir>/</bundleDir>
             </jarModule>
             <jarModule>
               <groupId>org.jboss.pnc</groupId>
-              <artifactId>pnc-spi</artifactId>
+              <artifactId>spi</artifactId>
               <includeInApplicationXml>true</includeInApplicationXml>
               <bundleDir>/</bundleDir>
             </jarModule>
@@ -153,12 +153,12 @@
             </jarModule>
             <webModule>
               <groupId>org.jboss.pnc</groupId>
-              <artifactId>pnc-rest</artifactId>
+              <artifactId>rest</artifactId>
               <bundleDir>/</bundleDir>
             </webModule>
             <webModule>
               <groupId>org.jboss.pnc</groupId>
-              <artifactId>pnc-web</artifactId>
+              <artifactId>web</artifactId>
               <bundleDir>/</bundleDir>
             </webModule>
           </modules>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -45,7 +45,7 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>pnc-rest</artifactId>
+      <artifactId>rest</artifactId>
       <scope>test</scope>
       <classifier>classes</classifier>
     </dependency>

--- a/jenkins-build-driver/pom.xml
+++ b/jenkins-build-driver/pom.xml
@@ -31,7 +31,7 @@
   <artifactId>jenkins-build-driver</artifactId>
   <packaging>jar</packaging>
 
-  <description>Implementation of pnc-spi:org.jboss.pnc.spi.builddriver.</description>
+  <description>Implementation of spi:org.jboss.pnc.spi.builddriver.</description>
 
   <dependencyManagement>
     <dependencies>
@@ -51,7 +51,7 @@
     <!-- Project dependencies -->
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-spi</artifactId>
+      <artifactId>spi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
@@ -59,7 +59,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-model</artifactId>
+      <artifactId>model</artifactId>
     </dependency>
 
     <!-- Remote dependencies -->

--- a/maven-repository-manager/pom.xml
+++ b/maven-repository-manager/pom.xml
@@ -30,7 +30,7 @@
 
   <artifactId>maven-repository-manager</artifactId>
 
-  <description>Implementation of pnc-spi:org.jboss.pnc.spi.repositorymanager</description>
+  <description>Implementation of spi:org.jboss.pnc.spi.repositorymanager</description>
 
   <dependencies>
     <dependency>
@@ -40,11 +40,11 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-model</artifactId>
+      <artifactId>model</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-spi</artifactId>
+      <artifactId>spi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -227,20 +227,20 @@
 
       <dependency>
         <groupId>org.jboss.pnc</groupId>
-        <artifactId>pnc-core</artifactId>
+        <artifactId>build-coordinator</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.jboss.pnc</groupId>
-        <artifactId>pnc-model</artifactId>
+        <artifactId>model</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <!-- Use this dependency to attach WAR itself -->
       <dependency>
         <groupId>org.jboss.pnc</groupId>
-        <artifactId>pnc-rest</artifactId>
+        <artifactId>rest</artifactId>
         <version>${project.version}</version>
         <type>war</type>
       </dependency>
@@ -248,7 +248,7 @@
       <!-- Use this dependency to attach transitive dependencies -->
       <dependency>
         <groupId>org.jboss.pnc</groupId>
-        <artifactId>pnc-rest</artifactId>
+        <artifactId>rest</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
       </dependency>
@@ -256,26 +256,26 @@
       <!-- Use this dependency to attach war classes -->
       <dependency>
         <groupId>org.jboss.pnc</groupId>
-        <artifactId>pnc-rest</artifactId>
+        <artifactId>rest</artifactId>
         <version>${project.version}</version>
         <classifier>classes</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.jboss.pnc</groupId>
-        <artifactId>pnc-spi</artifactId>
+        <artifactId>spi</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.jboss.pnc</groupId>
-        <artifactId>pnc-ui</artifactId>
+        <artifactId>ui</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.jboss.pnc</groupId>
-        <artifactId>pnc-web</artifactId>
+        <artifactId>web</artifactId>
         <version>${project.version}</version>
         <type>war</type>
       </dependency>
@@ -1378,7 +1378,7 @@
                       <artifactId>maven-scm-plugin</artifactId>
                       <version>1.8.1</version>
                       <configuration>
-                          <includes>pnc-ui/bower.json,pnc-ui/package.json,pnc-ui/npm-shrinkwrap.json</includes>
+                          <includes>ui/bower.json,ui/package.json,ui/npm-shrinkwrap.json</includes>
                           <message>Update JSON Versions</message>
                       </configuration>
                   </plugin>
@@ -1423,19 +1423,19 @@
                       <replaceregexp byline="false"
                                      flags="m"
                                      file="${basedir}/bower.json"
-                                     match="pnc-ui&quot;,&#10;  &quot;version&quot;: &quot;[0-9].*&quot;"
-                                     replace="pnc-ui&quot;,&#10;  &quot;version&quot;: &quot;${newversion}&quot;"/>
+                                     match="ui&quot;,&#10;  &quot;version&quot;: &quot;[0-9].*&quot;"
+                                     replace="ui&quot;,&#10;  &quot;version&quot;: &quot;${newversion}&quot;"/>
                       <replaceregexp byline="false"
                                      flags="m"
                                      file="${basedir}/package.json"
-                                     match="pnc-ui&quot;,&#10;  &quot;version&quot;: &quot;[0-9].*&quot;"
-                                     replace="pnc-ui&quot;,&#10;  &quot;version&quot;: &quot;${newversion}&quot;"/>
+                                     match="ui&quot;,&#10;  &quot;version&quot;: &quot;[0-9].*&quot;"
+                                     replace="ui&quot;,&#10;  &quot;version&quot;: &quot;${newversion}&quot;"/>
 
                       <replaceregexp byline="false"
                                      flags="m"
                                      file="${basedir}/npm-shrinkwrap.json"
-                                     match="pnc-ui&quot;,&#10;  &quot;version&quot;: &quot;[0-9].*&quot;"
-                                     replace="pnc-ui&quot;,&#10;  &quot;version&quot;: &quot;${newversion}&quot;"/>
+                                     match="ui&quot;,&#10;  &quot;version&quot;: &quot;[0-9].*&quot;"
+                                     replace="ui&quot;,&#10;  &quot;version&quot;: &quot;${newversion}&quot;"/>
 
                     </target>
                   </configuration>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -47,12 +47,12 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-core</artifactId>
+      <artifactId>build-coordinator</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-model</artifactId>
+      <artifactId>model</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -62,7 +62,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-spi</artifactId>
+      <artifactId>spi</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -31,12 +31,12 @@
   <artifactId>spi</artifactId>
   <packaging>jar</packaging>
 
-  <description>Contains all SPI interfaces the orchestrator will use to coordinate its sub-services for provisioning environments and repositories, triggering builds, storing domain objects. It is meant to be used in conjunction with pnc-model.</description>
+  <description>Contains all SPI interfaces the orchestrator will use to coordinate its sub-services for provisioning environments and repositories, triggering builds, storing domain objects. It is meant to be used in conjunction with model.</description>
 
   <dependencies>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-model</artifactId>
+      <artifactId>model</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -34,7 +34,7 @@
   <dependencies>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>pnc-ui</artifactId>
+      <artifactId>ui</artifactId>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
As a result of the refactor, the artifactIds in various modules needed further modification.
Basic review of changes:
pnc-something references changed to something in artifactId elements
pnc-core changed to build-coordinator

This allows a clean build with a clean maven repo :) 

