### PR TITLE
[NCL-1483] Add optional field with repositories

### DIFF
--- a/ui/app/import/product/directive/ProductImportStartForm/ProductImportStartForm.js
+++ b/ui/app/import/product/directive/ProductImportStartForm/ProductImportStartForm.js
@@ -50,6 +50,27 @@
               });
             }
           };
+          scope.addOptionalRepository = function() {
+            // check if it is defined. If no, define it
+            if (typeof scope.data.repositories === 'undefined') {
+              scope.data.repositories = [];
+            }
+            // add to the list
+            scope.data.repositories.push(scope.optionalRepository);
+
+            // clear the field in the UI
+            scope.optionalRepository = '';
+          };
+
+          scope.removeOptionalRepository = function(index) {
+            scope.data.repositories.splice(index, 1);
+          };
+
+          scope.formReset = function() {
+            scope.data = {};
+            scope.optionalRepository = '';
+            scope.startForm.$setPristine();
+          };
         }
       };
     }

--- a/ui/app/import/product/directive/ProductImportStartForm/product-import-start-form.html
+++ b/ui/app/import/product/directive/ProductImportStartForm/product-import-start-form.html
@@ -96,11 +96,45 @@
     </div>
   </div>
 
+  <div class="panel panel-default">
+    <div class="panel-body">
+
+      <div class="form-group"
+           ng-class="{ 'has-error' : startForm.startFormInput6.$invalid && !startForm.startFormInput6.$pristine, 'has-success': startForm.startFormInput6.$valid  && startForm.startFormInput6.$touched }">
+        <label for="startFormInput6" class="col-sm-2 control-label">
+          Optional Repositories&nbsp;<span class="pficon pficon-info" title="URLs of the optional repositories used for the project."></span>
+        </label>
+
+
+        <div class="col-sm-9">
+          <input type="url" id="startFormInput6" name="startFormInput6" class="form-control" ng-model="optionalRepository">
+          <span class="help-block" ng-show="startForm.startFormInput6.$error.url && !startForm.startFormInput6.$pristine">Invalid URL.</span>
+        </div>
+        <div class="col-sm-1">
+          <button type="button" class="btn btn-primary" ng-click="addOptionalRepository()">Add</button>
+        </div>
+      </div>
+
+      <hr>
+      <div class="form-group">
+          <label for="added_repositories" class="col-sm-2 control-label">
+            Added Repositories
+          </label>
+          <div class="col-sm-10" id="added_repositories">
+            <div ng-repeat="repository in data.repositories track by $index">
+              {{repository}} <button type="button" class="close" aria-label="Close" ng-click="removeOptionalRepository($index)"><span aria-hidden="true">×</span></button>
+              <hr>
+            </div>
+          </div>
+      </div>
+    </div>
+  </div>
+
 
   <div class="form-group pull-right">
     <div class="col-sm-offset-2 col-sm-10">
       <input type="submit" class="btn btn-primary" value="Start process" ng-disabled="submitDisabled || startForm.$invalid">
-      <input type="reset" class="btn btn-default" value="Clear">
+      <button type="button" class="btn btn-default" ng-click="formReset()">Clear</button>
     </div>
   </div>
 </form>


### PR DESCRIPTION
This optional field is added to the Product import process.

This allows products that need custom repositories (not defined in the
pom.xml) to be analyzed by allowing the user to specify the custom
repositories.

On submit, the additional field 'repositories' will be sent to the
configured Dependency Analysis server. That field will contain a list of
repositories to add.

I had to override the Clear button so that it also clears the list of repositories.

![2016-01-27-17-29-50](https://cloud.githubusercontent.com/assets/630746/12630855/72b9d620-c51c-11e5-900c-d13a14499e9a.gif)

Thank you to @alexcreasy for the mockup review :smile: 