### PR TITLE
Modifications to the EnvironmentEndpoint and EnvironmentRest classes

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/EnvironmentEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/EnvironmentEndpoint.java
@@ -84,11 +84,11 @@ public class EnvironmentEndpoint {
         return Response.ok().build();
     }
 
-    @ApiOperation(value = "Deletes an existing Product")
+    @ApiOperation(value = "Deletes an existing Environment")
     @DELETE
     @Path("/{id}")
-    public Response delete(@ApiParam(value = "License id", required = true) @PathParam("id") Integer licenseId) {
-        environmentProvider.delete(licenseId);
+    public Response delete(@ApiParam(value = "Environment id", required = true) @PathParam("id") Integer environmentId) {
+        environmentProvider.delete(environmentId);
         return Response.ok().build();
     }
 }

--- a/rest/src/main/java/org/jboss/pnc/rest/restmodel/EnvironmentRest.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/restmodel/EnvironmentRest.java
@@ -29,10 +29,10 @@ public class EnvironmentRest {
 
     private Integer id;
 
-    @ApiModelProperty(dataType = "string", allowableValues = "JAVA, DOCKER, NATIVE")
+    @ApiModelProperty(dataType = "string")
     private BuildType buildType;
 
-    @ApiModelProperty(dataType = "string", allowableValues = "LINUX, WINDOWS, OSX")
+    @ApiModelProperty(dataType = "string")
     private OperationalSystem operationalSystem;
 
     public EnvironmentRest() {

--- a/rest/src/main/java/org/jboss/pnc/rest/restmodel/EnvironmentRest.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/restmodel/EnvironmentRest.java
@@ -17,16 +17,22 @@
  */
 package org.jboss.pnc.rest.restmodel;
 
+import com.wordnik.swagger.annotations.ApiModelProperty;
 import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.Environment;
 import org.jboss.pnc.model.OperationalSystem;
 
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "Environment")
 public class EnvironmentRest {
 
     private Integer id;
 
+    @ApiModelProperty(dataType = "string", allowableValues = "JAVA, DOCKER, NATIVE")
     private BuildType buildType;
 
+    @ApiModelProperty(dataType = "string", allowableValues = "LINUX, WINDOWS, OSX")
     private OperationalSystem operationalSystem;
 
     public EnvironmentRest() {


### PR DESCRIPTION
These changes correct errors and inconsistencies within api-docs/environments
1) Correctly define the values within buildType and operationalSystem
2) Define the model used as Environment instead of EnvironmentRest, consistent with the other Endpoints
3) Correct small misnomers in the delete method