### PR TITLE
NCL-1451, NCL-1448, NCL-1413, NCL-1446 - Ui form reset and validation

### DIFF
--- a/ui/app/configuration-set/configuration-set-controllers.js
+++ b/ui/app/configuration-set/configuration-set-controllers.js
@@ -38,7 +38,7 @@
     'ProductVersionDAO',
     function($log, $state, products, BuildConfigurationSetDAO, ProductVersionDAO) {
       var self = this;
-      this.data = new BuildConfigurationSetDAO();
+      self.data = new BuildConfigurationSetDAO();
       self.products = products;
       self.productVersions = [];
 
@@ -74,7 +74,7 @@
         }
       };
 
-      this.submit = function() {
+      self.submit = function() {
         self.data.$save().then(
           function() {
             if (self.data.productVersionId) {
@@ -92,6 +92,16 @@
             }
           }
         );
+      };
+
+      self.reset = function(configurationSetForm) {
+        if (configurationSetForm) {
+          configurationSetForm.$setPristine();
+          configurationSetForm.$setUntouched();
+          self.data = new BuildConfigurationSetDAO();
+          self.selectedProductId = '';
+          self.getProductVersions(null);
+        }
       };
     }
   ]);
@@ -256,8 +266,17 @@
 
       // Update a build configuration set after editing
       self.update = function() {
-        $log.debug('Updating configuration-set: %O', this.set);
-        this.set.$update();
+        $log.debug('Updating configuration-set: %O', self.set);
+        self.set.$update(
+        ).then(
+          function() {
+            $state.go('configuration-set.detail', {
+              configurationSetId: self.set.id
+            }, {
+              reload: true
+            });
+          }
+        );
       };
 
       self.getProductVersions = function(productId) {

--- a/ui/app/configuration-set/views/configuration-set.create.html
+++ b/ui/app/configuration-set/views/configuration-set.create.html
@@ -69,7 +69,7 @@
         <div class="form-group">
           <div class="col-sm-offset-2 col-sm-10">
             <input type="submit" class="btn btn-primary" value="Create" ng-disabled="configurationSetForm.$invalid">
-            <input type="reset" class="btn btn-default" value="Clear">
+            <input type="reset" class="btn btn-default" value="Clear" ng-click="createSetCtrl.reset(configurationSetForm)">
           </div>
         </div>
       </form>

--- a/ui/app/configuration-set/views/configuration-set.detail.html
+++ b/ui/app/configuration-set/views/configuration-set.detail.html
@@ -47,7 +47,8 @@
 
   <form editable-form class="form-horizontal" name="setEditForm" onbeforesave="detailSetCtrl.update()" novalidate>
     <div class="form-group" ng-class="{ 'has-error': setEditForm.name.$invalid && !setEditForm.name.$pristine, 'has-success': setEditForm.name.$valid && setEditForm.name.$touched }">
-      <label for="input-name" class="col-sm-1 control-label">Name</label>
+      <label for="input-name" class="col-sm-1 control-label" ng-show="setEditForm.$visible">* Name</label>
+      <label for="input-name" class="col-sm-1 control-label" ng-show="!setEditForm.$visible">Name</label>
       <div class="col-sm-11">
         <p id="input-name" class="form-control-static" e-class="form-control" editable-text="detailSetCtrl.set.name" e-name="name" e-required>{{ detailSetCtrl.set.name || 'Empty' }}</p>
         <span class="help-block" ng-show="setEditForm.name.$error.required && !setEditForm.name.$pristine">Required field.</span>
@@ -58,7 +59,7 @@
         <button type="submit" class="btn btn-primary" ng-disabled="setEditForm.$waiting || setEditForm.name.$invalid">
           Save
         </button>
-        <button type="button" class="btn btn-default" ng-disabled="setEditForm.$waiting" ng-click="setEditForm.$cancel()">
+        <button type="button" class="btn btn-default" ng-disabled="setEditForm.$waiting" ng-click="setEditForm.$cancel(); setEditForm.$setPristine(); setEditForm.$setUntouched();">
           Cancel
         </button>
       </div>

--- a/ui/app/configuration/views/configuration.create.html
+++ b/ui/app/configuration/views/configuration.create.html
@@ -64,10 +64,12 @@
               </div>
             </div>
 
-            <div class="form-group">
-              <label for="input-scm-repo-url" class="col-sm-2 control-label">SCM Url</label>
+            <div class="form-group" ng-class="{ 'has-error': configurationForm.scmRepoURL.$invalid && !configurationForm.scmRepoURL.$pristine, 'has-success': configurationForm.scmRepoURL.$valid && configurationForm.scmRepoURL.$touched }">
+              <label for="input-scm-repo-url" class="col-sm-2 control-label">* SCM Url</label>
               <div class="col-sm-10">
-                <input id="input-scm-repo-url" class="form-control" name="scmRepoURL" ng-model="createCtrl.data.scmRepoURL">
+                <input type="url" id="input-scm-repo-url" class="form-control" name="scmRepoURL" ng-model="createCtrl.data.scmRepoURL" required>
+                <span class="help-block" ng-show="configurationForm.scmRepoURL.$error.required && !configurationForm.scmRepoURL.$pristine">Required field.</span>
+                <span class="help-block" ng-show="configurationForm.scmRepoURL.$error.url && !configurationForm.scmRepoURL.$pristine">Malformed URL.</span>
               </div>
             </div>
 
@@ -78,10 +80,11 @@
               </div>
             </div>
 
-            <div class="form-group">
-              <label for="input-build-script" class="col-sm-2 control-label">Build Script</label>
+            <div class="form-group" ng-class="{ 'has-error': configurationForm.buildScript.$invalid && !configurationForm.buildScript.$pristine, 'has-success': configurationForm.buildScript.$valid && configurationForm.buildScript.$touched }">
+              <label for="input-build-script" class="col-sm-2 control-label">* Build Script</label>
               <div class="col-sm-10">
-                <textarea id="input-build-script" class="form-control" name="buildScript" spellcheck="false" ng-model="createCtrl.data.buildScript"></textarea>
+                <textarea id="input-build-script" class="form-control" name="buildScript" spellcheck="false" ng-model="createCtrl.data.buildScript" required></textarea>
+                <span class="help-block" ng-show="configurationForm.buildScript.$error.required && !configurationForm.buildScript.$pristine">Required field.</span>
               </div>
             </div>
 
@@ -139,7 +142,7 @@
         <div class="form-group">
           <div class="col-sm-offset-2 col-sm-10">
             <input type="submit" class="btn btn-primary" value="Create" ng-disabled="configurationForm.$invalid">
-            <input type="reset" class="btn btn-default" value="Clear">
+            <input type="reset" class="btn btn-default" value="Clear" ng-click="createCtrl.reset(configurationForm)">
           </div>
         </div>
       </form>

--- a/ui/app/configuration/views/configuration.detail-main.html
+++ b/ui/app/configuration/views/configuration.detail-main.html
@@ -47,7 +47,8 @@
       <form editable-form class="form-horizontal" name="configurationForm" onbeforesave="detailCtrl.update()" novalidate>
 
         <div class="form-group" ng-class="{ 'has-error' : configurationForm.name.$invalid && !configurationForm.name.$pristine, 'has-success': configurationForm.name.$valid && configurationForm.name.$touched }">
-          <label for="input-name" class="col-sm-2 control-label">Name</label>
+          <label for="input-name" class="col-sm-2 control-label" ng-show="configurationForm.$visible">* Name</label>
+          <label for="input-name" class="col-sm-2 control-label" ng-show="!configurationForm.$visible">Name</label>
           <div class="col-sm-10">
             <p id="input-name" class="form-control-static" e-pattern="^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*(?!\.git)+$" e-class="form-control" editable-text="detailCtrl.configuration.name" e-name="name" e-required>{{ detailCtrl.configuration.name || 'Empty' }}</p>
             <span class="help-block" ng-show="configurationForm.name.$error.required && !configurationForm.name.$pristine">Required field.</span>
@@ -69,10 +70,13 @@
           </div>
         </div>
 
-        <div class="form-group">
-          <label for="input-scm-repo-url" class="col-sm-2 control-label">SCM Url</label>
+        <div class="form-group" ng-class="{ 'has-error': configurationForm.scmRepoURL.$invalid && !configurationForm.scmRepoURL.$pristine, 'has-success': configurationForm.scmRepoURL.$valid && configurationForm.scmRepoURL.$touched }">
+          <label for="input-scm-repo-url" class="col-sm-2 control-label" ng-show="configurationForm.$visible">* SCM Url</label>
+          <label for="input-scm-repo-url" class="col-sm-2 control-label" ng-show="!configurationForm.$visible">SCM Url</label>
           <div class="col-sm-10">
-            <p id="input-scm-repo-url" class="form-control-static" e-class="form-control" editable-text="detailCtrl.configuration.scmRepoURL" e-name="scmRepoURL">{{ detailCtrl.configuration.scmRepoURL || 'Empty' }}</p>
+            <p e-required e-type="url" id="input-scm-repo-url" class="form-control-static" e-class="form-control" editable-text="detailCtrl.configuration.scmRepoURL" e-name="scmRepoURL">{{ detailCtrl.configuration.scmRepoURL || 'Empty' }}</p>
+            <span class="help-block" ng-show="configurationForm.scmRepoURL.$error.required && !configurationForm.scmRepoURL.$pristine">Required field.</span>
+            <span class="help-block" ng-show="configurationForm.scmRepoURL.$error.url && !configurationForm.scmRepoURL.$pristine">Malformed URL.</span>
           </div>
         </div>
 
@@ -83,10 +87,12 @@
           </div>
         </div>
 
-        <div class="form-group">
-          <label for="input-build-script" class="col-sm-2 control-label">Build Script</label>
+        <div class="form-group" ng-class="{ 'has-error': configurationForm.buildScript.$invalid && !configurationForm.buildScript.$pristine, 'has-success': configurationForm.buildScript.$valid && configurationForm.buildScript.$touched }">
+          <label for="input-build-script" class="col-sm-2 control-label" ng-show="configurationForm.$visible">* Build Script</label>
+          <label for="input-build-script" class="col-sm-2 control-label" ng-show="!configurationForm.$visible">Build Script</label>
           <div class="col-sm-10">
-            <pre id="input-build-script" e-class="form-control" editable-textarea="detailCtrl.configuration.buildScript" e-name="buildScript">{{ detailCtrl.configuration.buildScript || 'Empty' }}</pre>
+            <pre e-required id="input-build-script" e-class="form-control" editable-textarea="detailCtrl.configuration.buildScript" e-name="buildScript">{{ detailCtrl.configuration.buildScript || 'Empty' }}</pre>
+            <span class="help-block" ng-show="configurationForm.buildScript.$error.required && !configurationForm.buildScript.$pristine">Required field.</span>
           </div>
         </div>
 
@@ -144,8 +150,8 @@
         </div>
 
         <div class="form-group">
-          <label for="input-environment" class="col-sm-2 control-label">Environment</label>
-
+          <label for="input-environment" class="col-sm-2 control-label" ng-show="configurationForm.$visible">* Environment</label>
+          <label for="input-environment" class="col-sm-2 control-label" ng-show="!configurationForm.$visible">Environment</label>
           <div class="col-sm-10">
               <p id="input-environment" editable-select="detailCtrl.environment" e-ng-options="environment.name for environment in detailCtrl.environments" onaftersave="detailCtrl.updateEnvironment()">
                   {{ detailCtrl.environment.name || 'Empty' }}
@@ -158,7 +164,7 @@
             <button type="submit" class="btn btn-primary" ng-disabled="configurationForm.$waiting || configurationForm.$invalid">
               Save
             </button>
-            <button type="button" class="btn btn-default" ng-disabled="configurationForm.$waiting" ng-click="configurationForm.$cancel()">
+            <button type="button" class="btn btn-default" ng-disabled="configurationForm.$waiting" ng-click="detailCtrl.cancel(configurationForm)">
               Cancel
             </button>
           </div>

--- a/ui/app/configuration/views/configuration.list.html
+++ b/ui/app/configuration/views/configuration.list.html
@@ -37,7 +37,6 @@
       <th>SCM Revision</th>
       <th>Created</th>
       <th>Modified</th>
-      <th>User</th>
     </thead>
     <tbody>
       <tr ng-repeat="configuration in listCtrl.configurations.data">
@@ -52,7 +51,6 @@
         <td>{{ configuration.scmRevision }}</td>
         <td>{{ configuration.creationTime | date:'medium'}}</td>
         <td>{{ configuration.lastModificationTime | date:'medium'}}</td>
-        <td></td>
       </tr>
     </tbody>
   </table>

--- a/ui/app/import/product/ProductImportCtrl.js
+++ b/ui/app/import/product/ProductImportCtrl.js
@@ -134,6 +134,11 @@
         return _.isString(str) && str.length > 0;
       };
 
