### PR TITLE
Build configuration endpoint changes

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
@@ -238,7 +238,7 @@ public class BuildConfigurationEndpoint extends AbstractEndpoint<BuildConfigurat
             @Context UriInfo uriInfo) throws ValidationException {
         UriBuilder uriBuilder = UriBuilder.fromUri(uriInfo.getBaseUri()).path("/build-configurations/{id}");
         int newId = buildConfigurationProvider.clone(id);
-        return Response.created(uriBuilder.build(newId)).entity(buildConfigurationProvider.getSpecific(newId)).build();
+        return Response.created(uriBuilder.build(newId)).entity(new Singleton(buildConfigurationProvider.getSpecific(newId))).build();
     }
 
     @ApiOperation(value = "Triggers the build of a specific Build Configuration", response = BuildRecordSingleton.class)

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
@@ -241,9 +241,9 @@ public class BuildConfigurationEndpoint extends AbstractEndpoint<BuildConfigurat
         return Response.created(uriBuilder.build(newId)).entity(new Singleton(buildConfigurationProvider.getSpecific(newId))).build();
     }
 
-    @ApiOperation(value = "Triggers the build of a specific Build Configuration", response = BuildRecordSingleton.class)
+    @ApiOperation(value = "Triggers the build of a specific Build Configuration")
     @ApiResponses(value = {
-            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION),
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION, response = BuildRecordSingleton.class),
             @ApiResponse(code = CONFLICTED_CODE, message = CONFLICTED_DESCRIPTION, response = ErrorResponseRest.class),
             @ApiResponse(code = INVLID_CODE, message = INVALID_DESCRIPTION, response = ErrorResponseRest.class),
             @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = ErrorResponseRest.class)


### PR DESCRIPTION
Modify the 'build' method in BuildConfigurationEndpoint to correctly indicate that a 200 response has a BuildRecordSingleton, instead of nothing. This corrects the swagger documentation on this method.

Wrap the response in the 'clone' method of  BuildConfigurationEndpoint instead of returning the raw BuildConfigurationRest