### PR TITLE
Fix inverted logic for adding a dependency. 

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProvider.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProvider.java
@@ -153,8 +153,8 @@ public class BuildConfigurationProvider extends AbstractProvider<BuildConfigurat
         BuildConfiguration dependency = repository.queryById(dependencyId);
 
         ValidationBuilder.validateObject(buildConfig, WhenCreatingNew.class)
-                .validateCondition(configId.equals(dependencyId), "A build configuration cannot depend on itself")
-                .validateCondition(dependency.getAllDependencies().contains(buildConfig), "Cannot add dependency from : " + configId + " to: " + dependencyId + " because it would introduce a cyclic dependency");
+                .validateCondition(!configId.equals(dependencyId), "A build configuration cannot depend on itself")
+                .validateCondition(!dependency.getAllDependencies().contains(buildConfig), "Cannot add dependency from : " + configId + " to: " + dependencyId + " because it would introduce a cyclic dependency");
 
         buildConfig.addDependency(dependency);
         repository.save(buildConfig);


### PR DESCRIPTION
validateCondition needs the boolean parameter to be true, otherwise validation will fail. Without this change, the validateCondition will only pass when configId == dependencyId, which cannot be the intent. With this fix, NCL-1264 becomes possible.