+      var isValidBCName = function (name) {
+        var BC_NAME_REGEXP = /^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*(?!\.git)+$/;
+        return BC_NAME_REGEXP.test(name);
+      };
+
       var isValidURL = function (url) {
         var URL_REGEXP = /^(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@\-\/]))?$/;
         return URL_REGEXP.test(url);
@@ -142,6 +147,7 @@
       var nodeValidate = function (node) {
         node.valid = isStrNonEmpty(node.nodeData.name) &&
           (!isStrNonEmpty(node.nodeData.scmUrl) || isValidURL(node.nodeData.scmUrl)) &&
+          (!isStrNonEmpty(node.nodeData.name) || isValidBCName(node.nodeData.name)) &&
           (node.nodeData.environmentId !== null) &&
           (node.nodeData.projectId !== null);
         return node.valid;

--- a/ui/app/import/product/directive/ProductImportBCForm/product-import-bc-form.html
+++ b/ui/app/import/product/directive/ProductImportBCForm/product-import-bc-form.html
@@ -20,7 +20,6 @@
 
 <form class="form-horizontal" name="bcForm" ng-submit="submit()" novalidate>
 
-
   <div class="panel panel-default">
     <div class="panel-body">
 
@@ -32,13 +31,11 @@
 
       <div class="form-group">
         <label class="col-sm-2 control-label">Internally built</label>
-
         <div class="col-sm-10">{{ data.internallyBuilt ? 'Yes' : 'No' }}</div>
       </div>
 
       <div class="form-group">
         <label class="col-sm-2 control-label">BC already exists</label>
-
         <div class="col-sm-10">{{ data.bcExists ? 'Yes' : 'No' }}</div>
       </div>
 
@@ -53,27 +50,23 @@
     </div>
   </div>
 
-
   <div class="panel panel-default" ng-hide="data.useExistingBc">
     <div class="panel-body">
 
-      <div class="form-group" ng-class="bcForm.input1.$dirty && bcForm.input1.$invalid ? 'has-error' : ''">
-        <label for="input1" class="col-sm-2 control-label">BC Name
-          &nbsp;<span class="pficon pficon-info" title="Name for the build configuration."></span>
+      <div class="form-group" ng-class="{ 'has-error' : bcForm.input1.$invalid, 'has-success': bcForm.input1.$valid && bcForm.input1.$touched }">
+        <label for="input1" class="col-sm-2 control-label">
+          * BC Name&nbsp;<span class="pficon pficon-info" title="Name for the build configuration."></span>
         </label>
 
         <div class="col-sm-10">
-          <input id="input1" name="input1" class="form-control" ng-model="data.name" required>
-
-          <div ng-show="bcForm.input1.$dirty && bcForm.input1.$error.required" class="help-block">
-            <p class="text-danger">Required field.</p>
-          </div>
+          <input id="input1" name="input1" class="form-control" ng-model="data.name" required pattern="^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*(?!\.git)+$">
+          <span class="help-block" ng-show="bcForm.input1.$error.required">Required field.</span>
+          <span class="help-block" ng-show="bcForm.input1.$error.pattern">The name contains not allowed characters (e.g spaces, commas, semicolons, apex, quotes) </span>
         </div>
       </div>
 
       <div class="form-group">
         <label for="input2" class="col-sm-2 control-label">Description</label>
-
         <div class="col-sm-10">
           <input id="input2" name="input2" class="form-control" ng-model="data.description">
         </div>
@@ -86,23 +79,16 @@
   <div class="panel panel-default" ng-hide="data.useExistingBc">
     <div class="panel-body">
 
-      <div class="form-group" ng-class="bcForm.input3.$dirty && bcForm.input3.$invalid ? 'has-error' : ''">
+      <div class="form-group" ng-class="{ 'has-error' : bcForm.input3.$invalid && !bcForm.input3.$pristine, 'has-success': bcForm.input3.$valid && bcForm.input3.$touched }">
         <label for="input3" class="col-sm-2 control-label">Git URL</label>
-
         <div class="col-sm-10">
           <input type="url" id="input3" name="input3" class="form-control" ng-model="data.scmUrl">
-
-          <div ng-show="bcForm.input3.$dirty && bcForm.input3.$error.url" class="help-block">
-            <p class="text-danger">Invalid URL.</p>
-          </div>
+          <span class="help-block" ng-show="bcForm.input3.$error.url && !bcForm.input3.$pristine">Invalid URL.</span>
         </div>
-
       </div>
-
 
       <div class="form-group">
         <label for="input5" class="col-sm-2 control-label">Revision</label>
-
         <div class="col-sm-10">
           <input id="input5" class="form-control" name="input5" ng-model="data.scmRevision">
           <div class="help-block">
@@ -120,15 +106,13 @@
 
       <div class="form-group">
         <label for="input6" class="col-sm-2 control-label">Build script</label>
-
         <div class="col-sm-10">
           <textarea id="input6" name="input6" rows="3" class="form-control" ng-model="data.buildScript"></textarea>
         </div>
       </div>
 
       <div class="form-group">
-        <label class="col-sm-2 control-label">Environment</label>
-
+        <label class="col-sm-2 control-label">* Environment</label>
         <div class="col-sm-10">
           <environment-dropdown selected-id="data.environmentId"></environment-dropdown>
           <div ng-show="data.environmentId === null" class="help-block">
@@ -138,8 +122,7 @@
       </div>
 
       <div class="form-group">
-        <label class="col-sm-2 control-label">Project</label>
-
+        <label class="col-sm-2 control-label">* Project</label>
         <div class="col-sm-10">
           <project-dropdown selected-id="data.projectId" refresh="refresh"></project-dropdown>
           <div ng-show="data.projectId === null" class="help-block">
@@ -156,7 +139,6 @@
 
     </div>
   </div>
-
 
   <div class="form-group pull-right">
     <div class="col-sm-12">

--- a/ui/app/import/product/directive/ProductImportStartForm/product-import-start-form.html
+++ b/ui/app/import/product/directive/ProductImportStartForm/product-import-start-form.html
@@ -20,45 +20,34 @@
 
 <form class="form-horizontal" name="startForm" ng-submit="submit()" novalidate>
 
-
   <div class="panel panel-default">
     <div class="panel-body">
 
       <div class="form-group"
-           ng-class="startForm.input1.$dirty && startForm.input1.$invalid ? 'has-error' : ''">
-        <label for="input1" class="col-sm-2 control-label">Product Name
-          &nbsp;<span class="pficon pficon-info" title="Name of the Product you are importing."></span>
+          ng-class="{ 'has-error' : startForm.input1.$invalid && !startForm.input1.$pristine, 'has-success': startForm.input1.$valid && startForm.input1.$touched }">
+        <label for="input1" class="col-sm-2 control-label">
+          * Product Name&nbsp;<span class="pficon pficon-info" title="Name of the Product you are importing."></span>
         </label>
 
         <div class="col-sm-10">
           <input id="input1" name="input1" class="form-control" ng-model="data.name" required>
-
-          <div ng-show="startForm.input1.$dirty && startForm.input1.$error.required" class="help-block">
-            <p class="text-danger">Required field.</p>
-          </div>
+          <span class="help-block" ng-show="startForm.input1.$error.required && !startForm.input1.$pristine">Required field.</span>
         </div>
       </div>
 
 
       <div class="form-group"
-           ng-class="startForm.input11.$dirty && startForm.input11.$invalid ? 'has-error' : ''">
-        <label for="input11" class="col-sm-2 control-label">Product version
-          &nbsp;<span class="pficon pficon-info" title="Major.minor version of a product, i.e. 7.0"></span>
+          ng-class="{ 'has-error' : startForm.input11.$invalid && !startForm.input11.$pristine, 'has-success': startForm.input11.$valid && startForm.input11.$touched }">
+        <label for="input11" class="col-sm-2 control-label">
+          * Product version&nbsp;<span class="pficon pficon-info" title="Major.minor version of a product, i.e. 7.0"></span>
         </label>
 
         <div class="col-sm-10">
           <input id="input11" name="input11" class="form-control" ng-model="data.productVersion"
                  pattern="^[0-9]+\.[0-9]+$"
                  required>
-
-          <div ng-show="startForm.input11.$dirty && startForm.input11.$error.required"
-               class="help-block">
-            <p class="text-danger">Required field.</p>
-          </div>
-          <div ng-show="startForm.input11.$dirty && startForm.input11.$error.pattern"
-               class="help-block">
-            <p class="text-danger">Product version must consist of two integers joined by a dot.</p>
-          </div>
+          <span class="help-block" ng-show="startForm.input11.$error.required && !startForm.input11.$pristine">Required field.</span>
+          <span class="help-block" ng-show="startForm.input11.$error.pattern && !startForm.input11.$pristine">The version should consist of two numeric parts separated by a dot (e.g 7.0).</span>
         </div>
       </div>
 
@@ -70,26 +59,21 @@
     <div class="panel-body">
 
       <div class="form-group"
-           ng-class="startForm.input2.$dirty && startForm.input2.$invalid ? 'has-error' : ''">
-        <label for="input2" class="col-sm-2 control-label">Git URL
-          &nbsp;<span class="pficon pficon-info" title="URL of the product code repository."></span>
+           ng-class="{ 'has-error' : startForm.input2.$invalid && !startForm.input2.$pristine, 'has-success': startForm.input2.$valid && startForm.input2.$touched }">
+        <label for="input2" class="col-sm-2 control-label">
+          * Git URL&nbsp;<span class="pficon pficon-info" title="URL of the product code repository."></span>
         </label>
 
         <div class="col-sm-10">
           <input type="url" id="input2" name="input2" class="form-control" ng-model="data.scmUrl" required>
-
-          <div ng-show="startForm.input2.$dirty && startForm.input2.$error.required" class="help-block">
-            <p class="text-danger">Required field.</p>
-          </div>
-          <div ng-show="startForm.input2.$dirty && startForm.input2.$error.url" class="help-block">
-            <p class="text-danger">Invalid URL.</p>
-          </div>
+          <span class="help-block" ng-show="startForm.input2.$error.required && !startForm.input2.$pristine">Required field.</span>
+          <span class="help-block" ng-show="startForm.input2.$error.url && !startForm.input2.$pristine">Invalid URL.</span>
         </div>
       </div>
 
       <div class="form-group">
-        <label for="input3" class="col-sm-2 control-label">Revision
-          &nbsp;<span class="pficon pficon-info" title="SCM revision to use."></span>
+        <label for="input3" class="col-sm-2 control-label">
+          Revision&nbsp;<span class="pficon pficon-info" title="SCM revision to use."></span>
         </label>
 
         <div class="col-sm-10">
@@ -101,11 +85,9 @@
       </div>
 
       <div class="form-group">
-        <label for="input4" class="col-sm-2 control-label">Path to root POM
-          &nbsp;<span class="pficon pficon-info"
-                      title="Location of the product's root POM file within the repository."></span>
+        <label for="input4" class="col-sm-2 control-label">
+          Path to root POM&nbsp;<span class="pficon pficon-info" title="Location of the product's root POM file within the repository."></span>
         </label>
-
         <div class="col-sm-10">
           <input placeholder="./pom.xml" id="input4" name="input4" class="form-control" ng-model="data.pomPath">
         </div>
@@ -117,10 +99,8 @@
 
   <div class="form-group pull-right">
     <div class="col-sm-offset-2 col-sm-10">
-      <input type="submit" class="btn btn-primary" value="Start process" ng-disabled="submitDisabled">
+      <input type="submit" class="btn btn-primary" value="Start process" ng-disabled="submitDisabled || startForm.$invalid">
       <input type="reset" class="btn btn-default" value="Clear">
     </div>
   </div>
-
-
 </form>

--- a/ui/app/import/product/directive/ProductImportTree/product-import-tree.html
+++ b/ui/app/import/product/directive/ProductImportTree/product-import-tree.html
@@ -23,17 +23,15 @@
   <div class="panel panel-default">
     <div class="panel-body">
 
-      <div class="form-group" ng-class="finishForm.inputf1.$dirty && finishForm.inputf1.$invalid ? 'has-error' : ''">
-        <label for="inputf1" class="col-sm-4 control-label">BC set name
-          &nbsp;<span class="pficon pficon-info"
+      <div class="form-group" ng-class="{ 'has-error' : finishForm.inputf1.$invalid, 'has-success': finishForm.inputf1.$valid && finishForm.inputf1.$touched }">
+        <label for="inputf1" class="col-sm-4 control-label">
+          * BC set name&nbsp;<span class="pficon pficon-info"
                       title="Name of the build configurations set that will contain selected configurations."></span>
         </label>
 
         <div class="col-sm-8">
-          <input id="inputf1" name="inputf1" class="form-control" ng-model="bcSetName">
-          <div ng-show="finishForm.inputf1.$dirty && finishForm.inputf1.$error.required" class="help-block">
-            <p class="text-danger">Required field.</p>
-          </div>
+          <input id="inputf1" name="inputf1" class="form-control" ng-model="bcSetName" required>
+          <span class="help-block" ng-show="finishForm.inputf1.$error.required">Required field.</span>
         </div>
       </div>
 
@@ -52,7 +50,7 @@
   <div class="form-group">
     <div class="col-sm-12">
       <div class="pull-right">
-        <input type="submit" class="btn btn-primary" value="Finish process" ng-disabled="submitDisabled">
+        <input type="submit" class="btn btn-primary" value="Finish process" ng-disabled="submitDisabled || finishForm.$invalid">
         <input type="reset" class="btn btn-default"
                pnc-confirm-click="reset()"
                pnc-confirm-message="Reset the entire import process and start over?" value="Reset">

--- a/ui/app/product/product-controllers.js
+++ b/ui/app/product/product-controllers.js
@@ -31,11 +31,12 @@
 
   module.controller('ProductDetailController', [
     '$log',
+    '$state',
     'productDetail',
     'productVersions',
     'ProductMilestoneDAO',
     'ProductReleaseDAO',
-    function($log, productDetail, productVersions, ProductMilestoneDAO, ProductReleaseDAO) {
+    function($log, $state, productDetail, productVersions, ProductMilestoneDAO, ProductReleaseDAO) {
 
       var that = this;
       that.product = productDetail;
@@ -44,7 +45,16 @@
       // Update a product after editing
       that.update = function() {
         $log.debug('Updating product: %O', that.product);
-        that.product.$update();
+        that.product.$update().then(
+          function() {
+
+            $state.go('product.detail', {
+              productId: that.product.id
+            }, {
+              reload: true
+            });
+          }
+        );
       };
 
       // Build wrapper objects
@@ -94,6 +104,7 @@
         that.version.$update(
         ).then(
           function() {
+
             $state.go('product.detail.version', {
               productId: productDetail.id,
               versionId: versionDetail.id
@@ -122,6 +133,14 @@
           });
         });
       };
+
+      that.reset = function(form) {
+        if (form) {
+          form.$setPristine();
+          form.$setUntouched();
+          that.data = new ProductDAO();
+        }
+      };
     }
   ]);
 
@@ -147,6 +166,14 @@
             });
           }
         );
