### PR TITLE
[NCL-908] Add externalArchiveId to build record

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
@@ -146,6 +146,11 @@ public class BuildRecord implements GenericEntity<Integer> {
     private BuildConfigSetRecord buildConfigSetRecord;
 
     /**
+     * Contains the ID of the matching build record store in an external system.  For example, Koji/Brew build ID.
+     */
+    private Integer externalArchiveId;
+
+    /**
      * Instantiates a new project build result.
      */
     public BuildRecord() {
@@ -402,6 +407,14 @@ public class BuildRecord implements GenericEntity<Integer> {
                 + ", buildConfiguration=" + buildConfigurationAudited + "]";
     }
 
+    public Integer getExternalArchiveId() {
+        return externalArchiveId;
+    }
+
+    public void setExternalArchiveId(Integer externalArchiveId) {
+        this.externalArchiveId = externalArchiveId;
+    }
+
     public static class Builder {
 
         private Integer id;
@@ -434,6 +447,8 @@ public class BuildRecord implements GenericEntity<Integer> {
 
         private BuildConfigSetRecord buildConfigSetRecord;
 
+        private Integer externalArchiveId;
+
         public Builder() {
             buildRecordSets = new ArrayList<>();
             dependencies = new ArrayList<>();
@@ -460,6 +475,7 @@ public class BuildRecord implements GenericEntity<Integer> {
             buildRecord.setStatus(status);
             buildRecord.setBuildDriverId(buildDriverId);
             buildRecord.setSystemImage(systemImage);
+            buildRecord.setExternalArchiveId(externalArchiveId);
 
             // Set the bi-directional mapping
             for (Artifact artifact : builtArtifacts) {
@@ -564,6 +580,11 @@ public class BuildRecord implements GenericEntity<Integer> {
 
         public Builder buildConfigSetRecord(BuildConfigSetRecord buildConfigSetRecord) {
             this.buildConfigSetRecord = buildConfigSetRecord;
+            return this;
+        }
+
+        public Builder externalArchiveId(Integer externalArchiveId) {
+            this.externalArchiveId = externalArchiveId;
             return this;
         }
     }

--- a/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildRecordRest.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildRecordRest.java
@@ -48,6 +48,8 @@ public class BuildRecordRest {
 
     private Integer systemImageId;
 
+    private Integer externalArchiveId;
+
     public BuildRecordRest() {
     }
 
@@ -55,6 +57,7 @@ public class BuildRecordRest {
         this.id = buildRecord.getId();
         this.startTime = buildRecord.getStartTime();
         this.endTime = buildRecord.getEndTime();
+        this.externalArchiveId = buildRecord.getExternalArchiveId();
         performIfNotNull(buildRecord.getBuildConfigurationAudited() != null, () -> buildConfigurationId = buildRecord
                 .getBuildConfigurationAudited().getId().getId());
         performIfNotNull(buildRecord.getBuildConfigurationAudited() != null, () -> buildConfigurationRev = buildRecord
@@ -144,6 +147,14 @@ public class BuildRecordRest {
 
     public void setSystemImageId(Integer systemImageId) {
         this.systemImageId = systemImageId;
+    }
+
+    public Integer getExternalArchiveId() {
+        return externalArchiveId;
+    }
+
+    public void setExternalArchiveId(Integer externalArchiveId) {
+        this.externalArchiveId = externalArchiveId;
     }
 
 }


### PR DESCRIPTION
This can store an id which maps to an associated record in an external system
such as Koji/Brew