### PR TITLE
update consumes API documentation for swagger

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationSetEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationSetEndpoint.java
@@ -276,7 +276,7 @@ public class BuildConfigurationSetEndpoint extends AbstractEndpoint<BuildConfigu
     })
     @POST
     @Path("/{id}/build")
-    @Consumes(MediaType.WILDCARD)
+    @Consumes(MediaType.APPLICATION_JSON)
     public Response build(
             @ApiParam(value = "Build Configuration Set id", required = true) @PathParam("id") Integer id,
             @ApiParam(value = "Optional Callback URL", required = false) @QueryParam("callbackUrl") String callbackUrl,


### PR DESCRIPTION
Slightly modify the @Consumes annotation for swagger.json. Without this slight tweak, clients generated from swagger-codegen will be incorrect. 