### PR TITLE
don't delete tracking on aprox, and propagate buildContentId via REST

### DIFF
--- a/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
+++ b/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
@@ -141,17 +141,7 @@ public class MavenRepositorySession implements RepositorySession
 
         promoteToBuildContentSet();
 
-        RepositoryManagerResult repositoryManagerResult = new MavenRepositoryManagerResult(uploads, downloads);
-
-        // clean up.
-        try {
-            aprox.module(AproxFoloAdminClientModule.class).clearTrackingRecord(buildRepoId);
-        } catch (AproxClientException e) {
-            throw new RepositoryManagerException(
-                    "Failed to clean up build repositories / tracking information for: %s. Reason: %s", e, buildRepoId,
-                    e.getMessage());
-        }
-        return repositoryManagerResult;
+        return new MavenRepositoryManagerResult(uploads, downloads);
     }
 
     /**

--- a/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildRecordRest.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildRecordRest.java
@@ -61,6 +61,8 @@ public class BuildRecordRest implements GenericRestEntity<Integer> {
 
     private Integer buildConfigSetRecordId;
 
+    private String buildContentId;
+
     public BuildRecordRest() {
     }
 
@@ -80,6 +82,8 @@ public class BuildRecordRest implements GenericRestEntity<Integer> {
         this.buildDriverId = buildRecord.getBuildDriverId();
         if(buildRecord.getBuildConfigSetRecord() != null)
             this.buildConfigSetRecordId = buildRecord.getBuildConfigSetRecord().getId();
+
+        this.buildContentId = buildRecord.getBuildContentId();
     }
 
     public BuildRecordRest(BuildTask buildTask) {
@@ -96,6 +100,8 @@ public class BuildRecordRest implements GenericRestEntity<Integer> {
         performIfNotNull(buildTask.getBuildSetTask(), () -> this.buildConfigSetRecordId = buildTask.getBuildSetTask().getId());
         if(buildTask.getUser() != null)
             this.userId = buildTask.getUser().getId();
+
+        this.buildContentId = buildTask.getBuildContentId();
     }
 
     @Override
@@ -198,5 +204,13 @@ public class BuildRecordRest implements GenericRestEntity<Integer> {
 
     public Integer getBuildConfigSetRecordId() {
         return buildConfigSetRecordId;
+    }
+
+    public String getBuildContentId() {
+        return buildContentId;
+    }
+
+    public void setBuildContentId(String buildContentId) {
+        this.buildContentId = buildContentId;
     }
 }


### PR DESCRIPTION
* Don't delete the tracking record for a build in AProx, so it can be used later in the workflow by other services.
* Propagate buildContentId from BuildRecord/BuildTask over REST via BuildRecordRest so workflow services can lookup the build id to access content on AProx / other repo managers.