### PR TITLE
Make swagger work irrespective of the base url

### DIFF
--- a/rest/src/main/resources/swagger.properties
+++ b/rest/src/main/resources/swagger.properties
@@ -16,4 +16,4 @@
 # limitations under the License.
 #
 
-baseUrl=http://${demo.pnc.ip.address}/pnc-rest/rest
+baseUrl=/pnc-rest/rest

--- a/web/src/main/webapp/apidocs/index.html
+++ b/web/src/main/webapp/apidocs/index.html
@@ -58,7 +58,7 @@ ${enable.security.end} -->
   <script type="text/javascript">
     $(function () {
       window.swaggerUi = new SwaggerUi({
-      url: "http://${demo.pnc.ip.address}/pnc-rest/rest/api-docs",
+      url: "/pnc-rest/rest/api-docs",
       dom_id: "swagger-ui-container",
       supportedSubmitMethods: ['get', 'post', 'put', 'delete'],
       onComplete: function(swaggerApi, swaggerUi){


### PR DESCRIPTION
Right now when viewing Swagger documentation from a local deployment, the documentation will try to execute commands to ${demo.pnc.ip.address}, when what we would like to do is execute commands to localhost so that we do not mess up with the demo server, or suffer from CORS.

This commit attempts to fix this by setting the links relative to the base url.