### PR TITLE
Ncl 1462 - Improve network calls and polish UI

### DIFF
--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationRestTest.java
@@ -254,7 +254,7 @@ public class BuildConfigurationRestTest {
         ResponseAssertion.assertThat(response).hasJsonValueEqual("content.id", configurationId)
                 .hasJsonValueEqual("content.name", updatedName).hasJsonValueEqual("content.buildScript", updatedBuildScript)
                 .hasJsonValueEqual("content.scmRepoURL", updatedScmUrl).hasJsonValueEqual("content.project.id", updatedProjectId)
-                .hasJsonValueEqual("content.environmentId", environmentId);
+                .hasJsonValueEqual("content.environment.id", environmentId);
         assertThat(projectResponseBeforeTheUpdate.getBody().print()).isEqualTo(projectResponseAfterTheUpdate.getBody().print());
         assertThat(environmentResponseBeforeTheUpdate.getBody().print())
                 .isEqualTo(environmentResponseAfterTheUpdate.getBody().print());

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationRestTest.java
@@ -366,13 +366,13 @@ public class BuildConfigurationRestTest {
 
         BuildConfigurationRest parentBuildConfiguration = new BuildConfigurationRest();
         parentBuildConfiguration.setName(UUID.randomUUID().toString());
-        parentBuildConfiguration.setProjectId(projectRestClient.getValue().getId());
-        parentBuildConfiguration.setEnvironmentId(environmentRestClient.getValue().getId());
+        parentBuildConfiguration.setProject(projectRestClient.getValue());
+        parentBuildConfiguration.setEnvironment(environmentRestClient.getValue());
 
         BuildConfigurationRest childBuildConfiguration = new BuildConfigurationRest();
         childBuildConfiguration.setName(UUID.randomUUID().toString());
-        childBuildConfiguration.setProjectId(projectRestClient.getValue().getId());
-        childBuildConfiguration.setEnvironmentId(environmentRestClient.getValue().getId());
+        childBuildConfiguration.setProject(projectRestClient.getValue());
+        childBuildConfiguration.setEnvironment(environmentRestClient.getValue());
 
         // when
         RestResponse<BuildConfigurationRest> parentConfiguration = this.buildConfigurationRestClient

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationRestTest.java
@@ -253,7 +253,7 @@ public class BuildConfigurationRestTest {
         ResponseAssertion.assertThat(response).hasStatus(200);
         ResponseAssertion.assertThat(response).hasJsonValueEqual("content.id", configurationId)
                 .hasJsonValueEqual("content.name", updatedName).hasJsonValueEqual("content.buildScript", updatedBuildScript)
-                .hasJsonValueEqual("content.scmRepoURL", updatedScmUrl).hasJsonValueEqual("content.projectId", updatedProjectId)
+                .hasJsonValueEqual("content.scmRepoURL", updatedScmUrl).hasJsonValueEqual("content.project.id", updatedProjectId)
                 .hasJsonValueEqual("content.environmentId", environmentId);
         assertThat(projectResponseBeforeTheUpdate.getBody().print()).isEqualTo(projectResponseAfterTheUpdate.getBody().print());
         assertThat(environmentResponseBeforeTheUpdate.getBody().print())

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildRecordRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildRecordRestTest.java
@@ -165,7 +165,7 @@ public class BuildRecordRestTest {
         ResponseAssertion.assertThat(response).hasStatus(200);
         ResponseAssertion.assertThat(response).hasJsonValueEqual("content.id", configurationId);
 
-        projectId = response.body().jsonPath().getInt("content.projectId");
+        projectId = response.body().jsonPath().getInt("content.project.id");
 
         logger.info("projectId: {} ", projectId);
 
@@ -187,7 +187,7 @@ public class BuildRecordRestTest {
         ResponseAssertion.assertThat(response).hasStatus(200);
         ResponseAssertion.assertThat(response).hasJsonValueEqual("content.id", configurationId);
 
-        projectId = response.body().jsonPath().getInt("content.projectId");
+        projectId = response.body().jsonPath().getInt("content.project.id");
 
         logger.info("projectId: {} ", projectId);
 

--- a/integration-test/src/test/resources/buildConfiguration_WithEmptyCreateDate_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_WithEmptyCreateDate_template.json
@@ -1,22 +1,9 @@
 {
     "name": "${_name}",
     "project": {
-      "id": ${_projectId},
-      "name": "Maven Plugin Test",
-      "description": "Sample Maven Project with plugins and external downloads",
-      "issueTrackerUrl": null,
-      "projectUrl": "https://github.com/rnc/mvn-plugin-test",
-      "configurationIds": [
-        5
-      ],
-      "licenseId": null
+      "id": ${_projectId}
     },
     "environment": {
-      "id": ${_environmentId},
-      "name": "Demo Environment 1",
-      "description": null,
-      "imageRepositoryUrl": null,
-      "buildType": "JAVA",
-      "imageId": null
+      "id": ${_environmentId}
     }
 }

--- a/integration-test/src/test/resources/buildConfiguration_WithEmptyCreateDate_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_WithEmptyCreateDate_template.json
@@ -1,5 +1,22 @@
 {
-  "name": "${_name}",
-  "projectId": "${_projectId}",
-  "environmentId": "${_environmentId}"
+    "name": "${_name}",
+    "project": {
+      "id": "${_projectId}",
+      "name": "Maven Plugin Test",
+      "description": "Sample Maven Project with plugins and external downloads",
+      "issueTrackerUrl": null,
+      "projectUrl": "https://github.com/rnc/mvn-plugin-test",
+      "configurationIds": [
+        5
+      ],
+      "licenseId": null
+    },
+    "environment": {
+      "id": ${_environmentId}"
+      "name": "Demo Environment 1",
+      "description": null,
+      "imageRepositoryUrl": null,
+      "buildType": "JAVA",
+      "imageId": null
+    }
 }

--- a/integration-test/src/test/resources/buildConfiguration_WithEmptyCreateDate_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_WithEmptyCreateDate_template.json
@@ -1,7 +1,7 @@
 {
     "name": "${_name}",
     "project": {
-      "id": "${_projectId}",
+      "id": ${_projectId},
       "name": "Maven Plugin Test",
       "description": "Sample Maven Project with plugins and external downloads",
       "issueTrackerUrl": null,
@@ -12,7 +12,7 @@
       "licenseId": null
     },
     "environment": {
-      "id": ${_environmentId}"
+      "id": ${_environmentId},
       "name": "Demo Environment 1",
       "description": null,
       "imageRepositoryUrl": null,

--- a/integration-test/src/test/resources/buildConfiguration_create_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_create_template.json
@@ -6,7 +6,7 @@
     "lastModificationTime":1418382545038,
     "repositories":null,
     "project": {
-      "id": "${_projectId}",
+      "id": ${_projectId},
       "name": "Maven Plugin Test",
       "description": "Sample Maven Project with plugins and external downloads",
       "issueTrackerUrl": null,
@@ -17,7 +17,7 @@
       "licenseId": null
     },
     "environment": {
-      "id": ${_environmentId}"
+      "id": ${_environmentId},
       "name": "Demo Environment 1",
       "description": null,
       "imageRepositoryUrl": null,

--- a/integration-test/src/test/resources/buildConfiguration_create_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_create_template.json
@@ -5,6 +5,23 @@
     "creationTime":1418382545021,
     "lastModificationTime":1418382545038,
     "repositories":null,
-    "projectId": "${_projectId}",
-    "environmentId": "${_environmentId}"
+    "project": {
+      "id": "${_projectId}",
+      "name": "Maven Plugin Test",
+      "description": "Sample Maven Project with plugins and external downloads",
+      "issueTrackerUrl": null,
+      "projectUrl": "https://github.com/rnc/mvn-plugin-test",
+      "configurationIds": [
+        5
+      ],
+      "licenseId": null
+    },
+    "environment": {
+      "id": ${_environmentId}"
+      "name": "Demo Environment 1",
+      "description": null,
+      "imageRepositoryUrl": null,
+      "buildType": "JAVA",
+      "imageId": null
+    }
 }

--- a/integration-test/src/test/resources/buildConfiguration_create_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_create_template.json
@@ -6,22 +6,9 @@
     "lastModificationTime":1418382545038,
     "repositories":null,
     "project": {
-      "id": ${_projectId},
-      "name": "Maven Plugin Test",
-      "description": "Sample Maven Project with plugins and external downloads",
-      "issueTrackerUrl": null,
-      "projectUrl": "https://github.com/rnc/mvn-plugin-test",
-      "configurationIds": [
-        5
-      ],
-      "licenseId": null
+      "id": ${_projectId}
     },
     "environment": {
-      "id": ${_environmentId},
-      "name": "Demo Environment 1",
-      "description": null,
-      "imageRepositoryUrl": null,
-      "buildType": "JAVA",
-      "imageId": null
+      "id": ${_environmentId}
     }
 }

--- a/integration-test/src/test/resources/buildConfiguration_update_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_update_template.json
@@ -5,6 +5,23 @@
     "creationTime": ${_creationTime},
     "lastModificationTime": ${_lastModificationTime},
     "repositories": "${_repositories}",
-    "projectId": "${_projectId}",
-    "environmentId": "${_environmentId}"
+    "project": {
+      "id": "${_projectId}",
+      "name": "Maven Plugin Test",
+      "description": "Sample Maven Project with plugins and external downloads",
+      "issueTrackerUrl": null,
+      "projectUrl": "https://github.com/rnc/mvn-plugin-test",
+      "configurationIds": [
+        5
+      ],
+      "licenseId": null
+    },
+    "environment": {
+      "id": ${_environmentId}"
+      "name": "Demo Environment 1",
+      "description": null,
+      "imageRepositoryUrl": null,
+      "buildType": "JAVA",
+      "imageId": null
+    }
 }

--- a/integration-test/src/test/resources/buildConfiguration_update_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_update_template.json
@@ -6,22 +6,9 @@
     "lastModificationTime": ${_lastModificationTime},
     "repositories": "${_repositories}",
     "project": {
-      "id": ${_projectId},
-      "name": "Maven Plugin Test",
-      "description": "Sample Maven Project with plugins and external downloads",
-      "issueTrackerUrl": null,
-      "projectUrl": "https://github.com/rnc/mvn-plugin-test",
-      "configurationIds": [
-        5
-      ],
-      "licenseId": null
+      "id": ${_projectId}
     },
     "environment": {
-      "id": ${_environmentId},
-      "name": "Demo Environment 1",
-      "description": null,
-      "imageRepositoryUrl": null,
-      "buildType": "JAVA",
-      "imageId": null
+      "id": ${_environmentId}
     }
 }

--- a/integration-test/src/test/resources/buildConfiguration_update_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_update_template.json
@@ -6,7 +6,7 @@
     "lastModificationTime": ${_lastModificationTime},
     "repositories": "${_repositories}",
     "project": {
-      "id": "${_projectId}",
+      "id": ${_projectId},
       "name": "Maven Plugin Test",
       "description": "Sample Maven Project with plugins and external downloads",
       "issueTrackerUrl": null,
@@ -17,7 +17,7 @@
       "licenseId": null
     },
     "environment": {
-      "id": ${_environmentId}"
+      "id": ${_environmentId},
       "name": "Demo Environment 1",
       "description": null,
       "imageRepositoryUrl": null,

--- a/integration-test/src/test/resources/buildConfiguration_with_id_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_with_id_template.json
@@ -7,7 +7,7 @@
     "lastModificationTime": ${_lastModificationTime},
     "repositories": "${_repositories}",
     "project": {
-      "id": "${_projectId}",
+      "id": ${_projectId},
       "name": "Maven Plugin Test",
       "description": "Sample Maven Project with plugins and external downloads",
       "issueTrackerUrl": null,
@@ -18,7 +18,7 @@
       "licenseId": null
     },
     "environment": {
-      "id": ${_environmentId}"
+      "id": ${_environmentId},
       "name": "Demo Environment 1",
       "description": null,
       "imageRepositoryUrl": null,

--- a/integration-test/src/test/resources/buildConfiguration_with_id_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_with_id_template.json
@@ -6,6 +6,23 @@
     "creationTime": ${_creationTime},
     "lastModificationTime": ${_lastModificationTime},
     "repositories": "${_repositories}",
-    "projectId": "${_projectId}",
-    "environmentId": "${_environmentId}"
+    "project": {
+      "id": "${_projectId}",
+      "name": "Maven Plugin Test",
+      "description": "Sample Maven Project with plugins and external downloads",
+      "issueTrackerUrl": null,
+      "projectUrl": "https://github.com/rnc/mvn-plugin-test",
+      "configurationIds": [
+        5
+      ],
+      "licenseId": null
+    },
+    "environment": {
+      "id": ${_environmentId}"
+      "name": "Demo Environment 1",
+      "description": null,
+      "imageRepositoryUrl": null,
+      "buildType": "JAVA",
+      "imageId": null
+    }
 }

--- a/integration-test/src/test/resources/buildConfiguration_with_id_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_with_id_template.json
@@ -7,22 +7,9 @@
     "lastModificationTime": ${_lastModificationTime},
     "repositories": "${_repositories}",
     "project": {
-      "id": ${_projectId},
-      "name": "Maven Plugin Test",
-      "description": "Sample Maven Project with plugins and external downloads",
-      "issueTrackerUrl": null,
-      "projectUrl": "https://github.com/rnc/mvn-plugin-test",
-      "configurationIds": [
-        5
-      ],
-      "licenseId": null
+      "id": ${_projectId}
     },
     "environment": {
-      "id": ${_environmentId},
-      "name": "Demo Environment 1",
-      "description": null,
-      "imageRepositoryUrl": null,
-      "buildType": "JAVA",
-      "imageId": null
+      "id": ${_environmentId}
     }
 }

--- a/rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProvider.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProvider.java
@@ -61,8 +61,9 @@ public class BuildConfigurationProvider extends AbstractProvider<BuildConfigurat
 
     @Inject
     public BuildConfigurationProvider(BuildConfigurationRepository buildConfigurationRepository,
-            BuildConfigurationAuditedRepository buildConfigurationAuditedRepository, RSQLPredicateProducer rsqlPredicateProducer,
-            SortInfoProducer sortInfoProducer, PageInfoProducer pageInfoProducer, ProductVersionRepository productVersionRepository) {
+            BuildConfigurationAuditedRepository buildConfigurationAuditedRepository,
+            RSQLPredicateProducer rsqlPredicateProducer, SortInfoProducer sortInfoProducer, PageInfoProducer pageInfoProducer,
+            ProductVersionRepository productVersionRepository) {
         super(buildConfigurationRepository, rsqlPredicateProducer, sortInfoProducer, pageInfoProducer);
         this.buildConfigurationAuditedRepository = buildConfigurationAuditedRepository;
         this.productVersionRepository = productVersionRepository;
@@ -89,7 +90,8 @@ public class BuildConfigurationProvider extends AbstractProvider<BuildConfigurat
 
     public CollectionInfo<BuildConfigurationRest> getAllForBuildConfigurationSet(int pageIndex, int pageSize,
             String sortingRsql, String query, Integer buildConfigurationSetId) {
-        return queryForCollection(pageIndex, pageSize, sortingRsql, query, withBuildConfigurationSetId(buildConfigurationSetId));
+        return queryForCollection(pageIndex, pageSize, sortingRsql, query,
+                withBuildConfigurationSetId(buildConfigurationSetId));
     }
 
     @Override
@@ -99,25 +101,25 @@ public class BuildConfigurationProvider extends AbstractProvider<BuildConfigurat
     }
 
     @Override
-    protected void validateBeforeUpdating(Integer id, BuildConfigurationRest buildConfigurationRest) throws ValidationException {
+    protected void validateBeforeUpdating(Integer id, BuildConfigurationRest buildConfigurationRest)
+            throws ValidationException {
         super.validateBeforeUpdating(id, buildConfigurationRest);
         validateIfItsNotConflicted(buildConfigurationRest);
     }
 
     private void validateIfItsNotConflicted(BuildConfigurationRest buildConfigurationRest)
             throws ConflictedEntryException, InvalidEntityException {
-        ValidationBuilder.validateObject(buildConfigurationRest, WhenUpdating.class)
-                .validateConflict(() -> {
-                    BuildConfiguration buildConfigurationFromDB = repository
-                            .queryByPredicates(withProjectId(buildConfigurationRest.getProjectId()),
-                                    withName(buildConfigurationRest.getName()));
+        ValidationBuilder.validateObject(buildConfigurationRest, WhenUpdating.class).validateConflict(() -> {
+            BuildConfiguration buildConfigurationFromDB = repository.queryByPredicates(
+                    withProjectId(buildConfigurationRest.getProject().getId()), withName(buildConfigurationRest.getName()));
 
-                    //don't validate against myself
-                    if(buildConfigurationFromDB != null && !buildConfigurationFromDB.getId().equals(buildConfigurationRest.getId())) {
-                        return new ConflictedEntryValidator.ConflictedEntryValidationError(buildConfigurationFromDB.getId(), BuildConfiguration.class, "Configuration with the same name already exists within project");
-                    }
-                    return null;
-                });
+            // don't validate against myself
+            if (buildConfigurationFromDB != null && !buildConfigurationFromDB.getId().equals(buildConfigurationRest.getId())) {
+                return new ConflictedEntryValidator.ConflictedEntryValidationError(buildConfigurationFromDB.getId(),
+                        BuildConfiguration.class, "Configuration with the same name already exists within project");
+            }
+            return null;
+        });
     }
 
     @Override
@@ -129,7 +131,7 @@ public class BuildConfigurationProvider extends AbstractProvider<BuildConfigurat
     protected Function<? super BuildConfigurationRest, ? extends BuildConfiguration> toDBModelModel() {
         return buildConfiguration -> {
             BuildConfiguration buildConfigurationFromDB = null;
-            if(buildConfiguration.getId() != null) {
+            if (buildConfiguration.getId() != null) {
                 buildConfigurationFromDB = repository.queryById(buildConfiguration.getId());
             }
             return buildConfiguration.toBuildConfiguration(buildConfigurationFromDB);
@@ -137,8 +139,8 @@ public class BuildConfigurationProvider extends AbstractProvider<BuildConfigurat
     }
 
     public Integer clone(Integer buildConfigurationId) throws ValidationException {
-        ValidationBuilder.validateObject(WhenCreatingNew.class)
-                .validateAgainstRepository(repository, buildConfigurationId, true);
+        ValidationBuilder.validateObject(WhenCreatingNew.class).validateAgainstRepository(repository, buildConfigurationId,
+                true);
 
         BuildConfiguration buildConfiguration = repository.queryById(buildConfigurationId);
 
@@ -167,7 +169,8 @@ public class BuildConfigurationProvider extends AbstractProvider<BuildConfigurat
         repository.save(buildConfig);
     }
 
-    public CollectionInfo<BuildConfigurationRest> getDependencies(int pageIndex, int pageSize, String sortingRsql, String query, Integer configId) {
+    public CollectionInfo<BuildConfigurationRest> getDependencies(int pageIndex, int pageSize, String sortingRsql, String query,
+            Integer configId) {
         return queryForCollection(pageIndex, pageSize, sortingRsql, query, withDependantConfiguration(configId));
     }
 
@@ -187,11 +190,8 @@ public class BuildConfigurationProvider extends AbstractProvider<BuildConfigurat
 
     public CollectionInfo<BuildConfigurationAuditedRest> getRevisions(int pageIndex, int pageSize, Integer id) {
         List<BuildConfigurationAudited> auditedBuildConfigs = buildConfigurationAuditedRepository.findAllByIdOrderByRevDesc(id);
-        return nullableStreamOf(auditedBuildConfigs)
-                .map(buildConfigurationAuditedToRestModel())
-                .skip(pageIndex * pageSize)
-                .limit(pageSize)
-                .collect(new CollectionInfoCollector<>(pageIndex, pageSize, auditedBuildConfigs.size()));
+        return nullableStreamOf(auditedBuildConfigs).map(buildConfigurationAuditedToRestModel()).skip(pageIndex * pageSize)
+                .limit(pageSize).collect(new CollectionInfoCollector<>(pageIndex, pageSize, auditedBuildConfigs.size()));
     }
 
     public BuildConfigurationAuditedRest getRevision(Integer id, Integer rev) {
@@ -200,7 +200,7 @@ public class BuildConfigurationProvider extends AbstractProvider<BuildConfigurat
         if (auditedBuildConfig == null) {
             return null;
         }
-        return new BuildConfigurationAuditedRest (auditedBuildConfig);
+        return new BuildConfigurationAuditedRest(auditedBuildConfig);
     }
 
     private Function<BuildConfigurationAudited, BuildConfigurationAuditedRest> buildConfigurationAuditedToRestModel() {

--- a/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigSetRecordRest.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigSetRecordRest.java
@@ -17,21 +17,22 @@
  */
 package org.jboss.pnc.rest.restmodel;
 
+import static java.util.Objects.requireNonNull;
+import static org.jboss.pnc.rest.utils.Utility.performIfNotNull;
+
+import java.util.Date;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Null;
+import javax.xml.bind.annotation.XmlRootElement;
+
 import org.jboss.pnc.model.BuildConfigSetRecord;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.BuildStatus;
 import org.jboss.pnc.rest.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.rest.validation.groups.WhenUpdating;
-
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Null;
-import javax.xml.bind.annotation.XmlRootElement;
-import java.util.Date;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static java.util.Objects.requireNonNull;
-import static org.jboss.pnc.rest.utils.Utility.performIfNotNull;
 
 @XmlRootElement(name = "BuildRecord")
 public class BuildConfigSetRecordRest implements GenericRestEntity<Integer> {
@@ -50,6 +51,8 @@ public class BuildConfigSetRecordRest implements GenericRestEntity<Integer> {
 
     private Integer userId;
 
+    private String username;
+
     private Integer productVersionId;
 
     private Set<Integer> buildRecordIds;
@@ -62,14 +65,15 @@ public class BuildConfigSetRecordRest implements GenericRestEntity<Integer> {
         this.id = buildConfigSetRecord.getId();
         this.startTime = buildConfigSetRecord.getStartTime();
         this.endTime = buildConfigSetRecord.getEndTime();
-        performIfNotNull(buildConfigSetRecord.getBuildConfigurationSet(), () -> buildConfigurationSetId = buildConfigSetRecord
-                .getBuildConfigurationSet().getId());
+        performIfNotNull(buildConfigSetRecord.getBuildConfigurationSet(),
+                () -> buildConfigurationSetId = buildConfigSetRecord.getBuildConfigurationSet().getId());
         performIfNotNull(buildConfigSetRecord.getUser(), () -> userId = buildConfigSetRecord.getUser().getId());
-        performIfNotNull(buildConfigSetRecord.getProductVersion(), () -> productVersionId = buildConfigSetRecord.getProductVersion().getId());
+        performIfNotNull(buildConfigSetRecord.getUser(), () -> username = buildConfigSetRecord.getUser().getUsername());
+        performIfNotNull(buildConfigSetRecord.getProductVersion(),
+                () -> productVersionId = buildConfigSetRecord.getProductVersion().getId());
         this.status = buildConfigSetRecord.getStatus();
         requireNonNull(buildConfigSetRecord.getBuildRecords());
-        this.buildRecordIds = buildConfigSetRecord.getBuildRecords().stream()
-                .map(BuildRecord::getId)
+        this.buildRecordIds = buildConfigSetRecord.getBuildRecords().stream().map(BuildRecord::getId)
                 .collect(Collectors.toSet());
     }
 
@@ -121,6 +125,14 @@ public class BuildConfigSetRecordRest implements GenericRestEntity<Integer> {
 
     public void setUserId(Integer userId) {
         this.userId = userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 
     public Integer getProductVersionId() {

--- a/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigSetRecordRest.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigSetRecordRest.java
@@ -43,6 +43,8 @@ public class BuildConfigSetRecordRest implements GenericRestEntity<Integer> {
 
     private Integer buildConfigurationSetId;
 
+    private String buildConfigurationSetName;
+
     private Date startTime;
 
     private Date endTime;
@@ -67,6 +69,8 @@ public class BuildConfigSetRecordRest implements GenericRestEntity<Integer> {
         this.endTime = buildConfigSetRecord.getEndTime();
         performIfNotNull(buildConfigSetRecord.getBuildConfigurationSet(),
                 () -> buildConfigurationSetId = buildConfigSetRecord.getBuildConfigurationSet().getId());
+        performIfNotNull(buildConfigSetRecord.getBuildConfigurationSet(),
+                () -> buildConfigurationSetName = buildConfigSetRecord.getBuildConfigurationSet().getName());
         performIfNotNull(buildConfigSetRecord.getUser(), () -> userId = buildConfigSetRecord.getUser().getId());
         performIfNotNull(buildConfigSetRecord.getUser(), () -> username = buildConfigSetRecord.getUser().getUsername());
         performIfNotNull(buildConfigSetRecord.getProductVersion(),
@@ -117,6 +121,14 @@ public class BuildConfigSetRecordRest implements GenericRestEntity<Integer> {
 
     public void setBuildConfigurationSetId(Integer buildConfigurationSetId) {
         this.buildConfigurationSetId = buildConfigurationSetId;
+    }
+
+    public String getBuildConfigurationSetName() {
+        return buildConfigurationSetName;
+    }
+
+    public void setBuildConfigurationSetName(String buildConfigurationSetName) {
+        this.buildConfigurationSetName = buildConfigurationSetName;
     }
 
     public Integer getUserId() {

--- a/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigurationRest.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigurationRest.java
@@ -17,25 +17,25 @@
  */
 package org.jboss.pnc.rest.restmodel;
 
-import io.swagger.annotations.ApiModelProperty;
-import org.jboss.pnc.model.BuildConfiguration;
-import org.jboss.pnc.model.BuildStatus;
-import org.jboss.pnc.model.BuildEnvironment;
-import org.jboss.pnc.model.ProductVersion;
-import org.jboss.pnc.model.Project;
-import org.jboss.pnc.rest.validation.groups.WhenCreatingNew;
-import org.jboss.pnc.rest.validation.groups.WhenUpdating;
+import static org.jboss.pnc.rest.utils.StreamHelper.nullableStreamOf;
+import static org.jboss.pnc.rest.utils.Utility.performIfNotNull;
+
+import java.util.Date;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
 import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlRootElement;
-import java.util.Date;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import static org.jboss.pnc.rest.utils.StreamHelper.nullableStreamOf;
-import static org.jboss.pnc.rest.utils.Utility.performIfNotNull;
+import org.jboss.pnc.model.BuildConfiguration;
+import org.jboss.pnc.model.BuildStatus;
+import org.jboss.pnc.model.ProductVersion;
+import org.jboss.pnc.rest.validation.groups.WhenCreatingNew;
+import org.jboss.pnc.rest.validation.groups.WhenUpdating;
+
+import io.swagger.annotations.ApiModelProperty;
 
 @XmlRootElement(name = "Configuration")
 public class BuildConfigurationRest implements GenericRestEntity<Integer> {

--- a/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildRecordRest.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildRecordRest.java
@@ -52,6 +52,8 @@ public class BuildRecordRest implements GenericRestEntity<Integer> {
 
     private Integer buildConfigurationId;
 
+    private String buildConfigurationName;
+
     private Integer buildConfigurationRev;
 
     private Integer userId;
@@ -104,6 +106,8 @@ public class BuildRecordRest implements GenericRestEntity<Integer> {
         performIfNotNull(buildRecord.getBuildConfigurationAudited(),
                 () -> buildConfigurationId = buildRecord.getBuildConfigurationAudited().getId().getId());
         performIfNotNull(buildRecord.getBuildConfigurationAudited(),
+                () -> buildConfigurationName = buildRecord.getBuildConfigurationAudited().getName());
+        performIfNotNull(buildRecord.getBuildConfigurationAudited(),
                 () -> buildConfigurationRev = buildRecord.getBuildConfigurationAudited().getRev());
         performIfNotNull(buildRecord.getUser(), () -> userId = buildRecord.getUser().getId());
         performIfNotNull(buildRecord.getUser(), () -> username = buildRecord.getUser().getUsername());
@@ -131,6 +135,7 @@ public class BuildRecordRest implements GenericRestEntity<Integer> {
         this.endTime = buildExecutionTask.getEndTime();
         if (buildExecutionTask.getBuildConfigurationAudited() != null) {
             this.buildConfigurationId = buildExecutionTask.getBuildConfigurationAudited().getId().getId();
+            this.buildConfigurationName = buildExecutionTask.getBuildConfigurationAudited().getName();
             this.buildConfigurationRev = buildExecutionTask.getBuildConfigurationAudited().getRev();
         }
         // FIXME Why masking i.e. BUILD_WAITING status with BUILDING ?
@@ -201,6 +206,14 @@ public class BuildRecordRest implements GenericRestEntity<Integer> {
 
     public void setBuildConfigurationRev(Integer buildConfigurationRev) {
         this.buildConfigurationRev = buildConfigurationRev;
+    }
+
+    public String getBuildConfigurationName() {
+        return buildConfigurationName;
+    }
+
+    public void setBuildConfigurationName(String buildConfigurationName) {
+        this.buildConfigurationName = buildConfigurationName;
     }
 
     public Integer getUserId() {

--- a/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildRecordRest.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/restmodel/BuildRecordRest.java
@@ -56,6 +56,8 @@ public class BuildRecordRest implements GenericRestEntity<Integer> {
 
     private Integer userId;
 
+    private String username;
+
     private String scmRepoURL;
 
     private String scmRevision;
@@ -78,14 +80,13 @@ public class BuildRecordRest implements GenericRestEntity<Integer> {
     private Set<Integer> buildRecordSetIds;
 
     /**
-     * The IDs of the build record sets which represent the builds performed for a milestone
-     * to which this build record belongs
+     * The IDs of the build record sets which represent the builds performed for a milestone to which this build record belongs
      */
     private Set<Integer> performedMilestoneBuildRecordSetIds;
 
     /**
-     * The IDs of the build record sets which represent the builds distributed for a milestone
-     * to which this build record belongs
+     * The IDs of the build record sets which represent the builds distributed for a milestone to which this build record
+     * belongs
      */
     private Set<Integer> distributedMilestoneBuildRecordSetIds;
 
@@ -100,26 +101,27 @@ public class BuildRecordRest implements GenericRestEntity<Integer> {
         this.scmRepoURL = buildRecord.getScmRepoURL();
         this.scmRevision = buildRecord.getScmRevision();
         this.externalArchiveId = buildRecord.getExternalArchiveId();
-        performIfNotNull(buildRecord.getBuildConfigurationAudited(), () -> buildConfigurationId = buildRecord
-                .getBuildConfigurationAudited().getId().getId());
-        performIfNotNull(buildRecord.getBuildConfigurationAudited(), () -> buildConfigurationRev = buildRecord
-                .getBuildConfigurationAudited().getRev());
+        performIfNotNull(buildRecord.getBuildConfigurationAudited(),
+                () -> buildConfigurationId = buildRecord.getBuildConfigurationAudited().getId().getId());
+        performIfNotNull(buildRecord.getBuildConfigurationAudited(),
+                () -> buildConfigurationRev = buildRecord.getBuildConfigurationAudited().getRev());
         performIfNotNull(buildRecord.getUser(), () -> userId = buildRecord.getUser().getId());
+        performIfNotNull(buildRecord.getUser(), () -> username = buildRecord.getUser().getUsername());
         performIfNotNull(buildRecord.getSystemImage(), () -> systemImageId = buildRecord.getSystemImage().getId());
         this.status = buildRecord.getStatus();
         this.buildDriverId = buildRecord.getBuildDriverId();
-        if(buildRecord.getBuildConfigSetRecord() != null)
+        if (buildRecord.getBuildConfigSetRecord() != null)
             this.buildConfigSetRecordId = buildRecord.getBuildConfigSetRecord().getId();
 
         this.buildContentId = buildRecord.getBuildContentId();
-        this.buildRecordSetIds = nullableStreamOf(buildRecord.getBuildRecordSets()).map(buildRecordSet -> buildRecordSet.getId())
-                .collect(Collectors.toSet());
-        this.performedMilestoneBuildRecordSetIds = nullableStreamOf(buildRecord.getBuildRecordSets()).filter(buildRecordSet -> buildRecordSet.getPerformedInProductMilestone() != null)
-                .map(buildRecordSet -> buildRecordSet.getId())
-                .collect(Collectors.toSet());
-        this.distributedMilestoneBuildRecordSetIds = nullableStreamOf(buildRecord.getBuildRecordSets()).filter(buildRecordSet -> buildRecordSet.getDistributedInProductMilestone() != null)
-                .map(buildRecordSet -> buildRecordSet.getId())
-                .collect(Collectors.toSet());
+        this.buildRecordSetIds = nullableStreamOf(buildRecord.getBuildRecordSets())
+                .map(buildRecordSet -> buildRecordSet.getId()).collect(Collectors.toSet());
+        this.performedMilestoneBuildRecordSetIds = nullableStreamOf(buildRecord.getBuildRecordSets())
+                .filter(buildRecordSet -> buildRecordSet.getPerformedInProductMilestone() != null)
+                .map(buildRecordSet -> buildRecordSet.getId()).collect(Collectors.toSet());
+        this.distributedMilestoneBuildRecordSetIds = nullableStreamOf(buildRecord.getBuildRecordSets())
+                .filter(buildRecordSet -> buildRecordSet.getDistributedInProductMilestone() != null)
+                .map(buildRecordSet -> buildRecordSet.getId()).collect(Collectors.toSet());
     }
 
     public BuildRecordRest(BuildExecutionTask buildExecutionTask, Date submitTime) {
@@ -134,9 +136,11 @@ public class BuildRecordRest implements GenericRestEntity<Integer> {
         // FIXME Why masking i.e. BUILD_WAITING status with BUILDING ?
         this.status = BuildStatus.BUILDING;
         buildExecutionTask.getLogsWebSocketLink().ifPresent(logsUri -> this.liveLogsUri = logsUri.toString());
-        performIfNotNull(buildExecutionTask.getBuildConfigSetRecordId(), () -> this.buildConfigSetRecordId = buildExecutionTask.getBuildConfigSetRecordId());
-        if(buildExecutionTask.getUser() != null) {
+        performIfNotNull(buildExecutionTask.getBuildConfigSetRecordId(),
+                () -> this.buildConfigSetRecordId = buildExecutionTask.getBuildConfigSetRecordId());
+        if (buildExecutionTask.getUser() != null) {
             this.userId = buildExecutionTask.getUser().getId();
+            this.username = buildExecutionTask.getUser().getUsername();
         }
         this.buildContentId = buildExecutionTask.getBuildContentId();
     }
@@ -205,6 +209,14 @@ public class BuildRecordRest implements GenericRestEntity<Integer> {
 
     public void setUserId(Integer userId) {
         this.userId = userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 
     public String getScmRepoURL() {

--- a/rest/src/main/java/org/jboss/pnc/rest/restmodel/ProductVersionRest.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/restmodel/ProductVersionRest.java
@@ -49,13 +49,13 @@ public class ProductVersionRest implements GenericRestEntity<Integer> {
 
     private Integer currentProductMilestoneId;
 
-    List<Integer> productMilestoneIds = new ArrayList<Integer>();
+    List<ProductMilestoneRest> productMilestones = new ArrayList<ProductMilestoneRest>();
 
-    List<Integer> productReleaseIds = new ArrayList<Integer>();
+    List<ProductReleaseRest> productReleases = new ArrayList<ProductReleaseRest>();
 
-    List<Integer> buildConfigurationSetIds = new ArrayList<Integer>();
+    List<BuildConfigurationSetRest> buildConfigurationSets = new ArrayList<BuildConfigurationSetRest>();
 
-    List<Integer> buildConfigurationIds = new ArrayList<Integer>();
+    List<BuildConfigurationRest> buildConfigurations = new ArrayList<BuildConfigurationRest>();
 
     public ProductVersionRest() {
     }
@@ -68,19 +68,18 @@ public class ProductVersionRest implements GenericRestEntity<Integer> {
                 ? productVersion.getCurrentProductMilestone().getId() : null;
 
         for (ProductMilestone milestone : productVersion.getProductMilestones()) {
-            productMilestoneIds.add(milestone.getId());
-        }
-
-        for (ProductRelease release : productVersion.getProductReleases()) {
-            productReleaseIds.add(release.getId());
+            productMilestones.add(new ProductMilestoneRest(milestone));
+            if (milestone.getProductRelease() != null) {
+                productReleases.add(new ProductReleaseRest(milestone.getProductRelease()));
+            }
         }
 
         for (BuildConfiguration buildConfiguration : productVersion.getBuildConfigurations()) {
-            buildConfigurationIds.add(buildConfiguration.getId());
+            buildConfigurations.add(new BuildConfigurationRest(buildConfiguration));
         }
 
         for (BuildConfigurationSet buildConfigurationSet : productVersion.getBuildConfigurationSets()) {
-            buildConfigurationSetIds.add(buildConfigurationSet.getId());
+            buildConfigurationSets.add(new BuildConfigurationSetRest(buildConfigurationSet));
         }
 
     }
@@ -111,36 +110,36 @@ public class ProductVersionRest implements GenericRestEntity<Integer> {
         this.productId = productId;
     }
 
-    public List<Integer> getBuildConfigurationSetIds() {
-        return buildConfigurationSetIds;
+    public List<ProductMilestoneRest> getProductMilestones() {
+        return productMilestones;
     }
 
-    public void setBuildConfigurationSetIds(List<Integer> buildConfigurationSetIds) {
-        this.buildConfigurationSetIds = buildConfigurationSetIds;
+    public void setProductMilestones(List<ProductMilestoneRest> productMilestones) {
+        this.productMilestones = productMilestones;
     }
 
-    public List<Integer> getBuildConfigurationIds() {
-        return buildConfigurationIds;
+    public List<ProductReleaseRest> getProductReleases() {
+        return productReleases;
     }
 
-    public void setBuildConfigurationIds(List<Integer> buildConfigurationIds) {
-        this.buildConfigurationIds = buildConfigurationIds;
+    public void setProductReleases(List<ProductReleaseRest> productReleases) {
+        this.productReleases = productReleases;
     }
 
-    public List<Integer> getProductMilestones() {
-        return this.productMilestoneIds;
+    public List<BuildConfigurationSetRest> getBuildConfigurationSets() {
+        return buildConfigurationSets;
     }
 
-    public void setProductMilestoneIds(List<Integer> productMilestoneIds) {
-        this.productMilestoneIds = productMilestoneIds;
+    public void setBuildConfigurationSets(List<BuildConfigurationSetRest> buildConfigurationSets) {
+        this.buildConfigurationSets = buildConfigurationSets;
     }
 
-    public List<Integer> getProductReleases() {
-        return this.productReleaseIds;
+    public List<BuildConfigurationRest> getBuildConfigurations() {
+        return buildConfigurations;
     }
 
-    public void setProductReleaseIds(List<Integer> productReleaseIds) {
-        this.productReleaseIds = productReleaseIds;
+    public void setBuildConfigurations(List<BuildConfigurationRest> buildConfigurations) {
+        this.buildConfigurations = buildConfigurations;
     }
 
     public Integer getCurrentProductMilestoneId() {

--- a/ui/app/configuration-set-record/directives/pncRecentBuildsForCSSet/pnc-recent-builds-for-cs-set.html
+++ b/ui/app/configuration-set-record/directives/pncRecentBuildsForCSSet/pnc-recent-builds-for-cs-set.html
@@ -33,7 +33,7 @@
       <td>{{ record.getBuildConfiguration().getProject().name }}</td>
       <td><a href ui-sref="configuration.detail.show({configurationId: record.getBuildConfiguration().id})">{{
         record.getBuildConfiguration().name }}</a></td>
-      <td>{{ record.getUser().username }}</td>
+      <td>{{ record.username }}</td>
       <td>
         <build-status-icon status="record.status"></build-status-icon>
         <a href ui-sref="record.detail.info({recordId: record.id})"># {{ record.id }}</a>

--- a/ui/app/configuration-set-record/directives/pncRecentBuildsForCSSet/pnc-recent-builds-for-cs-set.html
+++ b/ui/app/configuration-set-record/directives/pncRecentBuildsForCSSet/pnc-recent-builds-for-cs-set.html
@@ -31,8 +31,8 @@
     <tbody>
     <tr ng-repeat="record in page.data">
       <td>{{ record.getBuildConfiguration().getProject().name }}</td>
-      <td><a href ui-sref="configuration.detail.show({configurationId: record.getBuildConfiguration().id})">{{
-        record.getBuildConfiguration().name }}</a></td>
+      <td><a href ui-sref="configuration.detail.show({configurationId: record.buildConfigurationId})">{{
+        record.buildConfigurationName }}</a></td>
       <td>{{ record.username }}</td>
       <td>
         <build-status-icon status="record.status"></build-status-icon>

--- a/ui/app/configuration-set-record/directives/pncRecentCsBuilds/pnc-recent-cs-builds.html
+++ b/ui/app/configuration-set-record/directives/pncRecentCsBuilds/pnc-recent-cs-builds.html
@@ -42,7 +42,7 @@
       <td><a href ui-sref="configuration-set-record.detail.info({recordId: record.id})">{{ record.getConfigurationSet().name }}</a></td>
       <td>{{ record.startTime | date:'medium'}}</td>
       <td>{{ record.endTime | date:'medium'}}</td>
-      <td class="text-bold">{{ record.getUser().username }}</td>
+      <td class="text-bold">{{ record.username }}</td>
     </tr>
     <tr ng-hide="page.data.length">
       <td>

--- a/ui/app/configuration-set-record/directives/pncRecentCsBuilds/pnc-recent-cs-builds.html
+++ b/ui/app/configuration-set-record/directives/pncRecentCsBuilds/pnc-recent-cs-builds.html
@@ -39,7 +39,7 @@
         <build-status-icon status="record.status"></build-status-icon> {{ record.status }}
       </td>
       <td><a href ui-sref="configuration-set-record.detail.info({recordId: record.id})"># {{ record.id }} </a></td>
-      <td><a href ui-sref="configuration-set-record.detail.info({recordId: record.id})">{{ record.getConfigurationSet().name }}</a></td>
+      <td><a href ui-sref="configuration-set-record.detail.info({recordId: record.id})">{{ record.buildConfigurationSetName }}</a></td>
       <td>{{ record.startTime | date:'medium'}}</td>
       <td>{{ record.endTime | date:'medium'}}</td>
       <td class="text-bold">{{ record.username }}</td>

--- a/ui/app/configuration-set-record/directives/pncRunningBuildsForCSSet/pnc-running-builds-for-cs-set.html
+++ b/ui/app/configuration-set-record/directives/pncRunningBuildsForCSSet/pnc-running-builds-for-cs-set.html
@@ -33,7 +33,7 @@
       <td>{{ record.getBuildConfiguration().getProject().name }}</td>
       <td><a href ui-sref="configuration.detail.show({configurationId: record.getBuildConfiguration().id})">{{
         record.getBuildConfiguration().name }}</a></td>
-      <td>{{ record.getUser().username }}</td>
+      <td>{{ record.username }}</td>
       <td>
         <build-status-icon status="record.status"></build-status-icon>
         <a href ui-sref="record.detail.info({recordId: record.id})"># {{ record.id }}</a>

--- a/ui/app/configuration-set-record/directives/pncRunningBuildsForCSSet/pnc-running-builds-for-cs-set.html
+++ b/ui/app/configuration-set-record/directives/pncRunningBuildsForCSSet/pnc-running-builds-for-cs-set.html
@@ -31,8 +31,8 @@
     <tbody>
     <tr ng-repeat="record in page.data">
       <td>{{ record.getBuildConfiguration().getProject().name }}</td>
-      <td><a href ui-sref="configuration.detail.show({configurationId: record.getBuildConfiguration().id})">{{
-        record.getBuildConfiguration().name }}</a></td>
+      <td><a href ui-sref="configuration.detail.show({configurationId: record.buildConfigurationId})})">{{
+        record.buildConfigurationName }}</a></td>
       <td>{{ record.username }}</td>
       <td>
         <build-status-icon status="record.status"></build-status-icon>

--- a/ui/app/configuration-set-record/directives/pncRunningCsBuilds/pnc-running-cs-builds.html
+++ b/ui/app/configuration-set-record/directives/pncRunningCsBuilds/pnc-running-cs-builds.html
@@ -41,7 +41,7 @@
       <td><a href ui-sref="configuration-set-record.detail.info({recordId: record.id})"># {{ record.id }} </a></td>
       <td><a href ui-sref="configuration-set-record.detail.info({recordId: record.id})">{{ record.getConfigurationSet().name }}</a></td>
       <td>{{ record.startTime | date:'medium'}}</td>
-      <td class="text-bold">{{ record.getUser().username }}</td>
+      <td class="text-bold">{{ record.username }}</td>
     </tr>
     <tr ng-hide="page.data.length">
       <td>

--- a/ui/app/configuration-set-record/directives/pncRunningCsBuilds/pnc-running-cs-builds.html
+++ b/ui/app/configuration-set-record/directives/pncRunningCsBuilds/pnc-running-cs-builds.html
@@ -39,7 +39,7 @@
         <build-status-icon status="record.status"></build-status-icon> {{ record.status }}
       </td>
       <td><a href ui-sref="configuration-set-record.detail.info({recordId: record.id})"># {{ record.id }} </a></td>
-      <td><a href ui-sref="configuration-set-record.detail.info({recordId: record.id})">{{ record.getConfigurationSet().name }}</a></td>
+      <td><a href ui-sref="configuration-set-record.detail.info({recordId: record.id})">{{ record.buildConfigurationSetName }}</a></td>
       <td>{{ record.startTime | date:'medium'}}</td>
       <td class="text-bold">{{ record.username }}</td>
     </tr>

--- a/ui/app/configuration-set-record/views/record.detail.info.html
+++ b/ui/app/configuration-set-record/views/record.detail.info.html
@@ -20,7 +20,7 @@
 <div class="push-down">
   <dl class="dl-horizontal">
     <dt>Built by:</dt>
-    <dd>{{ ctrl.csRecordDetail.getUser().username }}</dd>
+    <dd>{{ ctrl.csRecordDetail.username }}</dd>
     <div>
       <pnc-running-builds-for-c-s-set bc-set-record-id="ctrl.csRecordDetail.id"></pnc-running-builds-for-c-s-set>
       <pnc-recent-builds-for-c-s-set bc-set-record-id="ctrl.csRecordDetail.id"></pnc-recent-builds-for-c-s-set>

--- a/ui/app/configuration-set/configuration-set-controllers.js
+++ b/ui/app/configuration-set/configuration-set-controllers.js
@@ -193,22 +193,6 @@
       $log.debug('ConfigurationSetDetailController >> this=%O', self);
       self.set = configurationSetDetail;
       self.configurations = configurations;
-      self.lastBuildRecords = [];
-
-      // Retrieve all the last builds (based on ID, not date) of all the build configurations
-      angular.forEach(configurations, function(configuration) {
-
-        BuildRecordDAO.getLatestForConfiguration({
-          configurationId: configuration.id
-        }).then(
-          function(result) {
-            if (result[0]) {
-              self.lastBuildRecords.push(result[0]);
-            }
-          }
-        );
-      });
-
       self.records = records;
 
       // Build a wrapper object that contains all is needed (to avoid 'ng-repeat' in the pages)

--- a/ui/app/configuration-set/directives/pncBCTab/pnc-bc-tab.html
+++ b/ui/app/configuration-set/directives/pncBCTab/pnc-bc-tab.html
@@ -57,7 +57,7 @@
           <build-status-icon status="buildRecord.status"></build-status-icon>
           <span><a href ui-sref="record.detail.info({recordId: buildRecord.id})"> # {{ buildRecord.id }}  </a></span>
           {{ buildRecord.endTime | date:'medium'}},
-          <span class="text-bold">   {{ buildRecord.getUser().username }}</span>
+          <span class="text-bold">   {{ buildRecord.username }}</span>
         </div>
         <em ng-hide="latestBuildRecords[configuration.id].length">none</em>
       </td>

--- a/ui/app/configuration-set/directives/pncBCTab/pnc-bc-tab.html
+++ b/ui/app/configuration-set/directives/pncBCTab/pnc-bc-tab.html
@@ -36,6 +36,7 @@
   <table class="table table-bordered table-striped table-hover">
     <thead>
     <th>Name</th>
+    <th>Project</th>
     <th>Created</th>
     <th>Modified</th>
     <th>Last Executed Build</th>
@@ -48,6 +49,7 @@
           {{ configuration.name }}
         </a>
       </td>
+      <td>{{ configuration.project.name}}</td>
       <td>{{ configuration.creationTime | date:'medium'}}</td>
       <td>{{ configuration.lastModificationTime | date:'medium'}}</td>
       <td>

--- a/ui/app/configuration/configuration-controllers.js
+++ b/ui/app/configuration/configuration-controllers.js
@@ -25,24 +25,8 @@
     '$log',
     '$state',
     'configurationList',
-    'ProjectDAO',
-    function($log, $state, configurationList, ProjectDAO) {
-      var that = this;
-
+    function($log, $state, configurationList) {
       this.configurations = configurationList;
-      this.projects = [];
-
-      angular.forEach(this.configurations.data, function(configuration) {
-        ProjectDAO.get({
-          projectId: configuration.projectId
-        }).$promise.then(
-          function(result) {
-            if (result) {
-              that.projects.push(result);
-            }
-          }
-        );
-      });
     }
   ]);
 

--- a/ui/app/configuration/configuration-controllers.js
+++ b/ui/app/configuration/configuration-controllers.js
@@ -157,7 +157,7 @@
 
       // We need to set environment from existing environments collections to be able to preselect
       // dropdown element when editing
-      this.environment = findEnvironment(this.configuration.environmentId, this.environments);
+      this.environment = findEnvironment(this.configuration.environment.id, this.environments);
 
       var that = this;
 
@@ -257,7 +257,7 @@
       };
 
       that.updateEnvironment = function() {
-          that.configuration.environmentId = that.environment.id;
+          that.configuration.environment.id = that.environment.id;
       };
 
       // Cloning a build configuration

--- a/ui/app/configuration/directives/pncRunningBuildsPanel/pnc-running-builds.html
+++ b/ui/app/configuration/directives/pncRunningBuildsPanel/pnc-running-builds.html
@@ -39,4 +39,5 @@
       </tr>
     </tbody>
   </table>
+  <pnc-pager class="pull-right" page="page"></pnc-pager>
 </div>

--- a/ui/app/configuration/views/configuration.create.html
+++ b/ui/app/configuration/views/configuration.create.html
@@ -32,7 +32,7 @@
                 * Project
               </label>
               <div class="col-sm-10">
-                <select name="projectId" ng-model="createCtrl.data.projectId" required>
+                <select name="projectId" ng-model="createCtrl.data.project.id" required>
                   <option value="">Select a Project</option>
                   <option ng-repeat="project in createCtrl.projects" value="{{ project.id }}">
                     {{ project.name }}
@@ -93,7 +93,7 @@
                 * Environment
               </label>
               <div class="col-sm-10">
-                <select name="environmentId" ng-model="createCtrl.data.environmentId" required>
+                <select name="environmentId" ng-model="createCtrl.data.environment.id" required>
                   <option value="">Select an Environment</option>
                   <option ng-repeat="environment in createCtrl.environments" value="{{ environment.id }}">
                     {{ environment.name }}

--- a/ui/app/configuration/views/configuration.list.html
+++ b/ui/app/configuration/views/configuration.list.html
@@ -46,7 +46,7 @@
           </a>
         </td>
         <td>{{ configuration.description }}</td>
-        <td>{{ configuration.getProject().name }}</td>
+        <td>{{ configuration.project.name }}</td>
         <td>{{ configuration.scmRepoURL }}</td>
         <td>{{ configuration.scmRevision }}</td>
         <td>{{ configuration.creationTime | date:'medium'}}</td>

--- a/ui/app/dashboard/directives/pnc-my-build-sets-panel.html
+++ b/ui/app/dashboard/directives/pnc-my-build-sets-panel.html
@@ -36,7 +36,7 @@
         <td>
           <build-status-icon status="record.status"></build-status-icon> {{ record.status }}
         </td>
-        <td><a href ui-sref="configuration-set-record.detail.info({recordId: record.id})">{{ record.getConfigurationSet().name }}</a></td>
+        <td><a href ui-sref="configuration-set-record.detail.info({recordId: record.id})">{{ record.buildConfigurationSetName }}</a></td>
         <td>{{ record.startTime | date:'medium'}}</td>
         <td>{{ record.endTime | date:'medium'}}</td>
       </tr>

--- a/ui/app/dashboard/directives/pnc-my-builds-panel.html
+++ b/ui/app/dashboard/directives/pnc-my-builds-panel.html
@@ -34,7 +34,7 @@
     <tbody>
       <tr ng-repeat="record in page.data">
         <td><build-status-icon status="record.status"></build-status-icon> {{ record.status }}</td>
-        <td><a href ui-sref="record.detail.info({ recordId: record.id })">{{ record.getBuildConfiguration().name }}</a></td>
+        <td><a href ui-sref="record.detail.info({ recordId: record.id })">{{ record.buildConfigurationName }}</a></td>
         <td>{{ record.startTime | date:'medium' }}</td>
         <td>{{ record.endTime | date:'medium' }}</td>
       </tr>

--- a/ui/app/import/product/ProductImportCtrl.js
+++ b/ui/app/import/product/ProductImportCtrl.js
@@ -148,8 +148,8 @@
         node.valid = isStrNonEmpty(node.nodeData.name) &&
           (!isStrNonEmpty(node.nodeData.scmUrl) || isValidURL(node.nodeData.scmUrl)) &&
           (!isStrNonEmpty(node.nodeData.name) || isValidBCName(node.nodeData.name)) &&
-          (node.nodeData.environmentId !== null) &&
-          (node.nodeData.projectId !== null);
+          (node.nodeData.environment.id !== null) &&
+          (node.nodeData.project.id !== null);
         return node.valid;
       };
 

--- a/ui/app/import/product/directive/ProductImportBCForm/ProductImportBCForm.js
+++ b/ui/app/import/product/directive/ProductImportBCForm/ProductImportBCForm.js
@@ -54,7 +54,7 @@
 
 
           var validate = function () {
-            if (scope.bcForm.$valid && scope.data.environmentId !== null && scope.data.projectId !== null) {
+            if (scope.bcForm.$valid && scope.data.environment.id !== null && scope.data.project.id !== null) {
               return true;
             } else {
               dirtyForm();

--- a/ui/app/import/product/directive/ProductImportBCForm/product-import-bc-form.html
+++ b/ui/app/import/product/directive/ProductImportBCForm/product-import-bc-form.html
@@ -114,8 +114,8 @@
       <div class="form-group">
         <label class="col-sm-2 control-label">* Environment</label>
         <div class="col-sm-10">
-          <environment-dropdown selected-id="data.environmentId"></environment-dropdown>
-          <div ng-show="data.environmentId === null" class="help-block">
+          <environment-dropdown selected-id="data.environment.id"></environment-dropdown>
+          <div ng-show="data.environment.id === null" class="help-block">
             <p class="text-danger">Required field.</p>
           </div>
         </div>
@@ -124,8 +124,8 @@
       <div class="form-group">
         <label class="col-sm-2 control-label">* Project</label>
         <div class="col-sm-10">
-          <project-dropdown selected-id="data.projectId" refresh="refresh"></project-dropdown>
-          <div ng-show="data.projectId === null" class="help-block">
+          <project-dropdown selected-id="data.project.id" refresh="refresh"></project-dropdown>
+          <div ng-show="data.project.id === null" class="help-block">
             <p class="text-danger">Required field.</p>
           </div>
         </div>

--- a/ui/app/product/_product.js
+++ b/ui/app/product/_product.js
@@ -67,9 +67,6 @@
         productDetail: function(ProductDAO, $stateParams) {
           return ProductDAO.get({ productId: $stateParams.productId })
           .$promise;
-        },
-        productVersions: function(ProductDAO, productDetail) {
-          return ProductDAO.getVersions({ productId: productDetail.id });
         }
       }
     });
@@ -96,16 +93,6 @@
           return ProductVersionDAO.get({
             productId: $stateParams.productId,
             versionId: $stateParams.versionId }).$promise;
-        },
-        buildConfigurationSets: function(ProductVersionDAO, $stateParams) {
-          return ProductVersionDAO.getAllBuildConfigurationSets({
-            productId: $stateParams.productId,
-            versionId: $stateParams.versionId }).$promise;
-        },
-        buildConfigurations: function(BuildConfigurationDAO, $stateParams) {
-          return BuildConfigurationDAO.getAllForProductVersion({
-            productId: $stateParams.productId,
-            versionId: $stateParams.versionId });
         }
       }
     });

--- a/ui/app/product/directives/pncProductVersionBCs/pnc-product-version-bcs.html
+++ b/ui/app/product/directives/pncProductVersionBCs/pnc-product-version-bcs.html
@@ -37,7 +37,7 @@
       <a ui-sref="configuration.detail.show({configurationId: configuration.id})" href>{{ configuration.name }}</a>
     </td>
     <td>{{ configuration.description }}</td>
-    <td>{{ configuration.getProject().name }}</td>
+    <td>{{ configuration.project.name }}</td>
     <td class="table-data-5-column-even-width">
       <div class="btn-group">
         <button class="btn btn-default ng-scope" tooltip="Start Build" tooltip-placement="bottom" ng-click="buildConfig(configuration)">

--- a/ui/app/product/directives/pncProductVersionMilestones/pnc-product-version-milestones.html
+++ b/ui/app/product/directives/pncProductVersionMilestones/pnc-product-version-milestones.html
@@ -39,7 +39,7 @@
   <th>Actions</th>
   </thead>
   <tbody>
-  <tr ng-repeat="productmilestone in page.data">
+  <tr ng-repeat="productmilestone in version.productMilestones">
     <td>
       <span class="label label-default"
             ng-class="{ 'label label-primary' : productmilestone.id == version.currentProductMilestoneId }">{{ productmilestone.version }}</span>
@@ -73,4 +73,3 @@
   </tr>
   </tbody>
 </table>
-<pnc-pager class="pull-right" page="page"></pnc-pager>

--- a/ui/app/product/directives/pncProductVersionMilestones/pncProductVersionMilestones.js
+++ b/ui/app/product/directives/pncProductVersionMilestones/pncProductVersionMilestones.js
@@ -27,9 +27,7 @@
   module.directive('pncProductVersionMilestones', [
     '$log',
     '$state',
-    'ProductVersionDAO',
-    'ProductMilestoneDAO',
-    function ($log, $state, ProductVersionDAO, ProductMilestoneDAO) {
+    function ($log, $state) {
 
       return {
         restrict: 'E',
@@ -41,7 +39,6 @@
 
           var versionDetail = scope.version;
           var productDetail = scope.version.getProduct();
-          scope.page = ProductMilestoneDAO.getPagedByProductVersion({versionId: scope.version.id});
 
           scope.unreleaseMilestone = function (milestone) {
             $log.debug('Unreleasing milestone: %O', milestone);

--- a/ui/app/product/directives/pncProductVersionMilestones/pncProductVersionMilestones.js
+++ b/ui/app/product/directives/pncProductVersionMilestones/pncProductVersionMilestones.js
@@ -33,12 +33,13 @@
         restrict: 'E',
         templateUrl: 'product/directives/pncProductVersionMilestones/pnc-product-version-milestones.html',
         scope: {
-          version: '='
+          version: '=',
+          product: '='
         },
         link: function (scope) {
 
           var versionDetail = scope.version;
-          var productDetail = scope.version.getProduct();
+          var productDetail = scope.product;
 
           scope.unreleaseMilestone = function (milestone) {
             $log.debug('Unreleasing milestone: %O', milestone);

--- a/ui/app/product/directives/pncProductVersionReleases/pnc-product-version-releases.html
+++ b/ui/app/product/directives/pncProductVersionReleases/pnc-product-version-releases.html
@@ -35,7 +35,7 @@
   <th>Actions</th>
   </thead>
   <tbody>
-  <tr ng-repeat="productrelease in page.data">
+  <tr ng-repeat="productrelease in version.productReleases">
     <td><span class="label label-success">{{ productrelease.version }}</span></td>
     <td>{{ productrelease.releaseDate | date:'yyyy/MM/dd'}}</td>
     <td class="text-center">
@@ -44,7 +44,7 @@
         <i class="glyphicon glyphicon-download-alt"></i>
       </a>
     </td>
-    <td>Released from Milestone <strong>{{ getMilestoneVersion(productrelease.productMilestoneId) }}</strong></td>
+    <td>Released from Milestone <strong>{{ versionMilestoneNames[productrelease.productMilestoneId] }}</strong></td>
     <td>{{ productrelease.supportLevel }}</td>
     <td>
       <button type="button" class="btn btn-sm btn-default" data-toggle="tooltip" title="Edit Release" ui-sref="product.detail.version.releaseUpdate({ releaseId: productrelease.id })">
@@ -57,4 +57,3 @@
   </tr>
   </tbody>
 </table>
-<pnc-pager class="pull-right" page="page"></pnc-pager>

--- a/ui/app/product/directives/pncProductVersionReleases/pncProductVersionReleases.js
+++ b/ui/app/product/directives/pncProductVersionReleases/pncProductVersionReleases.js
@@ -25,11 +25,7 @@
    * @author Jakub Senko
    */
   module.directive('pncProductVersionReleases', [
-    '$log',
-    '$state',
-    'ProductVersionDAO',
-    'ProductReleaseDAO',
-    function ($log, $state, ProductVersionDAO, ProductReleaseDAO) {
+    function () {
 
       return {
         restrict: 'E',
@@ -39,19 +35,11 @@
         },
         link: function (scope) {
 
-          var productmilestones = scope.version.getMilestones();
-
-          scope.page = ProductReleaseDAO.getPagedByProductVersion({versionId: scope.version.id });
-
-          scope.getMilestoneVersion = function(milestoneId) {
-            var milestoneVersion = '';
-            angular.forEach(productmilestones, function(versionMilestone) {
-              if (versionMilestone.id === milestoneId) {
-                milestoneVersion = versionMilestone.version;
-              }
-            });
-            return milestoneVersion;
-          };
+          var productmilestones = scope.version.productMilestones;
+          scope.versionMilestoneNames = {};
+          angular.forEach(productmilestones, function(versionMilestone) {
+            scope.versionMilestoneNames[versionMilestone.id] = versionMilestone.version;
+          });
         }
       };
     }

--- a/ui/app/product/directives/pncProductVersions/pnc-product-versions.html
+++ b/ui/app/product/directives/pncProductVersions/pnc-product-versions.html
@@ -34,9 +34,9 @@
         {{ version.version }}
       </a>
     </td>
-    <td> {{ getVersionMilestones(version.id) }}
+    <td>
        <span
-         ng-repeat="productmilestone in versionMilestones[version.id] | orderBy: '-productmilestone.startingDate'">
+         ng-repeat="productmilestone in version.productMilestones | orderBy: '-productmilestone.startingDate'">
              <span data-tooltip-html-unsafe="{{ getMilestoneTooltip(productmilestone) }}"
                    data-tooltip-placement="right"
                    class="label label-default"
@@ -46,13 +46,13 @@
        </span>
     </td>
     <td>
-           <span ng-repeat="productrelease in versionReleases[version.id] | orderBy: '-productrelease.releaseDate'">
-             <span data-tooltip-html-unsafe="{{ getReleaseTooltip(productrelease) }}"
-                   data-tooltip-placement="right"
-                   class="label label-success">
-               {{ productrelease.version }}
-             </span>
+         <span ng-repeat="productrelease in version.productReleases | orderBy: '-productrelease.releaseDate'">
+           <span data-tooltip-html-unsafe="{{ getReleaseTooltip(productrelease) }}"
+                 data-tooltip-placement="right"
+                 class="label label-success">
+             {{ productrelease.version }}
            </span>
+         </span>
     </td>
   </tr>
   </tbody>

--- a/ui/app/product/directives/pncProductVersions/pncProductVersions.js
+++ b/ui/app/product/directives/pncProductVersions/pncProductVersions.js
@@ -38,21 +38,6 @@
 
           scope.page = ProductVersionDAO.getPagedByProduct({productId: scope.productId});
 
-          scope.versionMilestones = {};
-
-          scope.versionReleases = {};
-
-          scope.page.onUpdate(function(page) {
-            _(page.data).each(function(version) {
-              version.getMilestones().then(function(data) {
-                scope.versionMilestones[version.id] = data;
-              });
-              version.getReleases().then(function(data) {
-                scope.versionReleases[version.id] = data;
-              });
-            });
-          });
-
           var formatDate = function(date) {
             return date.getFullYear() + '/' + date.getMonth() + '/' + date.getDate();
           };

--- a/ui/app/product/product-controllers.js
+++ b/ui/app/product/product-controllers.js
@@ -33,14 +33,10 @@
     '$log',
     '$state',
     'productDetail',
-    'productVersions',
-    'ProductMilestoneDAO',
-    'ProductReleaseDAO',
-    function($log, $state, productDetail, productVersions, ProductMilestoneDAO, ProductReleaseDAO) {
+    function($log, $state, productDetail) {
 
       var that = this;
       that.product = productDetail;
-      that.versions = productVersions;
 
       // Update a product after editing
       that.update = function() {
@@ -56,34 +52,6 @@
           }
         );
       };
-
-      // Build wrapper objects
-      that.versionMilestones = [];
-      that.versionReleases = [];
-
-      // Retrieve all the artifacts of all the build records of the build configurations set
-      angular.forEach(that.versions, function(version) {
-
-        ProductMilestoneDAO.getAllForProductVersion({
-          versionId: version.id
-        }).then(
-          function(results) {
-            angular.forEach(results, function(result) {
-              that.versionMilestones.push(result);
-            });
-          }
-        );
-
-        ProductReleaseDAO.getAllForProductVersion({
-          versionId: version.id
-        }).then(
-          function(results) {
-            angular.forEach(results, function(result) {
-              that.versionReleases.push(result);
-            });
-          }
-        );
-      });
     }
   ]);
 

--- a/ui/app/product/views/product.version.html
+++ b/ui/app/product/views/product.version.html
@@ -82,7 +82,7 @@
     <div class="col-sm-6 col-md-6 col-sm-pull-6 col-md-pull-6">
       <div class="row">
         <div class="col-md-12" ui-view="sidebar">
-          <pnc-product-version-milestones version="versionCtrl.version"></pnc-product-version-milestones>
+          <pnc-product-version-milestones version="versionCtrl.version" product="versionCtrl.product"></pnc-product-version-milestones>
         </div>
       </div>
     </div>

--- a/ui/app/project/_project.js
+++ b/ui/app/project/_project.js
@@ -68,11 +68,7 @@
         projectDetail: function(ProjectDAO, $stateParams) {
           return ProjectDAO.get({
             projectId: $stateParams.projectId}).$promise;
-        },
-        projectConfigurationList: function(BuildConfigurationDAO, $stateParams) {
-          return BuildConfigurationDAO.getAllForProject({
-            projectId: $stateParams.projectId});
-        },
+        }
       }
     });
 

--- a/ui/app/project/project-controllers.js
+++ b/ui/app/project/project-controllers.js
@@ -32,11 +32,9 @@
     '$log',
     '$state',
     'projectDetail',
-    'projectConfigurationList',
-    function($log, $state, projectDetail, projectConfigurationList) {
+    function($log, $state, projectDetail) {
       var that = this;
       that.project = projectDetail;
-      that.projectConfigurationList = projectConfigurationList;
 
       // Update a project after editing
       that.update = function() {

--- a/ui/app/project/views/project.detail.create-bc.html
+++ b/ui/app/project/views/project.detail.create-bc.html
@@ -64,7 +64,7 @@
             <div class="form-group">
               <label for="input-environment" class="col-sm-2 control-label">Environment</label>
               <div class="col-sm-10">
-              <select ng-model="ctrl.data.environmentId" required>
+              <select ng-model="ctrl.data.environment.id" required>
                 <option value="">Select an Environment</option>
                   <option ng-repeat="environment in ctrl.environments" value="{{ environment.id }}">
                     {{ environment.name }}

--- a/ui/app/record/directives/pncRecentBuilds/pnc-recent-builds.html
+++ b/ui/app/record/directives/pncRecentBuilds/pnc-recent-builds.html
@@ -50,7 +50,7 @@
         </td>
         <td>{{ record.startTime | date:'medium' }}</td>
         <td>{{ record.endTime | date:'medium' }}</td>
-        <td class="text-bold">{{ record.getUser().username }}</td>
+        <td class="text-bold">{{ record.username }}</td>
       </tr>
       <tr ng-hide="page.data.length">
         <td>

--- a/ui/app/record/directives/pncRecentBuilds/pnc-recent-builds.html
+++ b/ui/app/record/directives/pncRecentBuilds/pnc-recent-builds.html
@@ -45,7 +45,7 @@
         </td>
         <td>
           <a href ui-sref="configuration.detail.show({ configurationId: record.buildConfigurationId })">
-            {{ record.getBuildConfiguration().name }}
+            {{ record.buildConfigurationName }}
           </a>
         </td>
         <td>{{ record.startTime | date:'medium' }}</td>

--- a/ui/app/record/directives/pncRunningBuilds/pnc-running-builds.html
+++ b/ui/app/record/directives/pncRunningBuilds/pnc-running-builds.html
@@ -46,7 +46,7 @@
           </a>
         </td>
         <td>{{ record.startTime | date:'medium'}}</td>
-        <td class="text-bold">{{ record.getUser().username }}</td>
+        <td class="text-bold">{{ record.username }}</td>
       </tr>
       <tr ng-hide="page.data.length">
         <td>

--- a/ui/app/record/directives/pncRunningBuilds/pnc-running-builds.html
+++ b/ui/app/record/directives/pncRunningBuilds/pnc-running-builds.html
@@ -42,7 +42,7 @@
         <td><a href ui-sref="record.detail.info({recordId: record.id})"># {{ record.id }}</a></td>
         <td>
           <a href ui-sref="configuration.detail.show({ configurationId: record.buildConfigurationId })">
-            {{ record.getBuildConfiguration().name }}
+            {{ record.buildConfigurationName }}
           </a>
         </td>
         <td>{{ record.startTime | date:'medium'}}</td>

--- a/ui/app/record/views/record.detail.info.html
+++ b/ui/app/record/views/record.detail.info.html
@@ -19,30 +19,6 @@
 -->
 <div class="row push-down">
   <div class="col-sm-12 col-md-10 col-lg-8">
-    <!-- <dl class="dl-horizontal">
-    <dt>Description:</dt>
-      <dd>{{ recordCtrl.configuration.description }}</dd>
-      <dt>Project:</dt>
-      <dd><a href ui-sref="project.detail({ projectId: recordCtrl.project.id })">{{ recordCtrl.project.name }}</a></dd>
-      <dt>User:</dt>
-      <dd>{{ recordCtrl.record.getUser().username }}</dd>
-      <dt>Started:</dt>
-      <dd>{{ recordCtrl.record.startTime | date : 'medium' }}</dd>
-      <span ng-show="recordCtrl.record.endTime">
-        <dt>Finshed:</dt>
-        <dd>{{ recordCtrl.record.endTime | date : 'medium' }}</dd>
-      </span>
-      <dt>Result:</dt>
-      <dd ng-class="recordCtrl.record.status === 'SUCCESS' ? 'text-success' : 'text-danger'">{{ recordCtrl.record.status }}</dd>
-      <dt>SCM Repo:</dt>
-      <dd><a ng-href="{{ recordCtrl.configuration.scmRepoURL }}">{{ recordCtrl.configuration.scmRepoURL }}</a></dd>
-      <dt>SCM Revision:</dt>
-      <dd>{{ recordCtrl.configuration.scmRevision }}</dd>
-      <dt>Environment:</dt>
-      <dd>{{ recordCtrl.environment.name }}</dd>
-      <dt>Script:</dt>
-      <dd><pre class="pre-scrollable">{{ recordCtrl.configuration.buildScript }}</pre></dd>
-    </dl> -->
     <pnc-build-details pnc-record-id="recordCtrl.record.id"></pnc-build-details>
   </div>
 </div>


### PR DESCRIPTION
There are many unnecessary and duplicated network calls when loading the pages across Product Details, ProductVersions, BuildConfigurations, BuildConfigurationSets, mainly to retrieve Milestone, Releases, ProducVersions, Projects, Users, BuildConfigurations.
Some changes should be done:

* enrich where necessary the response of the endpoints, to have fully serialized objects and not just the ids, to avoid further network calls
* polish the UI, as many refactorings, that introduced angular directives, did not polish the network calls from the controllers, leading to many duplicated endpoints calls

