### PR TITLE
Fix breadcrumbs navigation for product and record

### DIFF
--- a/ui/app/configuration-set/configuration-set-controllers.js
+++ b/ui/app/configuration-set/configuration-set-controllers.js
@@ -69,7 +69,7 @@
                 productId: parseInt(self.selectedProductId),
                 versionId: self.data.productVersionId
               };
-              $state.go('product.version', params, {
+              $state.go('product.detail.version', params, {
                 reload: true,
                 inherit: false,
                 notify: true

--- a/ui/app/configuration/views/configuration.detail-main.html
+++ b/ui/app/configuration/views/configuration.detail-main.html
@@ -106,7 +106,7 @@
           <div class="col-sm-10">
             <!-- Show when edit is not selected -->
             <ul class="list-inline form-control-static" ng-hide="configurationForm.$visible">
-              <li ng-repeat="version in detailCtrl.productVersions.selected"><a href ui-sref="product.version({ productId: version.productId, versionId: version.id })">{{ version.version }}</a></li>
+              <li ng-repeat="version in detailCtrl.productVersions.selected"><a href ui-sref="product.detail.version({ productId: version.productId, versionId: version.id })">{{ version.version }}</a></li>
             </ul>
 
             <!-- Show when edit is selected -->

--- a/ui/app/milestone/_milestone.js
+++ b/ui/app/milestone/_milestone.js
@@ -31,22 +31,18 @@
   module.config(['$stateProvider', function ($stateProvider) {
 
     $stateProvider
-    .state('product.version.milestone', {
-      abstract: true,
+    .state('product.detail.version.milestoneCreate', {
+      url: '/milestone/create',
       views: {
         'content@': {
-          templateUrl: 'common/templates/single-col.tmpl.html'
+          templateUrl: 'milestone/views/milestone.create-update.html',
+          controller: 'MilestoneCreateUpdateController',
+          controllerAs: 'milestoneCreateUpdateCtrl',
         }
       },
-    })
-    .state('product.version.milestone.create', {
-      url: '/milestone/create',
-      templateUrl: 'milestone/views/milestone.create-update.html',
       data: {
         displayName: 'Create Milestone'
       },
-      controller: 'MilestoneCreateUpdateController',
-      controllerAs: 'milestoneCreateUpdateCtrl',
       resolve: {
         restClient: 'PncRestClient',
         milestoneDetail: function() {
@@ -54,14 +50,18 @@
         },
       },
     })
-    .state('product.version.milestone.update', {
+    .state('product.detail.version.milestoneUpdate', {
       url: '/milestone/{milestoneId:int}/update',
-      templateUrl: 'milestone/views/milestone.create-update.html',
+      views: {
+        'content@': {
+          templateUrl: 'milestone/views/milestone.create-update.html',
+          controller: 'MilestoneCreateUpdateController',
+          controllerAs: 'milestoneCreateUpdateCtrl',
+        }
+      },
       data: {
         displayName: 'Update Milestone'
       },
-      controller: 'MilestoneCreateUpdateController',
-      controllerAs: 'milestoneCreateUpdateCtrl',
       resolve: {
         restClient: 'PncRestClient',
         milestoneDetail: function (restClient, $stateParams) {
@@ -70,14 +70,18 @@
         }
       }
     })
-    .state('product.version.milestone.close', {
+    .state('product.detail.version.milestoneClose', {
       url: '/milestone/{milestoneId:int}/close',
-      templateUrl: 'milestone/views/milestone.close.html',
+      views: {
+        'content@': {
+          templateUrl: 'milestone/views/milestone.close.html',
+          controller: 'MilestoneCloseController',
+          controllerAs: 'milestoneCloseCtrl',
+        }
+      },
       data: {
         displayName: 'Close Milestone'
       },
-      controller: 'MilestoneCloseController',
-      controllerAs: 'milestoneCloseCtrl',
       resolve: {
         restClient: 'PncRestClient',
         milestoneDetail: function (restClient, $stateParams) {

--- a/ui/app/milestone/milestone-controllers.js
+++ b/ui/app/milestone/milestone-controllers.js
@@ -84,7 +84,7 @@
                   })
                   .then(
                     function() {
-                      $state.go('product.version', {
+                      $state.go('product.detail.version', {
                         productId: productDetail.id,
                         versionId: versionDetail.id
                       }, {
@@ -92,7 +92,7 @@
                       });
                     },
                     function() {
-                      $state.go('product.version', {
+                      $state.go('product.detail.version', {
                         productId: productDetail.id,
                         versionId: versionDetail.id
                       }, {
@@ -101,7 +101,7 @@
                     }
                   );
               } else {
-                $state.go('product.version', {
+                $state.go('product.detail.version', {
                   productId: productDetail.id,
                   versionId: versionDetail.id
                 }, {
@@ -113,7 +113,7 @@
         } else {
           that.data.$update().then(
             function() {
-              $state.go('product.version', {
+              $state.go('product.detail.version', {
                 productId: productDetail.id,
                 versionId: versionDetail.id
               }, {
@@ -153,7 +153,7 @@
         that.data.releaseDate = dateUtilConverter.convertToTimestampNoonUTC(that.data.releaseDate);
         that.data.$update().then(
           function() {
-            $state.go('product.version', {
+            $state.go('product.detail.version', {
               productId: productDetail.id,
               versionId: versionDetail.id
             }, {

--- a/ui/app/product/_product.js
+++ b/ui/app/product/_product.js
@@ -27,6 +27,7 @@
 
   module.config(['$stateProvider', function($stateProvider) {
     $stateProvider.state('product', {
+      url: '/product',
       abstract: true,
       views: {
         'content@': {
@@ -40,7 +41,7 @@
     });
 
     $stateProvider.state('product.list', {
-      url: '/product',
+      url: '',
       templateUrl: 'product/views/product.list.html',
       data: {
         displayName: 'Products'
@@ -56,7 +57,7 @@
     });
 
     $stateProvider.state('product.detail', {
-      url: '/product/{productId:int}',
+      url: '/{productId:int}',
       templateUrl: 'product/views/product.detail.html',
       data: {
          displayName: '{{ productDetail.name }}',
@@ -75,15 +76,19 @@
       }
     });
 
-    $stateProvider.state('product.version', {
+    $stateProvider.state('product.detail.version', {
       //parent: 'product.detail',
-      url: '/product/{productId:int}/version/{versionId:int}',
-      templateUrl: 'product/views/product.version.html',
+      url: '/version/{versionId:int}',
+      views: {
+        'content@': {
+          templateUrl: 'product/views/product.version.html',
+          controller: 'ProductVersionController',
+          controllerAs: 'versionCtrl',
+        }
+      },
       data: {
          displayName: '{{ versionDetail.version }}'
       },
-      controller: 'ProductVersionController',
-      controllerAs: 'versionCtrl',
       resolve: {
         restClient: 'PncRestClient',
         productDetail: function(restClient, $stateParams) {
@@ -129,14 +134,18 @@
       },
     });
 
-    $stateProvider.state('product.createversion', {
-      url: '/product/{productId:int}/createversion',
-      templateUrl: 'product/views/product.version.create.html',
+    $stateProvider.state('product.detail.createVersion', {
+      url: '/createversion',
+      views: {
+        'content@': {
+          templateUrl: 'product/views/product.version.create.html',
+          controller: 'ProductVersionCreateController',
+          controllerAs: 'productVersionCreateCtrl',
+        }
+      },
       data: {
         displayName: 'Create Product Version'
       },
-      controller: 'ProductVersionCreateController',
-      controllerAs: 'productVersionCreateCtrl',
       resolve: {
         restClient: 'PncRestClient',
         productDetail: function(restClient, $stateParams) {

--- a/ui/app/product/product-controllers.js
+++ b/ui/app/product/product-controllers.js
@@ -163,7 +163,7 @@
           versionId: versionDetail.id
         }).then(
           function() {
-            $state.go('product.version', {
+            $state.go('product.detail.version', {
               productId: productDetail.id,
               versionId: versionDetail.id
             }, {
@@ -185,7 +185,7 @@
           })
           .then(
             function() {
-              $state.go('product.version', {
+              $state.go('product.detail.version', {
                 productId: productDetail.id,
                 versionId: versionDetail.id
               }, {
@@ -260,6 +260,8 @@
         that.data.$save().then(function(result) {
             $state.go('product.detail', {
               productId: result.productId,
+            }, {
+              reload: true
             });
           }
         );

--- a/ui/app/product/views/product.detail.html
+++ b/ui/app/product/views/product.detail.html
@@ -82,7 +82,7 @@
   <pnc-header>
     <pnc-header-title><small>Product Versions</small></pnc-header-title>
     <pnc-header-buttons>
-      <button type="button" class="btn btn-lg btn-default" data-toggle="tooltip" title="Create Product Version" ui-sref="product.createversion({ productId: detailCtrl.product.id })">
+      <button type="button" class="btn btn-lg btn-default" data-toggle="tooltip" title="Create Product Version" ui-sref="product.detail.createVersion({ productId: detailCtrl.product.id })">
           <i class="pficon pficon-add"></i> Create
       </button>
     </pnc-header-buttons>
@@ -93,11 +93,11 @@
     <thead>
       <th>Version</th>
       <th>Milestones</th>
-      <th>Releases</th>      
+      <th>Releases</th>
     </thead>
     <tbody>
       <tr ng-repeat="version in detailCtrl.versions | filter:searchText">
-        <td class="bigger-text"><a href ui-sref="product.version({ productId: detailCtrl.product.id, versionId: version.id })">{{ version.version }}</a></td>
+        <td class="bigger-text"><a href ui-sref="product.detail.version({ productId: detailCtrl.product.id, versionId: version.id })">{{ version.version }}</a></td>
         <td>
            <span ng-repeat="productmilestone in detailCtrl.versionMilestones | filter: { productVersionId: version.id } | orderBy: '-productmilestone.startingDate'">
              <span data-tooltip-html-unsafe="{{detailCtrl.getMilestoneTooltip(productmilestone)}}" data-tooltip-placement="right" class="label label-default" ng-class="{ 'label label-primary' : productmilestone.id == version.currentProductMilestoneId }">{{ productmilestone.version }}</span>

--- a/ui/app/product/views/product.version.html
+++ b/ui/app/product/views/product.version.html
@@ -73,7 +73,7 @@
             <pnc-header>
               <pnc-header-title><small>Releases</small></pnc-header-title>
               <pnc-header-buttons>
-                <button type="button" class="btn btn-lg btn-default" data-toggle="tooltip" title="Create Release" ui-sref="product.version.release.create">
+                <button type="button" class="btn btn-lg btn-default" data-toggle="tooltip" title="Create Release" ui-sref="product.detail.version.releaseCreate">
                     <i class="pficon pficon-add"></i> Create
                 </button>
               </pnc-header-buttons>
@@ -92,7 +92,7 @@
                   <td><span class="label label-success">{{ productrelease.version }}</span></td>
                   <td>{{ productrelease.releaseDate | date:'yyyy/MM/dd'}}</td>
                   <td class="text-center">
-                     <a ng-show="productrelease.downloadUrl != undefined" ng-href="{{ productrelease.downloadUrl }}" target="_self" 
+                     <a ng-show="productrelease.downloadUrl != undefined" ng-href="{{ productrelease.downloadUrl }}" target="_self"
                        class="btn btn-default" title="Download Deliverables">
                        <i class="glyphicon glyphicon-download-alt"></i>
                      </a>
@@ -100,7 +100,7 @@
                   <td>Released from Milestone <strong>{{ versionCtrl.getMilestoneVersion(productrelease.productMilestoneId) }}</strong></td>
                   <td>{{ productrelease.supportLevel }}</td>
                   <td>
-                    <button type="button" class="btn btn-sm btn-default" data-toggle="tooltip" title="Edit Release" ui-sref="product.version.release.update({ releaseId: productrelease.id })">
+                    <button type="button" class="btn btn-sm btn-default" data-toggle="tooltip" title="Edit Release" ui-sref="product.detail.version.releaseUpdate({ releaseId: productrelease.id })">
                       <i class="pficon pficon-edit"></i>
                     </button>
                     <button type="button" class="btn btn-sm btn-danger disabled" data-toggle="tooltip" title="Delete Release">
@@ -120,7 +120,7 @@
           <pnc-header>
             <pnc-header-title><small>Milestones</small></pnc-header-title>
               <pnc-header-buttons>
-                <button type="button" class="btn btn-lg btn-default" data-toggle="tooltip" title="Create Milestone" ui-sref="product.version.milestone.create">
+                <button type="button" class="btn btn-lg btn-default" data-toggle="tooltip" title="Create Milestone" ui-sref="product.detail.version.milestoneCreate">
                     <i class="pficon pficon-add"></i> Create
                 </button>
               </pnc-header-buttons>
@@ -144,7 +144,7 @@
                   <td>{{ productmilestone.plannedReleaseDate | date:'yyyy/MM/dd'}}</td>
                   <td>{{ productmilestone.releaseDate | date:'yyyy/MM/dd'}}</td>
                   <td class="text-center">
-                     <a ng-show="productmilestone.downloadUrl != undefined" ng-href="{{ productmilestone.downloadUrl }}" target="_self" 
+                     <a ng-show="productmilestone.downloadUrl != undefined" ng-href="{{ productmilestone.downloadUrl }}" target="_self"
                        class="btn btn-default" title="Download Deliverables">
                        <i class="glyphicon glyphicon-download-alt"></i>
                      </a>
@@ -152,8 +152,8 @@
                   <td>{{ productmilestone.buildRecordSetId }}</td>
                   <td class="text-center">
                     <a ng-show="productmilestone.releaseDate == undefined" pnc-confirm-click="versionCtrl.markCurrentMilestone(productmilestone)" pnc-confirm-message="{{ 'Mark Milestone ' + productmilestone.version + ' as current ?'}}" title="Mark Milestone as current" class="btn btn-default"><i class="fa fa-clock-o"></i></a>
-                    <a ng-show="productmilestone.releaseDate == undefined" ui-sref="product.version.milestone.update({ milestoneId: productmilestone.id })" title="Update Milestone" class="btn btn-default"><i class="pficon pficon-edit"></i></a>
-                    <a ng-show="productmilestone.releaseDate == undefined" ui-sref="product.version.milestone.close({ milestoneId: productmilestone.id })" title="Release Milestone" class="btn btn-default"><i class="fa fa-lock"></i></a>
+                    <a ng-show="productmilestone.releaseDate == undefined" ui-sref="product.detail.version.milestoneUpdate({ milestoneId: productmilestone.id })" title="Update Milestone" class="btn btn-default"><i class="pficon pficon-edit"></i></a>
+                    <a ng-show="productmilestone.releaseDate == undefined" ui-sref="product.detail.version.milestoneClose({ milestoneId: productmilestone.id })" title="Release Milestone" class="btn btn-default"><i class="fa fa-lock"></i></a>
                     <a ng-show="productmilestone.releaseDate != undefined" pnc-confirm-click="versionCtrl.unreleaseMilestone(productmilestone)" pnc-confirm-message="{{ 'Confirm the unrelease of Milestone: ' + productmilestone.version + ' ?'}}" title="Unrelease Milestone" class="btn btn-default"><i class="fa fa-unlock-alt"></i></a>
                   </td>
                 </tr>

--- a/ui/app/record/_record.js
+++ b/ui/app/record/_record.js
@@ -49,6 +49,7 @@
       $urlRouterProvider.when('/record/:recordId', '/record/:recordId/info');
 
       $stateProvider.state('record.detail', {
+        abstract: true,
         url: '/{recordId:int}',
         templateUrl: 'record/views/record.detail.html',
         data: {

--- a/ui/app/release/_release.js
+++ b/ui/app/release/_release.js
@@ -31,24 +31,18 @@
 
   module.config(['$stateProvider', function ($stateProvider) {
     $stateProvider
-    .state('product.version.release', {
-      abstract: true,
-      url: '/release',
+    .state('product.detail.version.releaseCreate', {
+      url: '/release/create',
       views: {
         'content@': {
-          templateUrl: 'common/templates/single-col.tmpl.html'
+          templateUrl: 'release/views/release.create-update.html',
+          controller: 'ReleaseCreateUpdateController',
+          controllerAs: 'releaseCreateUpdateCtrl',
         }
       },
-    })
-    .state('product.version.release.create', {
-      url: '/create',
-      templateUrl: 'release/views/release.create-update.html',
       data: {
-        proxy: 'product.version.release.create',
         displayName: 'Create Release'
       },
-      controller: 'ReleaseCreateUpdateController',
-      controllerAs: 'releaseCreateUpdateCtrl',
       resolve: {
         restClient: 'PncRestClient',
         releaseDetail: function() {
@@ -56,15 +50,18 @@
         },
       },
     })
-    .state('product.version.release.update', {
-      url: '/{releaseId:int}/update',
-      templateUrl: 'release/views/release.create-update.html',
+    .state('product.detail.version.releaseUpdate', {
+      url: '/release/{releaseId:int}/update',
+      views: {
+        'content@': {
+          templateUrl: 'release/views/release.create-update.html',
+          controller: 'ReleaseCreateUpdateController',
+          controllerAs: 'releaseCreateUpdateCtrl',
+        }
+      },
       data: {
-        proxy: 'product.version.release.update',
         displayName: 'Update Release'
       },
-      controller: 'ReleaseCreateUpdateController',
-      controllerAs: 'releaseCreateUpdateCtrl',
       resolve: {
         restClient: 'PncRestClient',
         releaseDetail: function(restClient, $stateParams) {

--- a/ui/app/release/release-controllers.js
+++ b/ui/app/release/release-controllers.js
@@ -105,7 +105,7 @@
         if (!that.isUpdating) {
           that.data.$save().then(
             function() {
-              $state.go('product.version', {
+              $state.go('product.detail.version', {
                 productId: productDetail.id,
                 versionId: versionDetail.id
               }, {
@@ -116,7 +116,7 @@
         } else {
           that.data.$update().then(
             function() {
-              $state.go('product.version', {
+              $state.go('product.detail.version', {
                 productId: productDetail.id,
                 versionId: versionDetail.id
               }, {


### PR DESCRIPTION
The breadcrumb navigation for the product page is broken and doesn't
properly show the nested view hierarchy of the views.

This commit attempts to fix this issue for both the products and the
records page.

## Fixes
### Product Detail
From:
![before_products_detail](https://cloud.githubusercontent.com/assets/630746/9421911/9af25ef2-484c-11e5-9134-7e3d278d9f46.png)

To:
![after_products_details](https://cloud.githubusercontent.com/assets/630746/9421913/a4e9a500-484c-11e5-8e76-0d6a97a394c2.png)

### Product Milestone

From:
![before_milesone](https://cloud.githubusercontent.com/assets/630746/9421917/b3c2ee74-484c-11e5-90a1-e11461912bcd.png)

To:
![after_milestone](https://cloud.githubusercontent.com/assets/630746/9421919/bbc02dd0-484c-11e5-97e9-a7ee1214ddf9.png)

### Product Release

From:
![before_release](https://cloud.githubusercontent.com/assets/630746/9421921/c8423fc6-484c-11e5-96b6-a39835bc84e6.png)

To:
![after_release](https://cloud.githubusercontent.com/assets/630746/9421923/cec6ae0e-484c-11e5-85d6-6c6801617ae4.png)

### Record

From:
![before_record](https://cloud.githubusercontent.com/assets/630746/9421924/d71c4fdc-484c-11e5-9e02-92b98b4ddd9e.png)

To:
![after_record](https://cloud.githubusercontent.com/assets/630746/9421925/db526366-484c-11e5-9c56-fcfcae7b1b92.png)

## Changes
The changes require a renaming of some of the states so that the angular-ui-router can figure out the parent of each state.

I also moved some `templateUrl`, router definitions inside `views: { 'content@`: {}}` so that Angular could properly substitute the views, now that it knows about the parent of each state. (I think that's what's happening?)
