### PR TITLE
[NCL-1137] Fix the entity relations and transaction scopes related to…

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/core/builder/BuildCoordinator.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/core/builder/BuildCoordinator.java
@@ -162,7 +162,7 @@ public class BuildCoordinator {
                     topContentId,
                     buildSetContentId,
                     buildContentId,
-                    BuildExecutionType.COMPOSED_BUILD,
+                    buildSetTask.getBuildTaskType(),
                     buildSetTask.getBuildConfigSetRecord().getUser(),
                     buildSetTask,
                     datastoreAdapter.getNextBuildRecordId());
@@ -290,6 +290,7 @@ public class BuildCoordinator {
     private RunningBuild buildSetUp(BuildTask buildTask, RunningEnvironment runningEnvironment) {
         buildTask.setStatus(BuildStatus.BUILD_SETTING_UP);
         try {
+            buildTask.setStartTime(new Date());
             BuildDriver buildDriver = buildDriverFactory.getBuildDriver(buildTask.getBuildConfigurationAudited().getEnvironment().getBuildType());
             return buildDriver.startProjectBuild(buildTask, buildTask.getBuildConfigurationAudited(), runningEnvironment);
         } catch (Throwable e) {
@@ -318,6 +319,7 @@ public class BuildCoordinator {
     }
 
     private BuildDriverResult retrieveBuildDriverResults(BuildTask buildTask, CompletedBuild completedBuild) {
+        buildTask.setEndTime(new Date());
         buildTask.setStatus(BuildStatus.COLLECTING_RESULTS_FROM_BUILD_DRIVER);
         try {
             BuildDriverResult buildResult = completedBuild.getBuildResult();

--- a/build-coordinator/src/main/java/org/jboss/pnc/core/builder/BuildSetTask.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/core/builder/BuildSetTask.java
@@ -21,7 +21,6 @@ import org.jboss.pnc.core.events.DefaultBuildSetStatusChangedEvent;
 import org.jboss.pnc.core.exception.CoreException;
 import org.jboss.pnc.model.BuildConfigSetRecord;
 import org.jboss.pnc.model.BuildConfiguration;
-import org.jboss.pnc.model.BuildConfigurationAudited;
 import org.jboss.pnc.model.BuildConfigurationSet;
 import org.jboss.pnc.model.ProductMilestone;
 import org.jboss.pnc.spi.BuildExecutionType;
@@ -65,6 +64,7 @@ public class BuildSetTask {
         this.buildCoordinator = buildCoordinator;
         this.buildConfigSetRecord = buildConfigSetRecord;
         this.buildTaskType = buildTaskType;
+        System.out.println("setting product milestone: " + productMilestone);
         this.productMilestone = productMilestone;
         this.buildSetStatusChangedEventNotifier = buildCoordinator.getBuildSetStatusChangedEventNotifier();
         setStatus(BuildSetStatus.NEW);
@@ -138,7 +138,7 @@ public class BuildSetTask {
      * @return The build task with the matching configuration, or null if there is none
      */
     public BuildTask getBuildTask(BuildConfiguration buildConfig) {
-        return buildTasks.stream().filter((bt) -> bt.getBuildRecord().getLatestBuildConfiguration().equals(buildConfig)).findFirst().orElse(null);
+        return buildTasks.stream().filter((bt) -> bt.getBuildConfiguration().equals(buildConfig)).findFirst().orElse(null);
     }
 
     public Integer getId() {

--- a/build-coordinator/src/test/java/org/jboss/pnc/core/test/buildCoordinator/ReadDependenciesTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/core/test/buildCoordinator/ReadDependenciesTest.java
@@ -52,7 +52,7 @@ public class ReadDependenciesTest extends ProjectBuilder {
         }
 
         Assert.assertEquals("Missing build tasks in set.", 5, buildSetTask.getBuildTasks().size());
-        BuildTask buildTask2 = buildSetTask.getBuildTasks().stream().filter(task -> task.getBuildRecord().getLatestBuildConfiguration().getId().equals(2)).findFirst().get();
+        BuildTask buildTask2 = buildSetTask.getBuildTasks().stream().filter(task -> task.getBuildConfiguration().getId().equals(2)).findFirst().get();
         Assert.assertEquals("Wrong number of dependencies.", 2, buildTask2.getDependencies().size());
     }
 }

--- a/build-coordinator/src/test/java/org/jboss/pnc/core/test/mock/DatastoreMock.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/core/test/mock/DatastoreMock.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
@@ -54,7 +55,7 @@ public class DatastoreMock implements Datastore {
     AtomicInteger buildConfigAuditedRevSequence = new AtomicInteger(0);
 
     @Override
-    public BuildRecord storeCompletedBuild(BuildRecord buildRecord) {
+    public BuildRecord storeCompletedBuild(BuildRecord buildRecord, Set<Integer> buildRecordSetIds ) {
         log.info("Storing build " + buildRecord.getLatestBuildConfiguration());
         buildRecords.add(buildRecord);
         return buildRecord;

--- a/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildRecordRest.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildRecordRest.java
@@ -76,9 +76,9 @@ public class BuildRecordRest {
 
     public BuildRecordRest(BuildTask buildTask) {
         this.id = buildTask.getId();
-        BuildConfiguration buildConfiguration = buildTask.getBuildRecord().getLatestBuildConfiguration();
+        BuildConfiguration buildConfiguration = buildTask.getBuildConfiguration();
         this.startTime = buildConfiguration.getCreationTime();
-        performIfNotNull(buildTask.getBuildRecord().getLatestBuildConfiguration() != null && buildConfiguration != null,
+        performIfNotNull(buildTask.getBuildConfiguration() != null && buildConfiguration != null,
                 () -> buildConfigurationId = buildConfiguration.getId());
         this.status = BuildStatus.BUILDING;
         buildTask.getLogsWebSocketLink().ifPresent(logsUri -> this.liveLogsUri = logsUri.toString());

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/Datastore.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/Datastore.java
@@ -17,6 +17,8 @@
  */
 package org.jboss.pnc.spi.datastore;
 
+import java.util.Set;
+
 import org.jboss.pnc.model.BuildConfigSetRecord;
 import org.jboss.pnc.model.BuildConfigurationAudited;
 import org.jboss.pnc.model.BuildRecord;
@@ -33,7 +35,7 @@ public interface Datastore {
      * @param buildRecord Completed BuildRecord.
      * @throws DatastoreException Thrown if database is unable to process the request.
      */
-    BuildRecord storeCompletedBuild(BuildRecord buildRecord) throws DatastoreException;
+    BuildRecord storeCompletedBuild(BuildRecord buildRecord, Set<Integer> buildRecordSetIds) throws DatastoreException;
 
     /**
      * Returns User upon its username.

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuildRecordSetPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuildRecordSetPredicates.java
@@ -23,6 +23,8 @@ import org.jboss.pnc.model.BuildRecordSet_;
 import org.jboss.pnc.model.ProductMilestone;
 import org.jboss.pnc.spi.datastore.repositories.api.Predicate;
 
+import java.util.Set;
+
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.ListJoin;
 
@@ -43,5 +45,19 @@ public class BuildRecordSetPredicates {
             Join<BuildRecordSet, BuildRecord> buildRecords = root.join(BuildRecordSet_.buildRecords);
             return cb.equal(buildRecords.get(org.jboss.pnc.model.BuildRecord_.id), buildRecordId);
         };
+    }
+
+    /**
+     * Find the BuildRecordSets with an ID contained in the given set.
+     * @param buildRecordSetIds The set of IDs to search
+     * @return The collection of matching BuildRecordSets
+     */
+    public static Predicate<BuildRecordSet> withBuildRecordSetIdInSet(Set<Integer> buildRecordSetIds) {
+        if (buildRecordSetIds.isEmpty()) {
+            // return an always false predicate if there are no build config ids
+            return (root, query, cb) -> cb.disjunction();
+        } else {
+            return (root, query, cb) -> root.get(BuildRecordSet_.id).in(buildRecordSetIds);
+        }
     }
 }


### PR DESCRIPTION
… saving BuildRecords

- Reverse the entity ownership relation between build records and build record sets
- Set the start and end time of a build closer to when the build actually runs, instead of when the build coordinator task starts and ends.
- Make the DatastoreAdapter transactional so that it can fetch up to date entities which are related to the BuildRecord