### PR TITLE
NCL-1187 - Option to skip or force rebuild of existing builds in web UI

### DIFF
--- a/ui/app/common/restclient/services/BuildConfigurationSetDAO.js
+++ b/ui/app/common/restclient/services/BuildConfigurationSetDAO.js
@@ -50,12 +50,16 @@
           method: 'GET',
           url: ENDPOINT + '/build-configurations' + qh.searchOnly(['name'])
         },
-        build: {
+        forceBuild: {
           method: 'POST',
           url: ENDPOINT + '/build',
           params: {
             rebuildAll: true
           }
+        },
+        build: {
+          method: 'POST',
+          url: ENDPOINT + '/build'
         },
         removeConfiguration: {
           method: 'DELETE',

--- a/ui/app/configuration-set/configuration-set-controllers.js
+++ b/ui/app/configuration-set/configuration-set-controllers.js
@@ -234,6 +234,14 @@
         );
       });
 
+      self.forceBuild = function() {
+        $log.debug('**Initiating FORCED build of SET: %s**', self.set.name);
+
+        BuildConfigurationSetDAO.forceBuild({
+          configurationSetId: self.set.id
+        }, {});
+      };
+
       self.build = function() {
         $log.debug('**Initiating build of SET: %s**', self.set.name);
 

--- a/ui/app/configuration-set/views/configuration-set.detail.html
+++ b/ui/app/configuration-set/views/configuration-set.detail.html
@@ -21,9 +21,21 @@
   <pnc-header>
     <pnc-header-title>{{ detailSetCtrl.set.name }}</pnc-header-title>
     <pnc-header-buttons>
-      <button type="button" class="btn btn-lg btn-default" data-toggle="tooltip" title="Start Build" ng-click="detailSetCtrl.build()">
-        <i class="fa fa-play"></i> Build
-      </button>
+      <div class="btn-group">
+        <button class="btn btn-lg btn-default ng-scope" tooltip="Start Build" tooltip-placement="bottom" ng-click="detailSetCtrl.build()">
+          <i class="fa fa-play"></i>
+          <span class="shrink">Build</span>
+        </button>
+        <ul class="dropdown-menu"></ul>
+          <button class="btn btn-lg btn-default dropdown-toggle ng-scope" tooltip="Start Build forcing rebuilds" tooltip-placement="bottom" data-toggle="dropdown">
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            <li>
+              <a href ng-click="detailSetCtrl.forceBuild()"><span><i class="fa fa-play fa-color-red"></i>   Build forcing all rebuilds</span></a>
+            </li>
+          </ul>
+      </div>
       <button type="button" class="btn btn-lg btn-default" data-toggle="tooltip" title="Edit Configuration" ng-click="setEditForm.$show()" ng-class="{ 'active': setEditForm.$visible }">
         <i class="pficon pficon-edit"></i> Edit
       </button>

--- a/ui/app/product/directives/pncProductVersionBCSets/pnc-product-version-bcsets.html
+++ b/ui/app/product/directives/pncProductVersionBCSets/pnc-product-version-bcsets.html
@@ -37,9 +37,21 @@
   <tr ng-repeat="buildconfigurationset in page.data">
     <td><a href ui-sref="configuration-set.detail({ configurationSetId: buildconfigurationset.id })">{{ buildconfigurationset.name }}</a></td>
     <td class="table-data-5-column-even-width">
-      <button type="button" class="btn btn-sm btn-default" data-toggle="tooltip" title="Start Build" ng-click="buildConfigSet(buildconfigurationset)">
-        <i class="fa fa-play"></i> Build
-      </button>
+      <div class="btn-group">
+        <button class="btn btn-default ng-scope" tooltip="Start Build" tooltip-placement="bottom" ng-click="buildConfigSet(buildconfigurationset)">
+          <i class="fa fa-play"></i>
+          <span class="shrink">Build</span>
+        </button>
+        <ul class="dropdown-menu"></ul>
+          <button class="btn btn-default dropdown-toggle ng-scope" tooltip="Start Build forcing rebuilds" tooltip-placement="bottom" data-toggle="dropdown">
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            <li>
+              <a href ng-click="forceBuildConfigSet(buildconfigurationset)"><span><i class="fa fa-play fa-color-red"></i>   Build forcing all rebuilds</span></a>
+            </li>
+          </ul>
+      </div>
     </td>
   </tr>
   </tbody>

--- a/ui/app/product/directives/pncProductVersionBCSets/pncProductVersionBCSets.js
+++ b/ui/app/product/directives/pncProductVersionBCSets/pncProductVersionBCSets.js
@@ -42,13 +42,22 @@
 
           scope.page = ProductVersionDAO.getPagedBCSets({versionId: scope.version.id });
 
-          // Executing a build of a configurationSet
+          // Executing a build of a configurationSet forcing all the rebuilds
+          scope.forceBuildConfigSet = function(configSet) {
+            $log.debug('**Initiating FORCED build of SET: %s**', configSet.name);
+            BuildConfigurationSetDAO.forceBuild({
+              configurationSetId: configSet.id
+            }, {});
+          };
+
+          // Executing a build of a configurationSet NOT forcing all the rebuilds
           scope.buildConfigSet = function(configSet) {
             $log.debug('**Initiating build of SET: %s**', configSet.name);
             BuildConfigurationSetDAO.build({
               configurationSetId: configSet.id
             }, {});
           };
+
         }
       };
     }

--- a/ui/app/styles/app.css
+++ b/ui/app/styles/app.css
@@ -126,6 +126,10 @@ ul.pagination.pull-right {
   font-size: 14px;
 }
 
+.fa-color-red {
+  color: red;
+}
+
 button.debutton {
   -webkit-appearance: none;
   padding: 0;


### PR DESCRIPTION
This functionality add the possibility of selecting a standard BuildConfigurationSet build (that would reuse its existing BuildConfigurations builds, if any), or forcing the rebuild of all its BuildConfigurations, regardless of eventual existing builds.
** NOTE ** the previous default behavior of the "Build" button was to FORCE the rebuilds. Now it has changed to NOT FORCE the rebuilds. To force the rebuilds, a new Button is provided.

![buildconfigurationset_productversion_1](https://cloud.githubusercontent.com/assets/6085861/10190295/e39be414-676b-11e5-8aa1-a4eb93d9001f.png)
![buildconfigurationset_productversion_2](https://cloud.githubusercontent.com/assets/6085861/10190298/e69b96fa-676b-11e5-97f8-3bdc573eda47.png)
![buildconfigurationset_standalone](https://cloud.githubusercontent.com/assets/6085861/10190300/e9767246-676b-11e5-9bf4-fd8f1a143133.png)
