### PR TITLE
Describe repo/group for build, clean up build group afterward, improve tests.

### DIFF
--- a/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
+++ b/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
@@ -124,6 +124,12 @@ public class MavenRepositorySession implements RepositorySession {
         List<Artifact> downloads = processDownloads(report);
         Collections.sort(downloads, comp);
 
+        try {
+            aprox.stores().delete(StoreType.group, buildRepoId, "[Post-Build] Removing build aggregation group: " + buildRepoId );
+        } catch (AproxClientException e) {
+            throw new RepositoryManagerException("Failed to retrieve AProx stores module. Reason: %s", e, e.getMessage());
+        }
+
         Logger logger = LoggerFactory.getLogger(getClass());
         logger.info("Returning built artifacts / dependencies:\nUploads:\n  {}\n\nDownloads:\n  {}\n\n",
                 StringUtils.join(uploads, "\n  "), StringUtils.join(downloads, "\n  "));

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyBuildGroupRemovedAfterArtifactExtractionTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyBuildGroupRemovedAfterArtifactExtractionTest.java
@@ -1,0 +1,70 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.mavenrepositorymanager;
+
+import org.commonjava.aprox.folo.client.AproxFoloContentClientModule;
+import org.commonjava.aprox.model.core.Group;
+import org.commonjava.aprox.model.core.StoreKey;
+import org.commonjava.aprox.model.core.StoreType;
+import org.jboss.pnc.mavenrepositorymanager.fixture.TestBuildExecution;
+import org.jboss.pnc.model.Artifact;
+import org.jboss.pnc.spi.BuildExecution;
+import org.jboss.pnc.spi.repositorymanager.RepositoryManagerResult;
+import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class VerifyBuildGroupRemovedAfterArtifactExtractionTest extends AbstractRepositoryManagerDriverTest {
+
+    @Test
+    public void extractBuildArtifactsTriggersBuildRepoPromotionToChainGroup() throws Exception {
+        String path = "/org/myproj/myproj/1.0/myproj-1.0.pom";
+        String content = "This is a test " + System.currentTimeMillis();
+
+        String buildId = "build";
+
+        // create a dummy composed (chained) build execution, and a repo session based on it
+        BuildExecution execution = new TestBuildExecution(null, null, buildId, true);
+        RepositorySession session = driver.createBuildRepository(execution);
+
+        // simulate a build deploying a file.
+        driver.getAprox().module(AproxFoloContentClientModule.class)
+                .store(buildId, StoreType.hosted, buildId, path, new ByteArrayInputStream(content.getBytes()));
+
+        // now, extract the build artifacts. This will trigger promotion of the build hosted repo to the chain group.
+        RepositoryManagerResult result = session.extractBuildArtifacts();
+
+        // do some sanity checks while we're here
+        List<Artifact> deps = result.getBuiltArtifacts();
+        assertThat(deps.size(), equalTo(1));
+
+        Artifact a = deps.get(0);
+        assertThat(a.getFilename(), equalTo(new File(path).getName()));
+
+        // end result: the build aggregation group should have been garbage collected
+        boolean buildGroupExists = driver.getAprox().stores().exists(StoreType.group, buildId);
+        assertThat(buildGroupExists, equalTo(false));
+    }
+
+}

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyBuildRepoPromotionToUntestedBuildsGroupTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyBuildRepoPromotionToUntestedBuildsGroupTest.java
@@ -35,25 +35,24 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.util.List;
 
-public class VerifyBuildRepoPromotionToChainGroupTest extends AbstractRepositoryManagerDriverTest {
+public class VerifyBuildRepoPromotionToUntestedBuildsGroupTest extends AbstractRepositoryManagerDriverTest {
 
     @Test
     public void extractBuildArtifactsTriggersBuildRepoPromotionToChainGroup() throws Exception {
         String path = "/org/myproj/myproj/1.0/myproj-1.0.pom";
         String content = "This is a test " + System.currentTimeMillis();
 
-        String chainId = "chain";
         String buildId = "build";
 
-        // create a dummy composed (chained) build execution, and a repo session based on it
-        BuildExecution execution = new TestBuildExecution(null, chainId, buildId, true);
+        // create a dummy build execution, and a repo session based on it
+        BuildExecution execution = new TestBuildExecution(null, null, buildId, true);
         RepositorySession session = driver.createBuildRepository(execution);
 
         // simulate a build deploying a file.
         driver.getAprox().module(AproxFoloContentClientModule.class)
                 .store(buildId, StoreType.hosted, buildId, path, new ByteArrayInputStream(content.getBytes()));
 
-        // now, extract the build artifacts. This will trigger promotion of the build hosted repo to the chain group.
+        // now, extract the build artifacts. This will trigger promotion of the build hosted repo to the untested-builds group.
         RepositoryManagerResult result = session.extractBuildArtifacts();
 
         // do some sanity checks while we're here
@@ -63,9 +62,9 @@ public class VerifyBuildRepoPromotionToChainGroupTest extends AbstractRepository
         Artifact a = deps.get(0);
         assertThat(a.getFilename(), equalTo(new File(path).getName()));
 
-        // end result: the chain group should contain the build hosted repo.
-        Group chainGroup = driver.getAprox().stores().load(StoreType.group, chainId, Group.class);
-        assertThat(chainGroup.getConstituents().contains(new StoreKey(StoreType.hosted, buildId)), equalTo(true));
+        // end result: the untested-builds group should contain the build hosted repo.
+        Group untestedBuildsGroup = driver.getAprox().stores().load(StoreType.group, MavenRepositoryConstants.UNTESTED_BUILDS_GROUP, Group.class);
+        assertThat(untestedBuildsGroup.getConstituents().contains(new StoreKey(StoreType.hosted, buildId)), equalTo(true));
     }
 
 }

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/fixture/TestBuildExecution.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/fixture/TestBuildExecution.java
@@ -2,13 +2,13 @@
  * JBoss, Home of Professional Open Source.
  * Copyright 2014 Red Hat, Inc., and individual contributors
  * as indicated by the @author tags.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,8 @@ import java.net.URI;
 import java.util.Optional;
 
 public class TestBuildExecution implements BuildExecution {
+
+    private int id = 1;
 
     private String topContentId;
 
@@ -45,6 +47,10 @@ public class TestBuildExecution implements BuildExecution {
 
     public TestBuildExecution() {
         this("product+myproduct+1-0", null, "build+myproject+12345", false);
+    }
+
+    public int getId() {
+        return id;
     }
 
     @Override

--- a/spi/src/main/java/org/jboss/pnc/spi/BuildExecution.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/BuildExecution.java
@@ -22,6 +22,8 @@ import java.util.Optional;
 
 public interface BuildExecution {
 
+    int getId();
+
     String getTopContentId();
 
     String getBuildSetContentId();


### PR DESCRIPTION

- Tests adjusted to untested-builds group and for build-group cleanup after extraction of artifacts
- Adding desription including build ID and project name to hosted repo / build group
- Removing the build group when artifact extraction completes, since it's only useful during the build.