+      };
+
+      that.reset = function(form) {
+        if (form) {
+          form.$setPristine();
+          form.$setUntouched();
+          that.data = new ProductVersionDAO();
+        }
       };
     }
   ]);

--- a/ui/app/product/views/product.create.html
+++ b/ui/app/product/views/product.create.html
@@ -74,7 +74,7 @@
         <div class="form-group">
           <div class="col-sm-offset-2 col-sm-10">
             <input type="submit" class="btn btn-primary" value="Create" ng-disabled="productForm.$invalid">
-            <input type="reset" class="btn btn-default" value="Clear">
+            <input type="reset" class="btn btn-default" value="Clear" ng-click="productCreateCtrl.reset(productForm)">
           </div>
         </div>
 

--- a/ui/app/product/views/product.detail.html
+++ b/ui/app/product/views/product.detail.html
@@ -33,7 +33,8 @@
   <form editable-form class="form-horizontal" name="productForm" onbeforesave="detailCtrl.update()" novalidate>
 
     <div class="form-group" ng-class="{ 'has-error': productForm.name.$invalid && !productForm.name.$pristine, 'has-success': productForm.name.$valid && productForm.name.$touched }">
-      <label for="input-name" class="col-sm-1 control-label">Name</label>
+      <label for="input-name" class="col-sm-1 control-label" ng-show="productForm.$visible">* Name</label>
+      <label for="input-name" class="col-sm-1 control-label" ng-show="!productForm.$visible">Name</label>
       <div class="col-sm-11">
         <p id="input-name" class="form-control-static" e-class="form-control" editable-text="detailCtrl.product.name" e-name="name" e-required>{{ detailCtrl.product.name || 'Empty' }}</p>
         <span class="help-block" ng-show="productForm.name.$error.required && !productForm.name.$pristine">Required field.</span>
