### PR TITLE
[NCL-845] Display error if Build Configuration is added to Build Configuration Set where it already exists

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationSetEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationSetEndpoint.java
@@ -186,6 +186,8 @@ public class BuildConfigurationSetEndpoint {
     public Response addConfiguration(
             @ApiParam(value = "Build Configuration Set id", required = true) @PathParam("id") Integer id,
             BuildConfigurationRest buildConfig) {
+        if (buildConfigurationSetProvider.getSpecific(id).getBuildConfigurationIds().contains(buildConfig.getId()))
+            return Response.status(Response.Status.CONFLICT).build();
         buildConfigurationSetProvider.addConfiguration(id, buildConfig.getId());
         return Response.ok().build();
     }


### PR DESCRIPTION
If the user attempts to add a configuration to a build configuration set that already contains the configuration the web ui will now display an error.