### PR TITLE
[NCL-1291] Deprecate use of mirror repo in build execution config

### DIFF
--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
@@ -37,8 +37,10 @@ public class BuildExecutionConfigurationRest {
     private UserRest user;
     private String buildScript;
     private String name;
+    @Deprecated
     private String scmMirrorRepoURL;
     private String scmRepoURL;
+    @Deprecated
     private String scmMirrorRevision;
     private String scmRevision;
 
@@ -109,6 +111,7 @@ public class BuildExecutionConfigurationRest {
         this.name = name;
     }
 
+    @Deprecated
     public void setScmMirrorRepoURL(String scmMirrorRepoURL) {
         this.scmMirrorRepoURL = scmMirrorRepoURL;
     }
@@ -117,6 +120,7 @@ public class BuildExecutionConfigurationRest {
         this.scmRepoURL = scmRepoURL;
     }
 
+    @Deprecated
     public void setScmMirrorRevision(String scmMirrorRevision) {
         this.scmMirrorRevision = scmMirrorRevision;
     }
@@ -141,6 +145,7 @@ public class BuildExecutionConfigurationRest {
         return name;
     }
 
+    @Deprecated
     public String getScmMirrorRepoURL() {
         return scmMirrorRepoURL;
     }
@@ -149,6 +154,7 @@ public class BuildExecutionConfigurationRest {
         return scmRepoURL;
     }
 
+    @Deprecated
     public String getScmMirrorRevision() {
         return scmMirrorRevision;
     }

--- a/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionConfiguration.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionConfiguration.java
@@ -34,10 +34,12 @@ public interface BuildExecutionConfiguration extends BuildExecution {
 
     String getName();  //used to be buildConfiguration.name
 
+    @Deprecated
     String getScmMirrorRepoURL();
 
     String getScmRepoURL();
 
+    @Deprecated
     String getScmMirrorRevision();
 
     String getScmRevision();
@@ -82,6 +84,7 @@ public interface BuildExecutionConfiguration extends BuildExecution {
                 return name;
             }
 
+            @Deprecated
             @Override
             public String getScmMirrorRepoURL() {
                 return scmMirrorRepoURL;
@@ -92,6 +95,7 @@ public interface BuildExecutionConfiguration extends BuildExecution {
                 return scmRepoURL;
             }
 
+            @Deprecated
             @Override
             public String getScmMirrorRevision() {
                 return scmMirrorRevision;


### PR DESCRIPTION
The build execution config should only contain a single scm repo url and revision
to be built, and should not need to differentiate between upstream and mirror repo