### PR TITLE
Add response class to Swagger documentation

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigSetRecordEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigSetRecordEndpoint.java
@@ -53,7 +53,8 @@ public class BuildConfigSetRecordEndpoint {
         this.buildRecordProvider = buildRecordProvider;
     }
 
-    @ApiOperation(value = "Gets all build config set execution records")
+    @ApiOperation(value = "Gets all build config set execution records", responseContainer = "List",
+            response = BuildConfigSetRecordRest.class)
     @GET
     public List<BuildConfigSetRecordRest> getAll(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
@@ -63,14 +64,15 @@ public class BuildConfigSetRecordEndpoint {
         return buildConfigSetRecordProvider.getAll(pageIndex, pageSize, sortingRsql, rsql);
     }
 
-    @ApiOperation(value = "Gets specific build config set execution record")
+    @ApiOperation(value = "Gets specific build config set execution record", response = BuildConfigSetRecordRest.class)
     @GET
     @Path("/{id}")
     public Response getSpecific(@ApiParam(value = "BuildConfigSetRecord id", required = true) @PathParam("id") Integer id) {
         return Utility.createRestEnityResponse(buildConfigSetRecordProvider.getSpecific(id), id);
     }
 
-    @ApiOperation(value = "Gets the build records associated with this set")
+    @ApiOperation(value = "Gets the build records associated with this set",
+            responseContainer = "List", response = BuildRecordRest.class)
     @GET
     @Path("/{id}/build-records")
     public List<BuildRecordRest> getBuildRecords(

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
@@ -22,12 +22,14 @@ import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
 import org.jboss.pnc.auth.AuthenticationProvider;
 import org.jboss.pnc.core.exception.CoreException;
+import org.jboss.pnc.model.BuildConfigurationAudited;
 import org.jboss.pnc.model.User;
 import org.jboss.pnc.rest.provider.BuildConfigurationProvider;
 import org.jboss.pnc.rest.provider.BuildRecordProvider;
 import org.jboss.pnc.rest.provider.ConflictedEntryException;
 import org.jboss.pnc.rest.restmodel.BuildConfigurationAuditedRest;
 import org.jboss.pnc.rest.restmodel.BuildConfigurationRest;
+import org.jboss.pnc.rest.restmodel.BuildRecordRest;
 import org.jboss.pnc.rest.restmodel.ProductVersionRest;
 import org.jboss.pnc.rest.trigger.BuildTriggerer;
 import org.jboss.pnc.rest.utils.Utility;
@@ -75,7 +77,8 @@ public class BuildConfigurationEndpoint {
         this.buildRecordProvider = buildRecordProvider;
     }
 
-    @ApiOperation(value = "Gets all Build Configurations")
+    @ApiOperation(value = "Gets all Build Configurations",
+            responseContainer = "List", response = BuildConfigurationRest.class)
     @GET
     public List<BuildConfigurationRest> getAll(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
@@ -85,7 +88,7 @@ public class BuildConfigurationEndpoint {
         return buildConfigurationProvider.getAll(pageIndex, pageSize, sortingRsql, rsql);
     }
 
-    @ApiOperation(value = "Creates a new Build Configuration")
+    @ApiOperation(value = "Creates a new Build Configuration", response = BuildConfigurationRest.class)
     @POST
     public Response createNew(@NotNull @Valid BuildConfigurationRest buildConfigurationRest, @Context UriInfo uriInfo) throws ConflictedEntryException {
         int id = buildConfigurationProvider.store(buildConfigurationRest);
@@ -93,7 +96,7 @@ public class BuildConfigurationEndpoint {
         return Response.created(uriBuilder.build(id)).entity(buildConfigurationProvider.getSpecific(id)).build();
     }
 
-    @ApiOperation(value = "Gets a specific Build Configuration")
+    @ApiOperation(value = "Gets a specific Build Configuration", response = BuildConfigurationRest.class)
     @GET
     @Path("/{id}")
     public Response getSpecific(
@@ -117,7 +120,7 @@ public class BuildConfigurationEndpoint {
         return Response.ok().build();
     }
 
-    @ApiOperation(value = "Clones an existing Build Configuration")
+    @ApiOperation(value = "Clones an existing Build Configuration", response = BuildConfigurationRest.class)
     @POST
     @Path("/{id}/clone")
     public Response clone(@ApiParam(value = "Build Configuration id", required = true) @PathParam("id") Integer id,
@@ -170,7 +173,8 @@ public class BuildConfigurationEndpoint {
         }
     }
 
-    @ApiOperation(value = "Gets all Build Configurations of a Project")
+    @ApiOperation(value = "Gets all Build Configurations of a Project",
+            responseContainer = "List", response = BuildConfigurationRest.class)
     @GET
     @Path("/projects/{projectId}")
     public List<BuildConfigurationRest> getAllByProjectId(
@@ -182,7 +186,8 @@ public class BuildConfigurationEndpoint {
         return buildConfigurationProvider.getAllForProject(pageIndex, pageSize, sortingRsql, rsql, projectId);
     }
 
-    @ApiOperation(value = "Gets all Build Configurations of a Product")
+    @ApiOperation(value = "Gets all Build Configurations of a Product",
+            responseContainer = "List", response = BuildConfigurationRest.class)
     @GET
     @Path("/products/{productId}")
     public List<BuildConfigurationRest> getAllByProductId(
@@ -194,7 +199,8 @@ public class BuildConfigurationEndpoint {
         return buildConfigurationProvider.getAllForProduct(pageIndex, pageSize, sortingRsql, rsql, productId);
     }
 
-    @ApiOperation(value = "Gets all Build Configurations of the Specified Product Version")
+    @ApiOperation(value = "Gets all Build Configurations of the Specified Product Version",
+            responseContainer = "List", response = BuildConfigurationRest.class)
     @GET
     @Path("/products/{productId}/product-versions/{versionId}")
     public List<BuildConfigurationRest> getAllByProductId(
@@ -207,14 +213,16 @@ public class BuildConfigurationEndpoint {
         return buildConfigurationProvider.getAllForProductAndProductVersion(pageIndex, pageSize, sortingRsql, rsql, productId, versionId);
     }
 
-    @ApiOperation(value = "Get the direct dependencies of the specified configuration")
+    @ApiOperation(value = "Get the direct dependencies of the specified configuration",
+            responseContainer = "List", response = BuildConfigurationRest.class)
     @GET
     @Path("/{id}/dependencies")
     public Set<BuildConfigurationRest> getDependencies(@ApiParam(value = "Build configuration id", required = true) @PathParam("id") Integer id) {
         return buildConfigurationProvider.getDependencies(id);
     }
 
-    @ApiOperation(value = "Get the full list of both direct and indirect dependencies of the specified configuration")
+    @ApiOperation(value = "Get the full list of both direct and indirect dependencies of the specified configuration",
+            responseContainer = "List", response = BuildConfigurationRest.class)
     @GET
     @Path("/{id}/all-dependencies")
     public Set<BuildConfigurationRest> getAllDependencies(@ApiParam(value = "Build configuration id", required = true) @PathParam("id") Integer id) {
@@ -240,7 +248,8 @@ public class BuildConfigurationEndpoint {
         return Response.ok().build();
     }
 
-    @ApiOperation(value = "Get associated Product Versions of the specified Configuration")
+    @ApiOperation(value = "Get associated Product Versions of the specified Configuration",
+            responseContainer = "List", response = ProductVersionRest.class)
     @GET
     @Path("/{id}/product-versions")
     public List<ProductVersionRest> getProductVersions(@ApiParam(value = "Build configuration id", required = true) @PathParam("id") Integer id) {
@@ -267,14 +276,16 @@ public class BuildConfigurationEndpoint {
         return Response.ok().build();
     }
 
-    @ApiOperation(value = "Gets audited revisions of this build configuration")
+    @ApiOperation(value = "Gets audited revisions of this build configuration",
+            responseContainer = "List", response = BuildConfigurationAuditedRest.class)
     @GET
     @Path("/{id}/revisions")
     public List<BuildConfigurationAuditedRest> getRevisions(@ApiParam(value = "Build configuration id", required = true) @PathParam("id") Integer id) {
         return buildConfigurationProvider.getRevisions(id);
     }
 
-    @ApiOperation(value = "Get specific audited revision of this build configuration")
+    @ApiOperation(value = "Get specific audited revision of this build configuration",
+            response = BuildConfigurationAuditedRest.class)
     @GET
     @Path("/{id}/revisions/{rev}")
     public Response getRevision(@ApiParam(value = "Build configuration id", required = true) @PathParam("id") Integer id,
@@ -286,7 +297,8 @@ public class BuildConfigurationEndpoint {
         return Response.ok(buildConfigAudited).build();
     }
 
-    @ApiOperation(value = "Get all build record associated with this build configuration, returns empty list if no build records are found")
+    @ApiOperation(value = "Get all build record associated with this build configuration, returns empty list if no build records are found",
+            responseContainer = "List", response = BuildRecordRest.class)
     @GET
     @Path("/{id}/build-records")
     public Response getBuildRecords(
@@ -298,7 +310,8 @@ public class BuildConfigurationEndpoint {
         return buildConfigurationProvider.getBuildRecords(pageIndex, pageSize, sortingRsql, rsql, id);
     }
 
-    @ApiOperation(value = "Get latest build record associated with this build configuration, returns no content if no build records are found")
+    @ApiOperation(value = "Get latest build record associated with this build configuration, returns no content if no build records are found",
+            response = BuildRecordRest.class)
     @GET
     @Path("/{id}/build-records/latest")
     public Response getLatestBuildRecord(@ApiParam(value = "Build configuration id", required = true) @PathParam("id") Integer id) {

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationSetEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationSetEndpoint.java
@@ -73,7 +73,8 @@ public class BuildConfigurationSetEndpoint {
         this.buildTriggerer = buildTriggerer;
     }
 
-    @ApiOperation(value = "Gets all Build Configuration Sets")
+    @ApiOperation(value = "Gets all Build Configuration Sets",
+            responseContainer = "List", response = BuildConfigurationSetRest.class)
     @GET
     public List<BuildConfigurationSetRest> getAll(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
@@ -84,7 +85,7 @@ public class BuildConfigurationSetEndpoint {
         return buildConfigurationSetProvider.getAll(pageIndex, pageSize, sortingRsql, rsql);
     }
 
-    @ApiOperation(value = "Creates a new Build Configuration Set")
+    @ApiOperation(value = "Creates a new Build Configuration Set", response = BuildConfigurationSetRest.class)
     @POST
     public Response createNew(@NotNull @Valid BuildConfigurationSetRest buildConfigurationSetRest, @Context UriInfo uriInfo)
             throws ConflictedEntryException {
@@ -93,7 +94,7 @@ public class BuildConfigurationSetEndpoint {
         return Response.created(uriBuilder.build(id)).entity(buildConfigurationSetProvider.getSpecific(id)).build();
     }
 
-    @ApiOperation(value = "Gets a specific Build Configuration Set")
+    @ApiOperation(value = "Gets a specific Build Configuration Set", response = BuildConfigurationSetRest.class)
     @GET
     @Path("/{id}")
     public Response getSpecific(
@@ -119,7 +120,8 @@ public class BuildConfigurationSetEndpoint {
         return Response.ok().build();
     }
 
-    @ApiOperation(value = "Gets the Configurations for the Specified Set")
+    @ApiOperation(value = "Gets the Configurations for the Specified Set",
+            responseContainer = "List", response = BuildConfigurationRest.class)
     @GET
     @Path("/{id}/build-configurations")
     public List<BuildConfigurationRest> getConfigurations(
@@ -190,7 +192,8 @@ public class BuildConfigurationSetEndpoint {
         return Response.ok().build();
     }
 
-    @ApiOperation(value = "Gets all build records associated with the contained build configurations")
+    @ApiOperation(value = "Gets all build records associated with the contained build configurations",
+            responseContainer = "List", response = BuildRecordRest.class)
     @GET
     @Path("/{id}/build-records")
     public List<BuildRecordRest> getBuildRecords(

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildRecordEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildRecordEndpoint.java
@@ -20,6 +20,7 @@ package org.jboss.pnc.rest.endpoint;
 import org.jboss.pnc.rest.provider.ArtifactProvider;
 import org.jboss.pnc.rest.provider.BuildRecordProvider;
 import org.jboss.pnc.rest.restmodel.ArtifactRest;
+import org.jboss.pnc.rest.restmodel.BuildConfigurationAuditedRest;
 import org.jboss.pnc.rest.restmodel.BuildRecordRest;
 import org.jboss.pnc.rest.utils.Utility;
 
@@ -62,7 +63,7 @@ public class BuildRecordEndpoint {
         this.artifactProvider = artifactProvider;
     }
 
-    @ApiOperation(value = "Gets all Build Records")
+    @ApiOperation(value = "Gets all Build Records", responseContainer = "List", response = BuildRecordRest.class)
     @GET
     public List<BuildRecordRest> getAll(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
@@ -72,7 +73,7 @@ public class BuildRecordEndpoint {
         return buildRecordProvider.getAllArchived(pageIndex, pageSize, sortingRsql, rsql);
     }
 
-    @ApiOperation(value = "Gets specific Build Record")
+    @ApiOperation(value = "Gets specific Build Record", response = BuildRecordRest.class)
     @GET
     @Path("/{id}")
     public Response getSpecific(@ApiParam(value = "BuildRecord id", required = true) @PathParam("id") Integer id) {
@@ -84,7 +85,7 @@ public class BuildRecordEndpoint {
             @ApiResponse(code = 204, message = "BuildRecord exists, but the content is empty"),
             @ApiResponse(code = 404, message = "BuildRecord with specified id does not exist"),
     })
-    @ApiOperation(value = "Gets logs for specific Build Record")
+    @ApiOperation(value = "Gets logs for specific Build Record", response = String.class)
     @GET
     @Path("/{id}/log")
     @Produces(MediaType.TEXT_PLAIN)
@@ -99,7 +100,8 @@ public class BuildRecordEndpoint {
             return Response.ok(buildRecordProvider.getLogsForBuild(buildRecordLog)).build();
     }
 
-    @ApiOperation(value = "Gets artifacts for specific Build Record")
+    @ApiOperation(value = "Gets artifacts for specific Build Record",
+            responseContainer = "List", response = ArtifactRest.class)
     @GET
     @Path("/{id}/artifacts")
     public List<ArtifactRest> getArtifacts(
@@ -116,7 +118,8 @@ public class BuildRecordEndpoint {
      * Use /build-configuration/{id}/build-records
      */
     @Deprecated
-    @ApiOperation(value = "Gets the Build Records linked to a specific Build Configuration")
+    @ApiOperation(value = "Gets the Build Records linked to a specific Build Configuration",
+            responseContainer = "List", response = BuildRecordRest.class)
     @GET
     @Path("/build-configurations/{configurationId}")
     public List<BuildRecordRest> getAllForBuildConfiguration(
@@ -128,7 +131,8 @@ public class BuildRecordEndpoint {
         return buildRecordProvider.getAllForBuildConfiguration(pageIndex, pageSize, sortingRsql, rsql, configurationId);
     }
 
-    @ApiOperation(value = "Gets the Build Records linked to a specific Project")
+    @ApiOperation(value = "Gets the Build Records linked to a specific Project",
+            responseContainer = "List", response = BuildRecordRest.class)
     @GET
     @Path("/projects/{projectId}")
     public List<BuildRecordRest> getAllForProject(
@@ -140,7 +144,8 @@ public class BuildRecordEndpoint {
         return buildRecordProvider.getAllForProject(pageIndex, pageSize, sortingRsql, rsql, projectId);
     }
 
-    @ApiOperation(value = "Gets the audited build configuration for specific build record")
+    @ApiOperation(value = "Gets the audited build configuration for specific build record",
+            response = BuildConfigurationAuditedRest.class)
     @GET
     @Path("/{id}/build-configuration-audited")
     public Response getBuildConfigurationAudited(@ApiParam(value = "BuildRecord id", required = true) @PathParam("id") Integer id) {

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildRecordSetEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildRecordSetEndpoint.java
@@ -50,7 +50,8 @@ public class BuildRecordSetEndpoint {
         this.buildRecordSetProvider = buildRecordSetProvider;
     }
 
-    @ApiOperation(value = "Gets all BuildRecordSets")
+    @ApiOperation(value = "Gets all BuildRecordSets",
+            responseContainer = "List", response = BuildRecordSetRest.class)
     @GET
     public List<BuildRecordSetRest> getAll(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
@@ -60,14 +61,15 @@ public class BuildRecordSetEndpoint {
         return buildRecordSetProvider.getAll(pageIndex, pageSize, sortingRsql, rsql);
     }
 
-    @ApiOperation(value = "Gets a specific BuildRecordSet")
+    @ApiOperation(value = "Gets a specific BuildRecordSet", response = BuildRecordSetRest.class)
     @GET
     @Path("/{id}")
     public Response getSpecific(@ApiParam(value = "BuildRecordSet id", required = true) @PathParam("id") Integer id) {
         return Utility.createRestEnityResponse(buildRecordSetProvider.getSpecific(id), id);
     }
 
-    @ApiOperation(value = "Gets all BuildRecordSet of a Product Version")
+    @ApiOperation(value = "Gets all BuildRecordSet of a Product Version",
+            responseContainer = "List", response = BuildRecordSetRest.class)
     @GET
     @Path("/product-milestones/{versionId}")
     public List<BuildRecordSetRest> getAllForProductMilestone(
@@ -79,7 +81,8 @@ public class BuildRecordSetEndpoint {
         return buildRecordSetProvider.getAllForPerformedInProductMilestone(pageIndex, pageSize, sortingRsql, rsql, versionId);
     }
 
-    @ApiOperation(value = "Gets all BuildRecordSet of a BuildRecord")
+    @ApiOperation(value = "Gets all BuildRecordSet of a BuildRecord",
+            responseContainer = "List", response = BuildRecordSetRest.class)
     @GET
     @Path("/build-records/{recordId}")
     public List<BuildRecordSetRest> getAllForBuildRecord(
@@ -91,7 +94,7 @@ public class BuildRecordSetEndpoint {
         return buildRecordSetProvider.getAllForBuildRecord(pageIndex, pageSize, sortingRsql, rsql, recordId);
     }
 
-    @ApiOperation(value = "Creates a new BuildRecordSet")
+    @ApiOperation(value = "Creates a new BuildRecordSet", response = BuildRecordSetRest.class)
     @POST
     public Response createNew(@NotNull @Valid BuildRecordSetRest buildRecordSetRest, @Context UriInfo uriInfo) {
         UriBuilder uriBuilder = UriBuilder.fromUri(uriInfo.getRequestUri()).path("{id}");

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/EnvironmentEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/EnvironmentEndpoint.java
@@ -50,7 +50,7 @@ public class EnvironmentEndpoint {
         this.environmentProvider = environmentProvider;
     }
 
-    @ApiOperation(value = "Gets all Environments")
+    @ApiOperation(value = "Gets all Environments", responseContainer = "List", response = EnvironmentRest.class)
     @GET
     public List<EnvironmentRest> getAll(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
@@ -60,14 +60,14 @@ public class EnvironmentEndpoint {
         return environmentProvider.getAll(pageIndex, pageSize, sortingRsql, rsql);
     }
 
-    @ApiOperation(value = "Get specific Environment")
+    @ApiOperation(value = "Get specific Environment", response = EnvironmentRest.class)
     @GET
     @Path("/{id}")
     public Response getSpecific(@ApiParam(value = "Environment id", required = true) @PathParam("id") Integer id) {
         return Utility.createRestEnityResponse(environmentProvider.getSpecific(id), id);
     }
 
-    @ApiOperation(value = "Creates a new Environment")
+    @ApiOperation(value = "Creates a new Environment", response = EnvironmentRest.class)
     @POST
     public Response createNew(@NotNull @Valid EnvironmentRest environmentRest, @Context UriInfo uriInfo) {
         int id = environmentProvider.store(environmentRest);

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/LicenseEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/LicenseEndpoint.java
@@ -53,7 +53,7 @@ public class LicenseEndpoint {
         this.licenseProvider = licenseProvider;
     }
 
-    @ApiOperation(value = "Gets all Licenses")
+    @ApiOperation(value = "Gets all Licenses", responseContainer = "List", response = LicenseRest.class)
     @GET
     public List<LicenseRest> getAll(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
@@ -63,14 +63,14 @@ public class LicenseEndpoint {
         return licenseProvider.getAll(pageIndex, pageSize, sortingRsql, rsql);
     }
 
-    @ApiOperation(value = "Get specific License")
+    @ApiOperation(value = "Get specific License", response = LicenseRest.class)
     @GET
     @Path("/{id}")
     public Response getSpecific(@ApiParam(value = "License id", required = true) @PathParam("id") Integer id) {
         return Utility.createRestEnityResponse(licenseProvider.getSpecific(id), id);
     }
 
-    @ApiOperation(value = "Creates a new License")
+    @ApiOperation(value = "Creates a new License", response = LicenseRest.class)
     @POST
     public Response createNew(@NotNull @Valid LicenseRest licenseRest, @Context UriInfo uriInfo) {
         int id = licenseProvider.store(licenseRest);

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductEndpoint.java
@@ -54,7 +54,7 @@ public class ProductEndpoint {
         this.productVersionProvider = productVersionProvider;
     }
 
-    @ApiOperation(value = "Gets all Products")
+    @ApiOperation(value = "Gets all Products", responseContainer = "List", response = ProductRest.class)
     @GET
     public List<ProductRest> getAll(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
@@ -64,14 +64,14 @@ public class ProductEndpoint {
         return productProvider.getAll(pageIndex, pageSize, sortingRsql, rsql);
     }
 
-    @ApiOperation(value = "Get specific Product")
+    @ApiOperation(value = "Get specific Product", response = ProductRest.class)
     @GET
     @Path("/{id}")
     public Response getSpecific(@ApiParam(value = "Product id", required = true) @PathParam("id") Integer id) {
         return Utility.createRestEnityResponse(productProvider.getSpecific(id), id);
     }
 
-    @ApiOperation(value = "Creates a new Product")
+    @ApiOperation(value = "Creates a new Product", response = ProductRest.class)
     @POST
     public Response createNew(@NotNull @Valid ProductRest productRest,
             @Context UriInfo uriInfo) {
@@ -89,7 +89,8 @@ public class ProductEndpoint {
         return Response.ok().build();
     }
 
-    @ApiOperation(value = "Get all versions for a Product")
+    @ApiOperation(value = "Get all versions for a Product",
+            responseContainer = "List", response = ProductVersionRest.class)
     @GET
     @Path("/{id}/product-versions")
     public List<ProductVersionRest> getProductVersions(@ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductMilestoneEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductMilestoneEndpoint.java
@@ -62,7 +62,8 @@ public class ProductMilestoneEndpoint {
         this.productMilestoneProvider = productMilestoneProvider;
     }
 
-    @ApiOperation(value = "Gets all Product Milestones")
+    @ApiOperation(value = "Gets all Product Milestones",
+            responseContainer = "List", response = ProductMilestoneRest.class)
     @GET
     public List<ProductMilestoneRest> getAll(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
@@ -72,7 +73,8 @@ public class ProductMilestoneEndpoint {
         return productMilestoneProvider.getAll(pageIndex, pageSize, sortingRsql, rsql);
     }
 
-    @ApiOperation(value = "Gets all Product Milestones of the Specified Product Version")
+    @ApiOperation(value = "Gets all Product Milestones of the Specified Product Version",
+            responseContainer = "List", response = ProductMilestoneRest.class)
     @GET
     @Path("/product-versions/{versionId}")
     public List<ProductMilestoneRest> getAllByProductVersionId(
@@ -85,7 +87,7 @@ public class ProductMilestoneEndpoint {
         return productMilestoneProvider.getAllForProductVersion(pageIndex, pageSize, sortingRsql, rsql, versionId);
     }
 
-    @ApiOperation(value = "Gets specific Product Milestone")
+    @ApiOperation(value = "Gets specific Product Milestone", response = ProductMilestoneRest.class)
     @GET
     @Path("/{id}")
     public Response getSpecific(
@@ -93,7 +95,8 @@ public class ProductMilestoneEndpoint {
         return Utility.createRestEnityResponse(productMilestoneProvider.getSpecific(id), id);
     }
 
-    @ApiOperation(value = "Creates a new Product Milestone for the Specified Product Version")
+    @ApiOperation(value = "Creates a new Product Milestone for the Specified Product Version",
+            response = ProductMilestoneRest.class)
     @POST
     public Response createNew(@NotNull @Valid ProductMilestoneRest productMilestoneRest, @Context UriInfo uriInfo) {
 

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductReleaseEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductReleaseEndpoint.java
@@ -64,7 +64,7 @@ public class ProductReleaseEndpoint {
         this.productReleaseProvider = productReleaseProvider;
     }
 
-    @ApiOperation(value = "Gets all Product Releases")
+    @ApiOperation(value = "Gets all Product Releases", responseContainer = "List", response = ProductReleaseRest.class)
     @GET
     public List<ProductReleaseRest> getAll(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
@@ -74,7 +74,8 @@ public class ProductReleaseEndpoint {
         return productReleaseProvider.getAll(pageIndex, pageSize, sortingRsql, rsql);
     }
 
-    @ApiOperation(value = "Gets all Product Releases of the Specified Product Version")
+    @ApiOperation(value = "Gets all Product Releases of the Specified Product Version",
+            responseContainer = "List", response = ProductReleaseRest.class)
     @GET
     @Path("/product-versions/{versionId}")
     public List<ProductReleaseRest> getAllByProductVersionId(
@@ -87,14 +88,14 @@ public class ProductReleaseEndpoint {
         return productReleaseProvider.getAllForProductVersion(pageIndex, pageSize, sortingRsql, rsql, versionId);
     }
 
-    @ApiOperation(value = "Gets specific Product Release")
+    @ApiOperation(value = "Gets specific Product Release", response = ProductReleaseRest.class)
     @GET
     @Path("/{id}")
     public Response getSpecific(@ApiParam(value = "Product Release id", required = true) @PathParam("id") Integer id) {
         return Utility.createRestEnityResponse(productReleaseProvider.getSpecific(id), id);
     }
 
-    @ApiOperation(value = "Creates a new Product Release")
+    @ApiOperation(value = "Creates a new Product Release", response = ProductReleaseRest.class)
     @POST
     public Response createNew(
             @NotNull @Valid ProductReleaseRest productReleaseRest, @Context UriInfo uriInfo) {
@@ -113,7 +114,8 @@ public class ProductReleaseEndpoint {
         return Response.ok().build();
     }
 
-    @ApiOperation(value = "Gets all Product Releases Support Level")
+    @ApiOperation(value = "Gets all Product Releases Support Level",
+            responseContainer = "List", response = SupportLevel.class)
     @GET
     @Path("/support-level")
     public List<SupportLevel> getAllSupportLevel () {

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductVersionEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductVersionEndpoint.java
@@ -51,7 +51,7 @@ public class ProductVersionEndpoint {
         this.productVersionProvider = productVersionProvider;
     }
 
-    @ApiOperation(value = "Gets all Product Versions")
+    @ApiOperation(value = "Gets all Product Versions", responseContainer = "List", response = ProductVersionRest.class)
     @GET
     public List<ProductVersionRest> getAll(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
@@ -61,7 +61,7 @@ public class ProductVersionEndpoint {
         return productVersionProvider.getAll(pageIndex, pageSize, sortingRsql, rsql);
     }
 
-    @ApiOperation(value = "Gets specific Product Version")
+    @ApiOperation(value = "Gets specific Product Version", response = ProductVersionRest.class)
     @GET
     @Path("/{id}")
     public Response getSpecific(
@@ -78,7 +78,8 @@ public class ProductVersionEndpoint {
         return Response.ok().build();
     }
 
-    @ApiOperation(value = "Gets build configuration sets associated with a product version")
+    @ApiOperation(value = "Gets build configuration sets associated with a product version",
+            responseContainer = "List", response = BuildConfigurationSetRest.class)
     @GET
     @Path("/{id}/build-configuration-sets")
     public List<BuildConfigurationSetRest> getBuildConfigurationSets(
@@ -90,7 +91,7 @@ public class ProductVersionEndpoint {
         return productVersionProvider.getBuildConfigurationSets(id);
     }
 
-    @ApiOperation(value = "Create a new ProductVersion for a Product")
+    @ApiOperation(value = "Create a new ProductVersion for a Product", response = ProductVersionRest.class)
     @POST
     public Response createNewProductVersion(@NotNull @Valid ProductVersionRest productVersionRest, @Context UriInfo uriInfo){
         int productVersionId = productVersionProvider.store(productVersionRest);

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/ProjectEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/ProjectEndpoint.java
@@ -50,7 +50,7 @@ public class ProjectEndpoint {
         this.projectProvider = projectProvider;
     }
 
-    @ApiOperation(value = "Gets all Projects")
+    @ApiOperation(value = "Gets all Projects", responseContainer = "List", response = ProjectRest.class)
     @GET
     public List<ProjectRest> getAll(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
@@ -60,14 +60,14 @@ public class ProjectEndpoint {
         return projectProvider.getAll(pageIndex, pageSize, sortingRsql, rsql);
     }
 
-    @ApiOperation(value = "Gets specific Project")
+    @ApiOperation(value = "Gets specific Project", response = ProjectRest.class)
     @GET
     @Path("/{id}")
     public Response getSpecific(@ApiParam(value = "Project id", required = true) @PathParam("id") Integer id) {
         return Utility.createRestEnityResponse(projectProvider.getSpecific(id), id);
     }
 
-    @ApiOperation(value = "Creates a new Project")
+    @ApiOperation(value = "Creates a new Project", response = ProjectRest.class)
     @POST
     public Response createNew(@NotNull @Valid ProjectRest projectRest, @Context UriInfo uriInfo)
             throws ConflictedEntryException {

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/RunningBuildRecordEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/RunningBuildRecordEndpoint.java
@@ -52,7 +52,7 @@ public class RunningBuildRecordEndpoint {
             @ApiResponse(code = 200, message = "Successful retrieval all RunningBuildRecords"),
             @ApiResponse(code = 204, message = "No RunningBuildRecords available"),
     })
-    @ApiOperation(value = "Gets all running Build Records")
+    @ApiOperation(value = "Gets all running Build Records", responseContainer = "List", response = BuildRecordRest.class)
     @GET
     public List<BuildRecordRest> getAll(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") Integer pageIndex,
@@ -62,7 +62,7 @@ public class RunningBuildRecordEndpoint {
         return buildRecordProvider.getAllRunning(pageIndex, pageSize, sortingRsql, rsql);
     }
 
-    @ApiOperation(value = "Gets specific running Build Record")
+    @ApiOperation(value = "Gets specific running Build Record", response = BuildRecordRest.class)
     @GET
     @Path("/{id}")
     public Response getSpecific(@ApiParam(value = "BuildRecord id", required = true) @PathParam("id") Integer id) {

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/UserEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/UserEndpoint.java
@@ -49,7 +49,7 @@ public class UserEndpoint {
         this.userProvider = userProvider;
     }
 
-    @ApiOperation(value = "Gets all Users")
+    @ApiOperation(value = "Gets all Users", responseContainer = "List", response = UserRest.class)
     @GET
     public List<UserRest> getAll(
             @ApiParam(value = "Page index") @QueryParam("pageIndex") @DefaultValue("0") int pageIndex,
@@ -59,14 +59,14 @@ public class UserEndpoint {
         return userProvider.getAll(pageIndex, pageSize, sortingRsql, rsql);
     }
 
-    @ApiOperation(value = "Gets specific User")
+    @ApiOperation(value = "Gets specific User", response = UserRest.class)
     @GET
     @Path("/{id}")
     public Response getSpecific(@ApiParam(value = "User id", required = true) @PathParam("id") Integer id) {
         return Utility.createRestEnityResponse(userProvider.getSpecific(id), id);
     }
 
-    @ApiOperation(value = "Creates new User")
+    @ApiOperation(value = "Creates new User", response = UserRest.class)
     @POST
     public Response createNew(@NotNull @Valid UserRest userRest, @Context UriInfo uriInfo) {
         int id = userProvider.store(userRest);


### PR DESCRIPTION
When viewing the Swagger documentation, it can be useful to view the expected response JSON that we will receive from PNC REST endpoints.

This PR attempts to achieve this by defining the response class in the Swagger annotations.