### PR TITLE
[NCL-1618] Don't try to update build config when building build record

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
@@ -532,10 +532,7 @@ public class BuildRecord implements GenericEntity<Integer> {
             buildRecord.setSubmitTime(submitTime);
             buildRecord.setStartTime(startTime);
             buildRecord.setEndTime(endTime);
-            if (latestBuildConfiguration != null) {
-                latestBuildConfiguration.addBuildRecord(buildRecord);
-                buildRecord.setLatestBuildConfiguration(latestBuildConfiguration);
-            }
+            buildRecord.setLatestBuildConfiguration(latestBuildConfiguration);
             buildRecord.setBuildConfigurationAudited(buildConfigurationAudited);
             buildRecord.setUser(user);
             buildRecord.setScmRepoURL(scmRepoURL);


### PR DESCRIPTION
This can cause problems if the build config was not loaded during the current transaction.