### PR TITLE
Add @ApiModelProperty to the BuildStatus property in BuildConfigurationRest

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/EnvironmentEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/EnvironmentEndpoint.java
@@ -84,11 +84,11 @@ public class EnvironmentEndpoint {
         return Response.ok().build();
     }
 
-    @ApiOperation(value = "Deletes an existing Product")
+    @ApiOperation(value = "Deletes an existing Environment")
     @DELETE
     @Path("/{id}")
-    public Response delete(@ApiParam(value = "License id", required = true) @PathParam("id") Integer licenseId) {
-        environmentProvider.delete(licenseId);
+    public Response delete(@ApiParam(value = "Environment id", required = true) @PathParam("id") Integer environmentId) {
+        environmentProvider.delete(environmentId);
         return Response.ok().build();
     }
 }

--- a/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigurationRest.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigurationRest.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.rest.restmodel;
 
+import com.wordnik.swagger.annotations.ApiModelProperty;
 import org.jboss.pnc.model.BuildConfiguration;
 import org.jboss.pnc.model.BuildStatus;
 import org.jboss.pnc.model.Environment;
@@ -51,6 +52,7 @@ public class BuildConfigurationRest {
 
     private Timestamp lastModificationTime;
 
+    @ApiModelProperty(dataType = "string")
     private BuildStatus buildStatus;
 
     private String repositories;

--- a/rest/src/main/java/org/jboss/pnc/rest/restmodel/EnvironmentRest.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/restmodel/EnvironmentRest.java
@@ -17,16 +17,22 @@
  */
 package org.jboss.pnc.rest.restmodel;
 
+import com.wordnik.swagger.annotations.ApiModelProperty;
 import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.Environment;
 import org.jboss.pnc.model.OperationalSystem;
 
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "Environment")
 public class EnvironmentRest {
 
     private Integer id;
 
+    @ApiModelProperty(dataType = "string", allowableValues = "JAVA, DOCKER, NATIVE")
     private BuildType buildType;
 
+    @ApiModelProperty(dataType = "string", allowableValues = "LINUX, WINDOWS, OSX")
     private OperationalSystem operationalSystem;
 
     public EnvironmentRest() {


### PR DESCRIPTION
This change allows correct resolution of the BuildStatus type:

before change: 
http://pastebin.com/ywPzeFp6

after change:
http://pastebin.com/eBTyMfWE

Note that "$ref": BuildStatus becomes "type": "string" 

pnc-rest/rest/api-docs/build-configurations/

which I believe is desired here. 