### PR TITLE
BuildCoordinator.shutdown() should also shutdown the dbexecutor

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/core/builder/BuildCoordinator.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/core/builder/BuildCoordinator.java
@@ -442,5 +442,6 @@ public class BuildCoordinator {
 
     public void shutdownCoordinator(){
         executor.shutdown();
+        dbexecutorSingleThread.shutdown();
     }
 }


### PR DESCRIPTION
Need to shutdown all executors to end the java process.