@@ -73,7 +74,7 @@
         <button type="submit" class="btn btn-primary" ng-disabled="productForm.$waiting || productForm.name.$invalid">
           Save
         </button>
-        <button type="button" class="btn btn-default" ng-disabled="productForm.$waiting" ng-click="productForm.$cancel()">
+        <button type="button" class="btn btn-default" ng-disabled="productForm.$waiting" ng-click="productForm.$cancel(); productForm.$setPristine(); productForm.$setUntouched();">
           Cancel
         </button>
       </div>

--- a/ui/app/product/views/product.version.create.html
+++ b/ui/app/product/views/product.version.create.html
@@ -43,7 +43,7 @@
         <div class="form-group">
           <div class="col-sm-offset-2 col-sm-10">
             <input type="submit" class="btn btn-primary" value="Create" ng-disabled="productVersionForm.$invalid">
-            <input type="reset" class="btn btn-default" value="Clear">
+            <input type="reset" class="btn btn-default" value="Clear" ng-click="productVersionCreateCtrl.reset(productVersionForm)">
           </div>
         </div>
       </form>

--- a/ui/app/product/views/product.version.html
+++ b/ui/app/product/views/product.version.html
@@ -30,9 +30,11 @@
     </pnc-header-buttons>
   </pnc-header>
 
