### PR TITLE
Fix for relative path for import

### DIFF
--- a/ui/app/common/restclient/services/ProductImportDAO.js
+++ b/ui/app/common/restclient/services/ProductImportDAO.js
@@ -21,7 +21,7 @@
 
   var module = angular.module('pnc.common.restclient');
 
-  module.value('PRODUCT_IMPORT_ENDPOINT', 'da-bcg/rest/v-0.3/build-configuration/generate/product');
+  module.value('PRODUCT_IMPORT_ENDPOINT', '/da-bcg/rest/v-0.3/build-configuration/generate/product');
 
   /**
    * @author Jakub Senko


### PR DESCRIPTION
If the '/' in the path is omitted, PNC will try to access:

    'localhost:8080/pnc-web/da-bcg ...'

instead of:

    'localhost:8080/da-bcg ...'

This commit fixes it.