### PR TITLE
Use angular-loading-bar to show progress

### DIFF
--- a/ui/app/_pnc.js
+++ b/ui/app/_pnc.js
@@ -19,6 +19,7 @@
 
  (function() {
   var app = angular.module('pnc', [
+    'angular-loading-bar',
     'ui.router',
     'ui.bootstrap',
     'patternfly.notification',

--- a/ui/app/index.html
+++ b/ui/app/index.html
@@ -26,6 +26,7 @@
     <link rel="shortcut icon" href="images/favicon.ico">
     <!-- build:css(.) styles/vendor.css -->
     <!-- bower:css -->
+    <link rel="stylesheet" href="bower_components/angular-loading-bar/build/loading-bar.css" />
     <link rel="stylesheet" href="bower_components/patternfly/dist/css/patternfly.css" />
     <link rel="stylesheet" href="bower_components/font-awesome/css/font-awesome.css" />
     <link rel="stylesheet" href="bower_components/angular-xeditable/dist/css/xeditable.css" />
@@ -41,6 +42,7 @@
     <!-- bower:js -->
     <script src="bower_components/jquery/dist/jquery.js"></script>
     <script src="bower_components/angular/angular.js"></script>
+    <script src="bower_components/angular-loading-bar/build/loading-bar.js"></script>
     <script src="bower_components/patternfly/dist/js/patternfly.js"></script>
     <script src="bower_components/angular-patternfly/dist/angular-patternfly.js"></script>
     <script src="bower_components/angular-patternfly/dist/angular-patternfly.min.js"></script>

--- a/ui/app/styles/app.css
+++ b/ui/app/styles/app.css
@@ -174,3 +174,24 @@ form .editable-wrap {
   width: 100%;
   max-width: 500px;
 }
+
+#loading-bar .bar {
+  background: #FFA500;
+  height: 4px;
+}
+#loading-bar-spinner .spinner-icon {
+  border-top-color:  #FFA500;
+  border-left-color: #FFA500;
+}
+#loading-bar .peg {
+  -moz-box-shadow: #FFA500 1px 0 6px 1px;
+  -ms-box-shadow: #FFA500 1px 0 6px 1px;
+  -webkit-box-shadow: #FFA500 1px 0 6px 1px;
+  box-shadow: #FFA500 1px 0 6px 1px;
+}
+
+.loading-spinner {
+  -webkit-animation:spin 1s linear infinite;
+  -moz-animation:spin 1s linear infinite;
+  animation:spin 1s linear infinite;
+}

--- a/ui/bower.json
+++ b/ui/bower.json
@@ -3,6 +3,7 @@
   "version": "0.5.0",
   "dependencies": {
     "angular": "1.3.15",
+    "angular-loading-bar": "0.8.0",
     "patternfly": "1.1.4",
     "angular-patternfly": "patternfly/angular-patternfly#v0.0.5",
     "font-awesome": "4.2.0",


### PR DESCRIPTION
When using frontend web frameworks like Angular JS, sometimes it's
really hard to know when a page is loading after we click on a button.

For e.g if clicking the button redirects us to another page that takes a
long time to load, we don't have any visual feedback that the other page
is being loaded, prompting the user to re-press the button again.

In traditional web frameworks, our browser would show a spinner that
gives us visual feedback that it is still loading.

Using angular-loading-bar adds the visual feedback currently lacking in
our Web UI.

![2016-02-05-00-45-09](https://cloud.githubusercontent.com/assets/630746/12839083/39a19a52-cba3-11e5-9fd7-99dc4aeb6473.gif)

I've chosen to use the color orange for the bar since we don't use that color anywhere on PNC Web-UI, and is therefore easily seen, not yet too distracting.