### PR TITLE
Fix decorateNonPaged bug when DAO method called without arguments.

### DIFF
--- a/ui/app/common/pagination/PageFactory.js
+++ b/ui/app/common/pagination/PageFactory.js
@@ -222,6 +222,7 @@
       factory.decorateNonPaged = function (resource, methodName, newMethodName) {
         var origMethod = resource[methodName];
         resource[newMethodName] = function (origArgs) {
+          origArgs = origArgs || {};
           var args = _(origArgs).extend({
             pageIndex: 0,
             pageSize: 50 // sufficiently large number to prevent to many second calls


### PR DESCRIPTION
This is causing only a single page to be loaded instead of all.