-  <form editable-form class="form-horizontal" name="productVersionForm" onbeforesave="versionCtrl.update()" novalidate>
+  <form editable-form class="form-horizontal" name="productVersionForm" onbeforesave="versionCtrl.update(productVersionForm)" novalidate>
     <div class="form-group" ng-class="{ 'has-error': productVersionForm.version.$invalid && !productVersionForm.version.$pristine, 'has-success': productVersionForm.version.$valid && productVersionForm.version.$touched }">
-      <label for="input-version" class="col-sm-1 control-label">Version</label>
+      <label for="input-version" class="col-sm-1 control-label" ng-show="productVersionForm.$visible">* Version</label>
+      <label for="input-version" class="col-sm-1 control-label" ng-show="!productVersionForm.$visible">Version</label>
+
       <div class="col-sm-11">
         <p id="input-version" e-pattern="^[0-9]+\.[0-9]+$" e-class="form-control" editable-text="versionCtrl.version.version" e-name="version" e-required>{{ versionCtrl.version.version || 'Empty' }} </p>
         <span class="help-block" ng-show="productVersionForm.version.$error.required && !productVersionForm.version.$pristine">Required field.</span>
@@ -61,7 +63,7 @@
         <button type="submit" class="btn btn-primary" ng-disabled="productVersionForm.$waiting || productVersionForm.version.$invalid">
           Save
         </button>
