### PR TITLE
BuildCoordinator.shutdown() should also shutdown the dbexecutor

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/core/builder/BuildCoordinator.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/core/builder/BuildCoordinator.java
@@ -469,5 +469,6 @@ public class BuildCoordinator {
 
     public void shutdownCoordinator(){
         executor.shutdown();
+        dbexecutorSingleThread.shutdown();
     }
 }


### PR DESCRIPTION
Improvement from ahmedlawi92, just rebasing for merge since it's been in the queue for a while.