### PR TITLE
fix for NCL-1478; wrap rest entity in Pagination 

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
@@ -238,7 +238,7 @@ public class BuildConfigurationEndpoint extends AbstractEndpoint<BuildConfigurat
             @Context UriInfo uriInfo) throws ValidationException {
         UriBuilder uriBuilder = UriBuilder.fromUri(uriInfo.getBaseUri()).path("/build-configurations/{id}");
         int newId = buildConfigurationProvider.clone(id);
-        return Response.created(uriBuilder.build(newId)).entity(buildConfigurationProvider.getSpecific(newId)).build();
+        return Response.created(uriBuilder.build(newId)).entity(new Singleton(buildConfigurationProvider.getSpecific(newId))).build();
     }
 
     @ApiOperation(value = "Triggers the build of a specific Build Configuration", response = BuildRecordSingleton.class)


### PR DESCRIPTION
Fix for NCL-1478, properly wrap the cloned BC in a Singleton instance.