### PR TITLE
NCL-1014 - User who invoked the build is not displayed in UI

### DIFF
--- a/ui/app/configuration-set-record/directives/pncRecentCsBuilds/pnc-recent-cs-builds.html
+++ b/ui/app/configuration-set-record/directives/pncRecentCsBuilds/pnc-recent-cs-builds.html
@@ -31,6 +31,7 @@
       </td>
       <td><a href ui-sref="configuration-set-record.detail.info({recordId: record.id})"># {{ record.id }} &mdash; {{ record.getConfigurationSet().name }}</a></td>
       <td>{{ record.startTime | date:'medium'}} &mdash; {{ record.endTime | date:'medium'}}</td>
+      <td class="text-bold">{{ record.getUser().username }}</td>
     </tr>
     <tr ng-hide="page.data.length">
       <td>

--- a/ui/app/configuration-set-record/directives/pncRunningCsBuilds/pnc-running-cs-builds.html
+++ b/ui/app/configuration-set-record/directives/pncRunningCsBuilds/pnc-running-cs-builds.html
@@ -32,6 +32,7 @@
       </td>
       <td><a href ui-sref="configuration-set-record.detail.info({recordId: record.id})"># {{ record.id }} &mdash; {{ record.getConfigurationSet().name }}</a></td>
       <td>{{ record.startTime | date:'medium'}}</td>
+      <td class="text-bold">{{ record.getUser().username }}</td>
     </tr>
     <tr ng-hide="page.data.length">
       <td>

--- a/ui/app/configuration-set/directives/pncBCTab/pnc-bc-tab.html
+++ b/ui/app/configuration-set/directives/pncBCTab/pnc-bc-tab.html
@@ -38,7 +38,6 @@
     <th>Name</th>
     <th>Created</th>
     <th>Modified</th>
-    <th>User</th>
     <th>Last Executed Build</th>
     <th>Actions</th>
     </thead>
@@ -51,12 +50,12 @@
       </td>
       <td>{{ configuration.creationTime | date:'medium'}}</td>
       <td>{{ configuration.lastModificationTime | date:'medium'}}</td>
-      <td>John Doe</td>
       <td>
         <div ng-repeat="buildRecord in latestBuildRecords[configuration.id]">
           <build-status-icon status="buildRecord.status"></build-status-icon>
           <span><a href ui-sref="record.detail.info({recordId: buildRecord.id})"> # {{ buildRecord.id }}  </a></span>
-          {{ buildRecord.endTime | date:'medium'}}
+          {{ buildRecord.endTime | date:'medium'}},
+          <span class="text-bold">   {{ buildRecord.getUser().username }}</span>
         </div>
         <em ng-hide="latestBuildRecords[configuration.id].length">none</em>
       </td>

--- a/ui/app/record/directives/pncRecentBuilds/pnc-recent-builds.html
+++ b/ui/app/record/directives/pncRecentBuilds/pnc-recent-builds.html
@@ -40,6 +40,7 @@
           </a>
         </td>
         <td>{{ record.endTime | date:'medium' }}</td>
+        <td class="text-bold">{{ record.getUser().username }}</td>
       </tr>
       <tr ng-hide="page.data.length">
         <td>

--- a/ui/app/record/directives/pncRunningBuilds/pnc-running-builds.html
+++ b/ui/app/record/directives/pncRunningBuilds/pnc-running-builds.html
@@ -38,6 +38,7 @@
           </a>
         </td>
         <td>{{ record.startTime | date:'medium'}}</td>
+        <td class="text-bold">{{ record.getUser().username }}</td>
       </tr>
       <tr ng-hide="page.data.length">
         <td>

--- a/ui/app/styles/app.css
+++ b/ui/app/styles/app.css
@@ -130,6 +130,10 @@ ul.pagination.pull-right {
   color: red;
 }
 
+.text-bold {
+  font-weight: bold;
+}
+
 button.debutton {
   -webkit-appearance: none;
   padding: 0;


### PR DESCRIPTION
Added the visualization of the user who triggered the build in the "Build Progress" and "Configuration Set Build Progress" pages. Modified also the BuildConfigurationSet Details page, where a fake user (John Doe) was showed, intending to show who created the BuildConfiguration. But we don't have that data in the DB. So removed the column, and added the information of the user who triggered the last build. All the usernames are in bold, since it is a quite important data to show.

![buildconfigurationset_progress](https://cloud.githubusercontent.com/assets/6085861/10191592/9872b5c6-6775-11e5-9cb9-c1d1bc9ddf3a.png)
![buildconfiguration_progress](https://cloud.githubusercontent.com/assets/6085861/10191596/9f44261e-6775-11e5-98d0-f8a0388dd299.png)
![buildconfigurationset_details](https://cloud.githubusercontent.com/assets/6085861/10191597/a40e433c-6775-11e5-99fc-be5887fcc1d7.png)
