### PR TITLE
Ncl 1237

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
@@ -77,7 +77,6 @@ public class BuildConfiguration implements GenericEntity<Integer>, Cloneable {
         uniqueConstraints = @UniqueConstraint(name = "UK_build_configuration_id_product_version_id",
           columnNames = {"build_configuration_id", "product_version_id"}))
     @ForeignKey(name = "fk_build_configuration_product_versions_map_buildconfiguration", inverseName = "fk_build_configuration_product_versions_map_productversion")
-    
     private Set<ProductVersion> productVersions;
 
     @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
@@ -293,7 +292,9 @@ public class BuildConfiguration implements GenericEntity<Integer>, Cloneable {
         if (buildConfigurationSets == null) {
             this.buildConfigurationSets = new HashSet<BuildConfigurationSet>();
         }
-        this.buildConfigurationSets = buildConfigurationSets;
+        else {
+            this.buildConfigurationSets = buildConfigurationSets;
+        }
     }
 
     /**

--- a/model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
@@ -70,8 +70,14 @@ public class BuildConfiguration implements GenericEntity<Integer>, Cloneable {
 
     @NotAudited
     @ManyToMany
-    @JoinTable(name = "build_configuration_product_versions_map", joinColumns = { @JoinColumn(name = "build_configuration_id", referencedColumnName = "id") }, inverseJoinColumns = { @JoinColumn(name = "product_version_id", referencedColumnName = "id") })
+    @JoinTable(
+        name = "build_configuration_product_versions_map", 
+        joinColumns = { @JoinColumn(name = "build_configuration_id", referencedColumnName = "id") }, 
+        inverseJoinColumns = { @JoinColumn(name = "product_version_id", referencedColumnName = "id") },
+        uniqueConstraints = @UniqueConstraint(name = "UK_build_configuration_id_product_version_id",
+          columnNames = {"build_configuration_id", "product_version_id"}))
     @ForeignKey(name = "fk_build_configuration_product_versions_map_buildconfiguration", inverseName = "fk_build_configuration_product_versions_map_productversion")
+    
     private Set<ProductVersion> productVersions;
 
     @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)

--- a/model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
@@ -290,7 +290,7 @@ public class BuildConfiguration implements GenericEntity<Integer>, Cloneable {
      */
     public void setBuildConfigurationSets(Set<BuildConfigurationSet> buildConfigurationSets) {
         if (buildConfigurationSets == null) {
-            this.buildConfigurationSets = new HashSet<BuildConfigurationSet>();
+            this.buildConfigurationSets.clear();
         }
         else {
             this.buildConfigurationSets = buildConfigurationSets;

--- a/model/src/main/java/org/jboss/pnc/model/ProductVersion.java
+++ b/model/src/main/java/org/jboss/pnc/model/ProductVersion.java
@@ -70,8 +70,12 @@ public class ProductVersion implements GenericEntity<Integer> {
     @ForeignKey(name = "fk_productversion_currentmilestone")
     private ProductMilestone currentProductMilestone;
 
+    @ManyToMany(mappedBy = "productVersions")
+    private Set<BuildConfiguration> buildConfigurations;
+
     public ProductVersion() {
         buildConfigurationSets = new HashSet<>();
+        buildConfigurations = new HashSet<BuildConfiguration>();
         productMilestones = new HashSet<ProductMilestone>();
     }
 
@@ -157,6 +161,19 @@ public class ProductVersion implements GenericEntity<Integer> {
         this.buildConfigurationSets = buildConfigurationSets;
     }
 
+    public Set<BuildConfiguration> getBuildConfigurations() {
+        return buildConfigurations;
+    }
+
+    public void setBuildConfigurations(Set<BuildConfiguration> buildConfigurations) {
+        if (buildConfigurations == null) {
+            this.buildConfigurations = new HashSet<BuildConfiguration>();
+        }
+        else {
+            this.buildConfigurations = buildConfigurations;
+        }
+    }
+
     @Override
     public String toString() {
         return "ProductVersion [id=" + id + ", version=" + version + "]";
@@ -175,6 +192,8 @@ public class ProductVersion implements GenericEntity<Integer> {
         private ProductMilestone currentProductMilestone;
 
         private Set<BuildConfigurationSet> buildConfigurationSets = new HashSet<>();
+
+        private Set<BuildConfiguration> buildConfigurations = new HashSet<>();
 
         private Builder() {
         }
@@ -199,6 +218,13 @@ public class ProductVersion implements GenericEntity<Integer> {
                 buildConfigurationSet.setProductVersion(productVersion);
             }
             productVersion.setBuildConfigurationSets(buildConfigurationSets);
+
+            for (BuildConfiguration buildConfiguration : buildConfigurations) {
+                if (!buildConfiguration.getProductVersions().contains(productVersion)) {
+                    buildConfiguration.addProductVersion(productVersion);
+                }
+            }
+            productVersion.setBuildConfigurations(buildConfigurations);
 
             for (ProductMilestone productMilestone : productMilestones) {
                 productMilestone.setProductVersion(productVersion);

--- a/rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProvider.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProvider.java
@@ -84,8 +84,7 @@ public class BuildConfigurationProvider extends AbstractProvider<BuildConfigurat
 
     public CollectionInfo<BuildConfigurationRest> getAllForProductAndProductVersion(int pageIndex, int pageSize,
             String sortingRsql, String query, Integer productId, Integer versionId) {
-        return queryForCollection(pageIndex, pageSize, sortingRsql, query, withProductVersionId(versionId), withProductId(
-                productId));
+        return queryForCollection(pageIndex, pageSize, sortingRsql, query, withProductVersionId(versionId));
     }
 
     public CollectionInfo<BuildConfigurationRest> getAllForBuildConfigurationSet(int pageIndex, int pageSize,

--- a/rest/src/main/java/org/jboss/pnc/rest/restmodel/ProductVersionRest.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/restmodel/ProductVersionRest.java
@@ -21,6 +21,9 @@ import org.jboss.pnc.model.Product;
 import org.jboss.pnc.model.ProductMilestone;
 import org.jboss.pnc.model.ProductRelease;
 import org.jboss.pnc.model.ProductVersion;
+import org.jboss.pnc.model.BuildConfiguration;
+import org.jboss.pnc.model.BuildConfigurationSet;
+
 import org.jboss.pnc.rest.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.rest.validation.groups.WhenUpdating;
 
@@ -50,7 +53,9 @@ public class ProductVersionRest implements GenericRestEntity<Integer> {
 
     List<Integer> productReleaseIds = new ArrayList<Integer>();
 
-    List<Integer> buildConfigurationSetIds;
+    List<Integer> buildConfigurationSetIds = new ArrayList<Integer>();
+
+    List<Integer> buildConfigurationIds = new ArrayList<Integer>();
 
     public ProductVersionRest() {
     }
@@ -68,6 +73,14 @@ public class ProductVersionRest implements GenericRestEntity<Integer> {
 
         for (ProductRelease release : productVersion.getProductReleases()) {
             productReleaseIds.add(release.getId());
+        }
+
+        for (BuildConfiguration buildConfiguration : productVersion.getBuildConfigurations()) {
+            buildConfigurationIds.add(buildConfiguration.getId());
+        }
+
+        for (BuildConfigurationSet buildConfigurationSet : productVersion.getBuildConfigurationSets()) {
+            buildConfigurationSetIds.add(buildConfigurationSet.getId());
         }
 
     }
@@ -104,6 +117,14 @@ public class ProductVersionRest implements GenericRestEntity<Integer> {
 
     public void setBuildConfigurationSetIds(List<Integer> buildConfigurationSetIds) {
         this.buildConfigurationSetIds = buildConfigurationSetIds;
+    }
+
+    public List<Integer> getBuildConfigurationIds() {
+        return buildConfigurationIds;
+    }
+
+    public void setBuildConfigurationIds(List<Integer> buildConfigurationIds) {
+        this.buildConfigurationIds = buildConfigurationIds;
     }
 
     public List<Integer> getProductMilestones() {

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/ProductVersionPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/ProductVersionPredicates.java
@@ -42,10 +42,19 @@ public class ProductVersionPredicates {
         };
     }
 
-    public static Predicate<ProductVersion> withBuildConfigurationId(Integer buildConfigurationId) {
+    // THIS PREDICATE GIVES ALL THE PRODUCTVERSIONS LINKED TO THE BUILDCONFIGURATIONSETS THAT CONTAIN A CERTAIN BUILDCONFIGURATION
+    /*public static Predicate<ProductVersion> withBuildConfigurationId(Integer buildConfigurationId) {
         return (root, query, cb) -> {
             SetJoin<ProductVersion, BuildConfigurationSet> buildConfigurationSetSetJoin = root.join(ProductVersion_.buildConfigurationSets);
             SetJoin<BuildConfigurationSet, BuildConfiguration> buildConfigurationJoin = buildConfigurationSetSetJoin.join( BuildConfigurationSet_.buildConfigurations);
+            return cb.equal(buildConfigurationJoin.get(BuildConfiguration_.id), buildConfigurationId);
+        };
+    }*/
+
+    // THIS PREDICATE GIVES ALL THE PRODUCTVERSIONS LINKED TO A CERTAIN BUILDCONFIGURATION
+    public static Predicate<ProductVersion> withBuildConfigurationId(Integer buildConfigurationId) {
+        return (root, query, cb) -> {
+            SetJoin<ProductVersion, BuildConfiguration> buildConfigurationJoin = root.join(ProductVersion_.buildConfigurations);
             return cb.equal(buildConfigurationJoin.get(BuildConfiguration_.id), buildConfigurationId);
         };
     }

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/ProductVersionPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/ProductVersionPredicates.java
@@ -51,7 +51,9 @@ public class ProductVersionPredicates {
         };
     }*/
 
-    // THIS PREDICATE GIVES ALL THE PRODUCTVERSIONS LINKED TO A CERTAIN BUILDCONFIGURATION
+    /**
+     * This predicate returns all the ProductVersions linked to a specified BuildConfiguration
+     */
     public static Predicate<ProductVersion> withBuildConfigurationId(Integer buildConfigurationId) {
         return (root, query, cb) -> {
             SetJoin<ProductVersion, BuildConfiguration> buildConfigurationJoin = root.join(ProductVersion_.buildConfigurations);

--- a/ui/app/common/directives/pnc-select.js
+++ b/ui/app/common/directives/pnc-select.js
@@ -51,6 +51,7 @@
     var tmpl =
       '<ul class="list-group" ng-show="shouldShow()">' +
         '<li class="list-group-item" ng-repeat="item in selectedItems">' +
+          '{{ additionalDisplayItemsById[item.id] }} ' +
           '{{ item[displayProperty] }}' +
           '<button type="button" class="close" aria-label="Close" ng-click="removeItem(item)">' +
             '<span aria-hidden="true">×</span>' +
@@ -71,6 +72,7 @@
         selectedItems: '=',
         query: '&',
         displayProperty: '@',
+        additionalDisplayItemsById: '=',
         placeholder: '@'
       },
       template: tmpl,

--- a/ui/app/common/restclient/services/ProductVersionDAO.js
+++ b/ui/app/common/restclient/services/ProductVersionDAO.js
@@ -69,7 +69,7 @@
 
       resource.prototype.getProduct = cachedGetter(
         function (version) {
-          return ProductDAO.get({productId: version.productId}).$promise;
+          return ProductDAO.get({productId: version.productId});
         }
       );
 
@@ -84,7 +84,6 @@
           return ProductReleaseDAO.getAllForProductVersion({versionId: version.id});
         }
       );
-
       return resource;
     }
   ]);

--- a/ui/app/configuration/_configuration.js
+++ b/ui/app/configuration/_configuration.js
@@ -136,13 +136,13 @@
         runningBuildRecordList: function(RunningBuildRecordDAO) {
           return RunningBuildRecordDAO.query();
         },
-        products: function(ProductDAO) {
+        allProducts: function(ProductDAO) {
           return ProductDAO.query();
         },
         configurations: function(BuildConfigurationDAO) {
           return BuildConfigurationDAO.query();
         },
-        productVersions: function(BuildConfigurationDAO, $stateParams) {
+        linkedProductVersions: function(BuildConfigurationDAO, $stateParams) {
           return BuildConfigurationDAO.getProductVersions({
             configurationId: $stateParams.configurationId });
         },

--- a/ui/app/configuration/configuration-controllers.js
+++ b/ui/app/configuration/configuration-controllers.js
@@ -131,19 +131,26 @@
     'configurationDetail',
     'environmentDetail',
     'projectDetail',
-    'productVersions',
+    'linkedProductVersions',
     'dependencies',
-    'products',
+    'allProducts',
     'configurations',
     function($log, $state, $filter, Notifications, ProductDAO, BuildConfigurationDAO,
       configurationDetail, environmentDetail, projectDetail,
-      linkedProductVersions, dependencies, products, configurations) {
+      linkedProductVersions, dependencies, allProducts, configurations) {
 
       this.configuration = configurationDetail;
       this.environment = environmentDetail;
       this.project = projectDetail;
+      this.allProducts = allProducts;
 
       var that = this;
+
+      // Could not make it work in a nicer way (i.e. via cachedGetter) - avibelli
+      that.allProductsMaps = {};
+      that.allProducts.forEach(function ( prod ) {
+          that.allProductsMaps[ prod.id ] = prod;
+      });
 
       // Filtering and selection of linked ProductVersions.
       this.products = {
@@ -172,6 +179,7 @@
       // Bootstrap products, depending on whether the BuildConfiguration
       // already has a ProductVersion attached.
       if (linkedProductVersions && linkedProductVersions.length > 0) {
+
         ProductDAO.get({
           productId: linkedProductVersions[0].productId
         }).$promise.then(function(result) {
@@ -180,9 +188,8 @@
           that.productVersions.update();
         });
       } else {
-        that.products.all = products;
+        that.products.all = allProducts;
       }
-
 
       // Selection of dependencies.
       this.dependencies = {

--- a/ui/app/configuration/configuration-controllers.js
+++ b/ui/app/configuration/configuration-controllers.js
@@ -81,12 +81,18 @@
         });
       };
 
-
       // Filtering and selection of linked ProductVersions.
       this.products = {
         all: products,
         selected: null
       };
+
+      // Could not make it work in a nicer way (i.e. via cachedGetter) - avibelli
+      this.allProductsMaps = {};
+      this.allProductNamesMaps = {};
+      this.products.all.forEach(function ( prod ) {
+          that.allProductsMaps[ prod.id ] = prod;
+      });
 
       this.productVersions = {
         selected: [],
@@ -97,6 +103,11 @@
             productId: that.products.selected.id
           }).then(function(data) {
             that.productVersions.all = data;
+
+            // TOFIX - Ugly but quick - avibelli
+            data.forEach(function ( prodVers ) {
+                that.allProductNamesMaps[ prodVers.id ] = that.allProductsMaps[ prodVers.productId ].name + ' - ';
+            });
           });
         },
         getItems: function($viewValue) {
@@ -161,7 +172,7 @@
       // TOFIX - Ugly but quick - avibelli
       that.allProductNamesMaps = {};
       linkedProductVersions.forEach(function ( prodVers ) {
-          that.allProductNamesMaps[ prodVers.id ] = that.allProductsMaps[ prodVers.productId ].name;
+          that.allProductNamesMaps[ prodVers.id ] = that.allProductsMaps[ prodVers.productId ].name + ' - ';
       });
 
       this.productVersions = {

--- a/ui/app/configuration/configuration-controllers.js
+++ b/ui/app/configuration/configuration-controllers.js
@@ -146,17 +146,23 @@
 
       var that = this;
 
+      // Filtering and selection of linked ProductVersions.
+      this.products = {
+        all: allProducts,
+        selected: null
+      };
+
       // Could not make it work in a nicer way (i.e. via cachedGetter) - avibelli
       that.allProductsMaps = {};
       that.allProducts.forEach(function ( prod ) {
           that.allProductsMaps[ prod.id ] = prod;
       });
 
-      // Filtering and selection of linked ProductVersions.
-      this.products = {
-        all: [],
-        selected: null
-      };
+      // TOFIX - Ugly but quick - avibelli
+      that.allProductNamesMaps = {};
+      linkedProductVersions.forEach(function ( prodVers ) {
+          that.allProductNamesMaps[ prodVers.id ] = that.allProductsMaps[ prodVers.productId ].name;
+      });
 
       this.productVersions = {
         selected: linkedProductVersions,
@@ -184,11 +190,8 @@
           productId: linkedProductVersions[0].productId
         }).$promise.then(function(result) {
           that.products.selected = result;
-          that.products.all = [that.products.selected];
           that.productVersions.update();
         });
-      } else {
-        that.products.all = allProducts;
       }
 
       // Selection of dependencies.

--- a/ui/app/configuration/views/configuration.create.html
+++ b/ui/app/configuration/views/configuration.create.html
@@ -82,7 +82,7 @@
     <div class="form-group">
       <label for="input-product-versions" class="col-sm-2 control-label">Product Versions</label>
       <div class="col-sm-10 col-md-4" ng-show="createCtrl.products.selected">
-        <pnc-select selected-items="createCtrl.productVersions.selected" display-property="version" query="createCtrl.productVersions.getItems($viewValue)" placeholder="Enter product version..."></pnc-select>
+        <pnc-select selected-items="createCtrl.productVersions.selected" additional-display-items-by-id="createCtrl.allProductNamesMaps" display-property="version" query="createCtrl.productVersions.getItems($viewValue)" placeholder="Enter product version..."></pnc-select>
       </div>
     </div>
 

--- a/ui/app/configuration/views/configuration.detail-main.html
+++ b/ui/app/configuration/views/configuration.detail-main.html
@@ -115,16 +115,19 @@
             <select id="input-product" ng-model="detailCtrl.products.selected" ng-options="product.name for product in detailCtrl.products.all" ng-change="detailCtrl.productVersions.update()"></select>
           </div>
         </div>
+
         <div class="form-group">
           <label for="input-product-versions" class="col-sm-2 control-label">Product Versions</label>
           <div class="col-sm-10">
             <!-- Show when edit is not selected -->
             <ul class="list-inline form-control-static" ng-hide="configurationForm.$visible">
-              <li ng-repeat="version in detailCtrl.productVersions.selected"><a href ui-sref="product.detail.version({ productId: version.productId, versionId: version.id })">{{ version.version }}</a></li>
+              <li ng-repeat="version in detailCtrl.productVersions.selected">
+               <a href ui-sref="product.detail.version({ productId: version.productId, versionId: version.id })">{{ detailCtrl.allProductsMaps[version.productId].name }} - {{ version.version }}</a>
+              </li>
             </ul>
 
             <!-- Show when edit is selected -->
-            <pnc-select id="input-product-versions" ng-show="configurationForm.$visible && detailCtrl.products.selected" selected-items="detailCtrl.productVersions.selected" display-property="version" query="detailCtrl.productVersions.getItems($viewValue)" placeholder="Enter product version..."></pnc-select>
+            <pnc-select id="input-product-versions" ng-show="configurationForm.$visible && detailCtrl.products.selected" selected-items="detailCtrl.productVersions.selected" additional-display-items-by-id="detailCtrl.allProductNamesMaps" display-property="version" query="detailCtrl.productVersions.getItems($viewValue)" placeholder="Enter product version..."></pnc-select>
           </div>
         </div>
 

--- a/ui/app/product/directives/pncProductVersionBCs/pnc-product-version-bcs.html
+++ b/ui/app/product/directives/pncProductVersionBCs/pnc-product-version-bcs.html
@@ -27,6 +27,8 @@
 <table class="table table-bordered table-striped">
   <thead>
   <th>Name</th>
+  <th>Description</th>
+  <th>Project</th>
   <th>Action</th>
   </thead>
   <tbody>
@@ -34,6 +36,8 @@
     <td>
       <a ui-sref="configuration.detail.show({configurationId: configuration.id})" href>{{ configuration.name }}</a>
     </td>
+    <td>{{ configuration.description }}</td>
+    <td>{{ configuration.getProject().name }}</td>
     <td class="table-data-5-column-even-width">
       <div class="btn-group">
         <button class="btn btn-default ng-scope" tooltip="Start Build" tooltip-placement="bottom" ng-click="buildConfig(configuration)">


### PR DESCRIPTION
Implementation meant to make the linking of BuildConfiguration to ProductVersions more friendly and clear (and making possible to choice more than one Product). This uncovered some missing pieces, like:
* uniqueConstraints missing on ManyToMany mapping
* the missing mapping from ProductVersion to BuildConfigurations
* a wrong Predicate to get the list of ProductVersions given a BuildConfiguration
* a redundant condition on a Predicate
* the need to tweak some UI directives (in an improvable way once 0.7 is out) to display some additional information