### PR TITLE
Get the right BC id (instead of the wrong project id) in validateBefo…

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProvider.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProvider.java
@@ -177,7 +177,7 @@ public class BuildConfigurationProvider {
 
         //don't validate against myself
         if(buildConfigurationFromDB != null && !buildConfigurationFromDB.getId().equals(buildConfigurationRest.getId())) {
-            throw new  ConflictedEntryException("Configuration with the same name already exists within project", BuildConfiguration.class, buildConfigurationRest.getProjectId());
+            throw new  ConflictedEntryException("Configuration with the same name already exists within project", BuildConfiguration.class, buildConfigurationFromDB.getId());
         }
     }
 


### PR DESCRIPTION
When BC conflicts, it returns wrong conflict Id. Looks like it returns project id instead of BC id. 