### PR TITLE
Return 409(Conflict) if adding BuildConfiguration to BuildConfigurationSet where the BuildConfiguration already exists.

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationSetEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationSetEndpoint.java
@@ -186,8 +186,7 @@ public class BuildConfigurationSetEndpoint {
     public Response addConfiguration(
             @ApiParam(value = "Build Configuration Set id", required = true) @PathParam("id") Integer id,
             BuildConfigurationRest buildConfig) {
-        buildConfigurationSetProvider.addConfiguration(id, buildConfig.getId());
-        return Response.ok().build();
+        return buildConfigurationSetProvider.addConfiguration(id, buildConfig.getId());
     }
 
     @ApiOperation(value = "Removes a configuration from the specified config set")

--- a/rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationSetProvider.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationSetProvider.java
@@ -35,6 +35,7 @@ import org.springframework.data.domain.Pageable;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
+import javax.ws.rs.core.Response;
 
 import java.util.List;
 import java.util.Set;
@@ -50,8 +51,6 @@ public class BuildConfigurationSetProvider {
 
     private BuildConfigurationSetRepository buildConfigurationSetRepository;
     private BuildRecordRepository buildRecordRepository;
-
-    @Inject
     private BuildConfigurationRepository buildConfigurationRepository;
 
     public BuildConfigurationSetProvider() {
@@ -59,9 +58,11 @@ public class BuildConfigurationSetProvider {
 
     @Inject
     public BuildConfigurationSetProvider(BuildConfigurationSetRepository buildConfigurationSetRepository,
-            BuildRecordRepository buildRecordRepository) {
+            BuildRecordRepository buildRecordRepository,
+            BuildConfigurationRepository buildConfigurationRepository) {
         this.buildConfigurationSetRepository = buildConfigurationSetRepository;
         this.buildRecordRepository = buildRecordRepository;
+        this.buildConfigurationRepository = buildConfigurationRepository;
     }
 
     public Function<? super BuildConfigurationSet, ? extends BuildConfigurationSetRest> toRestModel() {
@@ -149,11 +150,14 @@ public class BuildConfigurationSetProvider {
                 .collect(Collectors.toList());
     }
 
-    public void addConfiguration(Integer configurationSetId, Integer configurationId) {
+    public Response addConfiguration(Integer configurationSetId, Integer configurationId) {
         BuildConfigurationSet buildConfigSet = buildConfigurationSetRepository.findOne(configurationSetId);
         BuildConfiguration buildConfig = buildConfigurationRepository.findOne(configurationId);
+        if (buildConfigSet.getBuildConfigurations().contains(buildConfig))
+            return Response.status(Response.Status.CONFLICT).build();
         buildConfigSet.addBuildConfiguration(buildConfig);
         buildConfigurationSetRepository.save(buildConfigSet);
+        return Response.ok().build();
     }
 
     public void removeConfiguration(Integer configurationSetId, Integer configurationId) {

--- a/rest/src/test/java/org/jboss/pnc/rest/provider/BuildConfigurationSetProviderTest.java
+++ b/rest/src/test/java/org/jboss/pnc/rest/provider/BuildConfigurationSetProviderTest.java
@@ -1,0 +1,67 @@
+package org.jboss.pnc.rest.provider;
+
+import org.jboss.pnc.datastore.repositories.BuildConfigurationRepository;
+import org.jboss.pnc.datastore.repositories.BuildConfigurationSetRepository;
+import org.jboss.pnc.datastore.repositories.BuildRecordRepository;
+import org.jboss.pnc.model.BuildConfiguration;
+import org.jboss.pnc.model.BuildConfigurationSet;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class BuildConfigurationSetProviderTest {
+
+    @Test
+    public void addExistingBuildConfigurationToSet(){
+        BuildConfigurationSetRepository buildConfigurationSetRepository = mock(BuildConfigurationSetRepository.class);
+        BuildConfigurationRepository buildConfigurationRepository = mock(BuildConfigurationRepository.class);
+        BuildRecordRepository buildRecordRepository = mock(BuildRecordRepository.class);
+
+        BuildConfigurationSet testBCS = createBuildConfigurationSet(1);
+        addConfigsToSet(testBCS, createBuildConfiguration(1), createBuildConfiguration(2));
+
+        when(buildConfigurationSetRepository.findOne(1)).thenReturn(testBCS);
+        when(buildConfigurationRepository.findOne(2)).thenReturn(createBuildConfiguration(2));
+
+        BuildConfigurationSetProvider buildConfigurationSetProvider = new BuildConfigurationSetProvider(buildConfigurationSetRepository, buildRecordRepository, buildConfigurationRepository);
+        assertEquals(409, buildConfigurationSetProvider.addConfiguration(1,2).getStatus());
+    }
+
+    @Test
+    public void addNewBuildConfigurationToSet(){
+        BuildConfigurationSetRepository buildConfigurationSetRepository = mock(BuildConfigurationSetRepository.class);
+        BuildConfigurationRepository buildConfigurationRepository = mock(BuildConfigurationRepository.class);
+        BuildRecordRepository buildRecordRepository = mock(BuildRecordRepository.class);
+
+        BuildConfigurationSet testBCS = createBuildConfigurationSet(1);
+        addConfigsToSet(testBCS, createBuildConfiguration(1), createBuildConfiguration(2));
+
+        when(buildConfigurationSetRepository.findOne(1)).thenReturn(testBCS);
+        when(buildConfigurationRepository.findOne(3)).thenReturn(createBuildConfiguration(3));
+
+        BuildConfigurationSetProvider buildConfigurationSetProvider = new BuildConfigurationSetProvider(buildConfigurationSetRepository, buildRecordRepository, buildConfigurationRepository);
+        assertEquals(200, buildConfigurationSetProvider.addConfiguration(1,3).getStatus());
+    }
+
+    private BuildConfiguration createBuildConfiguration(int id){
+        BuildConfiguration retVal = new BuildConfiguration();
+        retVal.setId(id);
+        return retVal;
+    }
+
+    private BuildConfigurationSet createBuildConfigurationSet(int id){
+        BuildConfigurationSet retVal = new BuildConfigurationSet();
+        retVal.setId(id);
+        return retVal;
+    }
+
+    private void addConfigsToSet(BuildConfigurationSet bset, BuildConfiguration... bconfigs){
+        for (BuildConfiguration config : bconfigs){
+            bset.addBuildConfiguration(config);
+        }
+    }
+
+}


### PR DESCRIPTION
Return error status if BuildConfiguration already exists in BuildConfigurationSet so that the UI will display an error.