### PR TITLE
The Build Configurations list show duplicate project

### DIFF
--- a/ui/app/configuration/views/configuration.list.html
+++ b/ui/app/configuration/views/configuration.list.html
@@ -48,7 +48,7 @@
         </td>
         <td>{{ configuration.description }}</td>
         <td>
-          <div ng-repeat="project in listCtrl.projects | filter: { id: configuration.projectId }">
+          <div ng-repeat="project in listCtrl.projects | filter: { id: configuration.projectId } | limitTo: 1">
             {{ project.name }}
           </div>
         </td>


### PR DESCRIPTION
When a user adds several build configurations with the same project, the
project name gets duplicated several times when viewing the list of
build configurations.

http://localhost:8080/pnc-web/#/configuration

This happens because the frontend will loop through the build
configurations, grab the project information for the project id
associated with each build configuration, and add the project
information to a list.

If two build configurations have the same project id, there will be
duplicates of the project info in that list. The duplicates will show up
in the UI.

This commit attempts to fix the duplication by simply adding a 'limitTo'
to the `ng-repeat` command so that the duplicates do not show up.

However, a better fix would be to use a set to store those project info
so that we are guaranteed that there are no duplicates. However there
are no built-in set data structure in ES5 right now.