### PR TITLE
No need to show projects column on the projects view

### DIFF
--- a/ui/app/project/views/project.detail.html
+++ b/ui/app/project/views/project.detail.html
@@ -85,7 +85,6 @@
     <thead>
       <th>Name</th>
       <th>Description</th>
-      <th>Project</th>
       <th>SCM Repository</th>
       <th>SCM Revision</th>
       <th>Created</th>
@@ -100,7 +99,6 @@
           </a>
         </td>
         <td>{{ configuration.description }}</td>
-        <td>{{ configuration.projectId }}</td>
         <td>{{ configuration.scmRepoURL }}</td>
         <td>{{ configuration.scmRevision }}</td>
         <td>{{ configuration.creationTime | date:'medium'}}</td>


### PR DESCRIPTION
Right now we are showing the project id in the projects view in the list of build configurations.

Since we're already in the projects view, I believe it's redundant to have a column in the build configurations section of the projects page.

Also note: I think I'm going to start a lot of mini PRs for the minor UI changes I'd like to see, instead of a big one. Reason is I'm not sure if the UI change I want to make will get accepted or not.