### PR TITLE
Persistence updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The default build with command `mvn clean install` comes with no authentication.
 use -Dauth=true together with your build command.
 Enabling authentication meand following
 1. Your backend REST endpoints will become secured
-    - inside pnc-rest.war under folder WEB-INF are added files from /pnc-rest/src/main/auth
+    - inside rest.war under folder WEB-INF are added files from rest/src/main/auth
     - keycloak.json file is configuration file managing connection to Keycloak server
     - web.xml file where you define security-constraints & security-roles, which specifies users
       authrorization's to each REST endpoint
@@ -100,15 +100,15 @@ Possible issues:
 
 Main Modules
 ------------
-* `datastore`: Implementation of pnc-spi:org.jboss.pnc.spi.datastore
-* `jenkins-build-driver`: Implementation of pnc-spi:org.jboss.pnc.spi.builddriver
-* `maven-repository-manager`: Implementation of pnc-spi:org.jboss.pnc.spi.repositorymanager
-* `pnc-core`: Contains implementations of action-controllers, which include the business logic for orchestrating builds, test runs, etc. Action controllers are used to isolate logic from the REST API, so it can be reused in embedded scenarios
-* `pnc-model`: Contains domain model for the orchestrator. This is just model classes + serialization helpers, and would also be suitable for writing a java client api to support integration
-* `pnc-rest-bindings`: REST API. This is a series of classes that use JAX-RS to translate HTTP communications to calls into the action controllers in the core, and format any output (such as constructing resource URLs, etc.)
-* `pnc-spi`: Contains all SPI interfaces the orchestrator will use to coordinate its sub-services for provisioning environments and repositories, triggering builds, storing domain objects. It is meant to be used in conjunction with pnc-model
-* `pnc-processes`: Contains jBPM processes for PNC
-* `pnc-web`: Contains Web UI resoures (html + js pages, images etc.)
+* `datastore`: Implementation of spi:org.jboss.pnc.spi.datastore
+* `jenkins-build-driver`: Implementation of spi:org.jboss.pnc.spi.builddriver
+* `maven-repository-manager`: Implementation of spi:org.jboss.pnc.spi.repositorymanager
+* `build-coordinator`: Contains implementations of action-controllers, which include the business logic for orchestrating builds, test runs, etc. Action controllers are used to isolate logic from the REST API, so it can be reused in embedded scenarios
+* `model`: Contains domain model for the orchestrator. This is just model classes + serialization helpers, and would also be suitable for writing a java client api to support integration
+* `rest`: REST API. This is a series of classes that use JAX-RS to translate HTTP communications to calls into the action controllers in the core, and format any output (such as constructing resource URLs, etc.)
+* `spi`: Contains all SPI interfaces the orchestrator will use to coordinate its sub-services for provisioning environments and repositories, triggering builds, storing domain objects. It is meant to be used in conjunction with pnc-model
+* `processes`: Contains jBPM processes for PNC
+* `web`: Contains Web UI resoures (html + js pages, images etc.)
 
 Building with Postgresql
 -----------------------

--- a/datastore/pom.xml
+++ b/datastore/pom.xml
@@ -31,7 +31,7 @@
   <artifactId>datastore</artifactId>
   <packaging>ejb</packaging>
 
-  <description>Implementation of pnc-spi:org.jboss.pnc.spi.datastore</description>
+  <description>Implementation of spi:org.jboss.pnc.spi.datastore</description>
 
   <dependencies>
     <!-- Project dependencies -->

--- a/datastore/src/main/resources/META-INF/persistence.xml
+++ b/datastore/src/main/resources/META-INF/persistence.xml
@@ -25,7 +25,7 @@
         http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
    <persistence-unit name="primary">
        <jta-data-source>@persistence.jta-data-source@</jta-data-source>
-       <jar-file>pnc-model.jar</jar-file>
+       <jar-file>model.jar</jar-file>
        <properties>
          <!-- Properties for Hibernate -->
           <property name="hibernate.dialect" value="@persistence.hibernate.dialect@"/>

--- a/ear-package/pom.xml
+++ b/ear-package/pom.xml
@@ -155,11 +155,13 @@
               <groupId>org.jboss.pnc</groupId>
               <artifactId>rest</artifactId>
               <bundleDir>/</bundleDir>
+	      <contextRoot>/pnc-rest</contextRoot> 
             </webModule>
             <webModule>
               <groupId>org.jboss.pnc</groupId>
               <artifactId>web</artifactId>
               <bundleDir>/</bundleDir>
+	      <contextRoot>/pnc-web</contextRoot> 
             </webModule>
           </modules>
         </configuration>

--- a/integration-test/src/test/resources/test-ds.xml
+++ b/integration-test/src/test/resources/test-ds.xml
@@ -6,7 +6,7 @@
         http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
   <persistence-unit name="primary">
     <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
-    <jar-file>pnc-model.jar</jar-file>
+    <jar-file>model.jar</jar-file>
     <properties>
       <!-- Properties for Hibernate -->
       <property name="hibernate.dialect" value="org.jboss.pnc.datastore.H2Dialect"/>


### PR DESCRIPTION
A few more changes related to the maven module refactor. The important one is the change in the persistence.xml, which was failing to find the @Entity annotated classes due to an outdated model.jar reference. 