### PR TITLE
Add UI Validation based on the models

### DIFF
--- a/ui/app/configuration/views/configuration.create.html
+++ b/ui/app/configuration/views/configuration.create.html
@@ -33,8 +33,9 @@
     <div class="form-group">
       <label for="input-project" class="col-sm-2 control-label">Project</label>
       <div class="col-sm-10">
-      <select ng-model="createCtrl.data.projectId">
-      <option ng-repeat="project in createCtrl.projects" value="{{ project.id }}">
+      <select ng-model="createCtrl.data.projectId" required>
+          <option value="">Select a Project</option>
+          <option ng-repeat="project in createCtrl.projects" value="{{ project.id }}">
             {{ project.name }}
           </option>
         </select>
@@ -72,7 +73,9 @@
     <div class="form-group">
       <label for="input-product" class="col-sm-2 control-label">Product</label>
       <div class="col-sm-10">
-        <select id="input-product" ng-model="createCtrl.products.selected" ng-options="product.name for product in createCtrl.products.all" ng-change="createCtrl.productVersions.update()"></select>
+        <select id="input-product" ng-model="createCtrl.products.selected" ng-options="product.name for product in createCtrl.products.all" ng-change="createCtrl.productVersions.update()">
+          <option value="">Select a Product</option>
+        </select>
       </div>
     </div>
 
@@ -100,8 +103,9 @@
       <div class="form-group">
         <label for="input-environment" class="col-sm-2 control-label">Environment</label>
         <div class="col-sm-10">
-        <select ng-model="createCtrl.data.environmentId">
-        <option ng-repeat="environment in createCtrl.environments" value="{{ environment.id }}">
+        <select ng-model="createCtrl.data.environmentId" required>
+          <option value="">Select an Environment</option>
+            <option ng-repeat="environment in createCtrl.environments" value="{{ environment.id }}">
               {{ environment.operationalSystem + ' / ' + environment.buildType }}
             </option>
           </select>

--- a/ui/app/milestone/views/milestone.create-update.html
+++ b/ui/app/milestone/views/milestone.create-update.html
@@ -34,10 +34,10 @@
       <div class="col-sm-10">
         <div class="input-group">
           <span class="input-group-addon">{{ milestoneCreateUpdateCtrl.productVersion.version }}.</span>
-          <input required id="input-version" class="form-control" name="version" ng-model="milestoneCreateUpdateCtrl.version" ng-pattern="/^[0-9]/">
+          <input required id="input-version" class="form-control" name="version" ng-model="milestoneCreateUpdateCtrl.version" pattern="^[0-9]+\.[\w]+$">
         </div>
         <span class="help-block" ng-show="milestoneForm.version.$error.required && !milestoneForm.version.$pristine">Required field.</span>
-        <span class="help-block" ng-show="milestoneForm.version.$error.pattern && !milestoneForm.version.$pristine">Version must start with a number.</span>
+        <span class="help-block" ng-show="milestoneForm.version.$error.pattern && !milestoneForm.version.$pristine">Version must start with a number, followed by a dot and then a qualifier (e.g ER1)</span>
       </div>
     </div>
 

--- a/ui/app/product/views/product.version.create.html
+++ b/ui/app/product/views/product.version.create.html
@@ -26,7 +26,8 @@
     <div class="form-group">
       <label for="input-version" class="col-sm-2 control-label">Version     <span class="pficon pficon-info" title="This represents a set of milestones and releases which correspond to a major.minor version of a product, i.e. 7.0"></span></label>
       <div class="col-sm-10">
-        <input id="input-version" class="form-control" name="version" ng-model="productVersionCreateCtrl.data.version" required>
+        <input id="input-version" class="form-control" name="version" ng-model="productVersionCreateCtrl.data.version" required pattern="^[0-9]+\.[0-9]+$">
+        <div ng-show="productVersionForm.version.$error.pattern">The version should consist of two numeric parts separated by a dot.</div>
       </div>
     </div>
 

--- a/ui/app/release/views/release.create-update.html
+++ b/ui/app/release/views/release.create-update.html
@@ -33,10 +33,10 @@
       <div class="col-sm-10">
         <div class="input-group">
           <span class="input-group-addon">{{ releaseCreateUpdateCtrl.productVersion.version }}.</span>
-          <input required id="input-version" class="form-control" name="version" ng-model="releaseCreateUpdateCtrl.version" ng-pattern="/^[0-9]/">
+          <input required id="input-version" class="form-control" name="version" ng-model="releaseCreateUpdateCtrl.version" pattern="^[0-9]+\.[\w]+$">
         </div>
         <span class="help-block" ng-show="releaseForm.version.$error.required && !releaseForm.version.$pristine">Required field.</span>
-        <span class="help-block" ng-show="releaseForm.version.$error.pattern && !releaseForm.version.$pristine">Version must start with a number.</span>
+        <span class="help-block" ng-show="releaseForm.version.$error.pattern && !releaseForm.version.$pristine">Version must start with a number, followed by a dot and then a qualifier (e.g GA)</span>
       </div>
     </div>
 


### PR DESCRIPTION
1. For the Configuration creation view:
   `ui/app/configuration/views/configuration.create.html`

   In `model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java`,
   the fields marked with `@NotNull` are marked as required in the
   web-ui (name, environment, and project)

2. For the Milestone creation view:
   `ui/app/milestone/views/milestone.create-update.html`

   In `model/src/main/java/org/jboss/pnc/model/ProductMilestone.java`,
   the regex validation for the version is reflected in the web-ui too.
   As such, the error message has been updated.
   `ng-pattern` is also changed to `pattern` since this seems to
   activate the regex UI validation.

3. For the Release creation view:
   `ui/app/release/views/release.create-update.html`

   Same explanation as 2. Model found in:
   `model/src/main/java/org/jboss/pnc/model/ProductRelease.java`

4. For the Product Version creation view:
   `ui/app/product/views/product.version.create.html`

   In `pnc/model/src/main/java/org/jboss/pnc/model/ProductVersion.java`,
   the 'version' field has a restriction of being required and have a
   regex validation. The web-ui already marks the version field as
   required, but lacks the regex validation. The regex validation is
   therefore added in the UI.