-        <button type="button" class="btn btn-default" ng-disabled="productVersionForm.$waiting" ng-click="productVersionForm.$cancel()">
+        <button type="button" class="btn btn-default" ng-disabled="productVersionForm.$waiting" ng-click="productVersionForm.$cancel(); productVersionForm.$setPristine(); productVersionForm.$setUntouched();">
           Cancel
         </button>
       </div>

--- a/ui/app/project/project-controllers.js
+++ b/ui/app/project/project-controllers.js
@@ -29,16 +29,29 @@
   ]);
 
   module.controller('ProjectDetailController', [
+    '$log',
+    '$state',
     'projectDetail',
     'projectConfigurationList',
-    function(projectDetail, projectConfigurationList) {
-      this.project = projectDetail;
-      this.projectConfigurationList = projectConfigurationList;
+    function($log, $state, projectDetail, projectConfigurationList) {
+      var that = this;
+      that.project = projectDetail;
+      that.projectConfigurationList = projectConfigurationList;
 
-      this.update = function() {
-        this.project.$update();
+      // Update a project after editing
+      that.update = function() {
+        $log.debug('Updating project: %O', that.project);
+        that.project.$update(
+        ).then(
+          function() {
+            $state.go('project.detail', {
+              projectId: that.project.id
+            }, {
+              reload: true
+            });
+          }
+        );
       };
-
     }
   ]);
 
@@ -62,6 +75,7 @@
         if (form) {
           form.$setPristine();
           form.$setUntouched();
+          $scope.project = new ProjectDAO();
         }
       };
     }

