### PR TITLE
Fix triggerBuilds to return correct taskId

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/trigger/BuildTriggerer.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/trigger/BuildTriggerer.java
@@ -130,7 +130,7 @@ public class BuildTriggerer {
             buildRecordSet.setPerformedInProductMilestone(productVersion.getCurrentProductMilestone());
         }
 
-        Integer taskId = buildCoordinator.build(configuration, currentUser).getBuildConfiguration().getId();
+        Integer taskId = buildCoordinator.build(configuration, currentUser).getId();
         return taskId;
     }
 


### PR DESCRIPTION
I find /build-configurations/{id}/build callbackUrl does not work. After debugging into it, I find the culprit is in triggerBuilds which returns the configuration Id instead of taskId. 