### PR TITLE
Changed Type annotation of BuildLogs to a non deprecated one; forced …

### DIFF
--- a/datastore/src/main/resources/META-INF/persistence.xml
+++ b/datastore/src/main/resources/META-INF/persistence.xml
@@ -32,6 +32,7 @@
           <property name="hibernate.hbm2ddl.auto" value="@persistence.hibernate.hbm2ddl.auto@"/>
           <property name="hibernate.show_sql" value="false"/>
           <property name="hibernate.format_sql" value="true"/>
+          <property name="hibernate.jdbc.use_streams_for_binary" value="true"/>
       </properties>
    </persistence-unit>
 </persistence>

--- a/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
@@ -115,9 +115,9 @@ public class BuildRecord implements GenericEntity<Integer> {
     private String scmRevision;
 
     @Lob
-    // Type below is compatible with Oracle and PostgreSQL ("org.hibernate.type.TextType" not with Oracle)
     // Use "org.hibernate.type.MaterializedClobType" from Hibernate 4.2.x
-    @Type(type = "org.hibernate.type.StringClobType")
+    @Type(type = "org.hibernate.type.MaterializedClobType")
+    @Basic(fetch = FetchType.LAZY)
     private String buildLog;
 
     @Enumerated(value = EnumType.STRING)

--- a/model/src/test/resources/META-INF/persistence.xml
+++ b/model/src/test/resources/META-INF/persistence.xml
@@ -49,6 +49,7 @@
       <property name="hibernate.hbm2ddl.auto" value="create-drop" />
       <property name="hibernate.show_sql" value="true"/>
       <property name="hibernate.format_sql" value="true"/>
+      <property name="hibernate.jdbc.use_streams_for_binary" value="true"/>
     </properties>
   </persistence-unit>
 </persistence>


### PR DESCRIPTION
…Lazy fetching; specified an additional property to use streams (may be overridden by driver implementation)