--- a/ui/app/project/views/project.create.html
+++ b/ui/app/project/views/project.create.html
@@ -50,17 +50,19 @@
         <div class="panel panel-default">
           <div class="panel-body">
             <!-- Validation: This field is optional, however if it is not empty it must be a valid URL -->
-            <div class="form-group" ng-class="{ 'has-error': projectForm.projectUrl.$invalid, 'has-success': projectForm.projectUrl.$valid && project.projectUrl }">
+            <div class="form-group" ng-class="{ 'has-error': projectForm.projectUrl.$invalid && !projectForm.projectUrl.$pristine, 'has-success': projectForm.projectUrl.$valid && project.projectUrl }">
               <label for="input-url" class="col-sm-2 control-label">Project URL</label>
               <div class="col-sm-10">
                 <input type="url" id="input-url" class="form-control" name="projectUrl" ng-model="project.projectUrl">
+                <span class="help-block" ng-show="projectForm.projectUrl.$invalid && !projectForm.projectUrl.$pristine">Malformed URL.</span>
               </div>
             </div>
             <!-- Validation: This field is optional, however if it is not empty it must be a valid URL -->
-            <div class="form-group" ng-class="{ 'has-error': projectForm.issueTrackerUrl.$invalid, 'has-success': projectForm.issueTrackerUrl.$valid && project.issueTrackerUrl }">
+            <div class="form-group" ng-class="{ 'has-error': projectForm.issueTrackerUrl.$invalid && !projectForm.issueTrackerUrl.$pristine, 'has-success': projectForm.issueTrackerUrl.$valid && project.issueTrackerUrl }">
               <label for="input-issue-tracker" class="col-sm-2 control-label">Issue Tracker URL</label>
               <div class="col-sm-10">
                 <input type="url" id="input-issue-tracker" class="form-control" name="issueTrackerUrl" ng-model="project.issueTrackerUrl">
+                <span class="help-block" ng-show="projectForm.issueTrackerUrl.$invalid && !projectForm.issueTrackerUrl.$pristine">Malformed URL.</span>
               </div>
             </div>
           </div>

--- a/ui/app/project/views/project.detail.html
+++ b/ui/app/project/views/project.detail.html
@@ -33,7 +33,8 @@
   <form editable-form name="projectForm" class="form-horizontal" onbeforesave="detailCtrl.update()" novalidate>
 
     <div class="form-group" ng-class="{ 'has-error': projectForm.name.$invalid && !projectForm.name.$pristine, 'has-success': projectForm.name.$valid && projectForm.name.$touched }">
-      <label for="input-name" class="col-sm-1 control-label">Name</label>
+      <label for="input-name" class="col-sm-1 control-label" ng-show="projectForm.$visible">* Name</label>
+      <label for="input-name" class="col-sm-1 control-label" ng-show="!projectForm.$visible">Name</label>
       <div class="col-sm-11">
         <p id="input-name" e-class="form-control" editable-text="detailCtrl.project.name" e-name="name" e-required>{{ detailCtrl.project.name || 'Empty' }}</p>
         <span class="help-block" ng-show="projectForm.name.$error.required && !projectForm.name.$pristine">Required field.</span>
@@ -45,16 +46,18 @@
         <p id="static-description" class="form-control-static">{{ detailCtrl.project.description || 'Empty' }}</p>
       </div>
     </div>
-    <div class="form-group">
+    <div class="form-group" ng-class="{ 'has-error': projectForm.projectUrl.$invalid && !projectForm.projectUrl.$pristine, 'has-success': projectForm.projectUrl.$valid && project.projectUrl }">
       <label for="input-url" class="col-sm-1 control-label">URL</label>
       <div class="col-sm-11">
-        <p id="input-url" e-class="form-control" editable-text="detailCtrl.project.projectUrl" e-name="projectUrl">{{ detailCtrl.project.projectUrl || 'Empty' }}</p>
+        <p id="input-url" e-type="url" e-class="form-control" editable-text="detailCtrl.project.projectUrl" e-name="projectUrl">{{ detailCtrl.project.projectUrl || 'Empty' }}</p>
+        <span class="help-block" ng-show="projectForm.projectUrl.$invalid && !projectForm.projectUrl.$pristine">Malformed URL.</span>
       </div>
     </div>
-    <div class="form-group">
+    <div class="form-group" ng-class="{ 'has-error': projectForm.issueTrackerUrl.$invalid && !projectForm.issueTrackerUrl.$pristine, 'has-success': projectForm.issueTrackerUrl.$valid && project.issueTrackerUrl }">
       <label for="input-issue-tracker" class="col-sm-1 control-label">Issue tracker</label>
       <div class="col-sm-11">
-        <p id="input-issue-tracker" e-class="form-control" editable-text="detailCtrl.project.issueTrackerUrl" e-name="issueTrackerUrl">{{ detailCtrl.project.issueTrackerUrl || 'Empty' }}</p>
+        <p id="input-issue-tracker" e-type="url" e-class="form-control" editable-text="detailCtrl.project.issueTrackerUrl" e-name="issueTrackerUrl">{{ detailCtrl.project.issueTrackerUrl || 'Empty' }}</p>
+        <span class="help-block" ng-show="projectForm.issueTrackerUrl.$invalid && !projectForm.issueTrackerUrl.$pristine">Malformed URL.</span>
       </div>
     </div>
 
@@ -63,7 +66,7 @@
         <button type="submit" class="btn btn-primary" ng-disabled="projectForm.$waiting || projectForm.$invalid">
           Save
         </button>
-        <button type="button" class="btn btn-default" ng-disabled="projectForm.$waiting" ng-click="projectForm.$cancel()">
+        <button type="button" class="btn btn-default" ng-disabled="projectForm.$waiting" ng-click="projectForm.$cancel(); projectForm.$setPristine(); projectForm.$setUntouched();">
           Cancel
         </button>
       </div>


### PR DESCRIPTION
@alexcreasy 
This adds some consistency when creating and updating Products, Projects, BuildConfigurations, BuildConfigurationSets, ProductVersions, implementing full "clear" and "cancel" functionality (which reset also the form validation state for consistency). Moreover, it adds validation (and feedback) when editing entities inline. After the update, also the pages get reloaded to update all the Breadcrumbs (in some cases they were left not updated).

