### PR TITLE
[NCL-1649] Allow a single BuiltArtifact to be linked to multiple buil…

### DIFF
--- a/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
@@ -25,6 +25,7 @@ import org.jboss.pnc.model.BuildConfigurationAudited;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.BuildRecordSet;
 import org.jboss.pnc.model.BuildStatus;
+import org.jboss.pnc.model.BuiltArtifact;
 import org.jboss.pnc.model.User;
 import org.jboss.pnc.spi.datastore.Datastore;
 import org.jboss.pnc.spi.datastore.predicates.UserPredicates;
@@ -85,6 +86,7 @@ public class DefaultDatastore implements Datastore {
         BuildRecord buildRecord = buildRecordBuilder.build();
         refreshBuildConfiguration(buildRecord);
         buildRecord.setDependencies(saveArtifacts(buildRecord.getDependencies()));
+        buildRecord.setBuiltArtifacts(saveBuiltArtifacts(buildRecord.getBuiltArtifacts()));
         buildRecord = buildRecordRepository.save(buildRecord);
         for(BuildRecordSet buildRecordSet : buildRecordSetRepository.queryWithPredicates(withBuildRecordSetIdInSet(buildRecordSetIds))) {
             buildRecordSet.addBuildRecord(buildRecord);
@@ -95,23 +97,48 @@ public class DefaultDatastore implements Datastore {
     }
 
     /**
-     * Match the artifacts in the list to existing artifacts in the database
-     * If no matching artifact exists in the db, the artifact is kept as-is
+     * Save the unsaved artifacts in the list to the database.  For each artifact in the given list,
+     * check if the artifact exists in the database.  If it already exists, replace it with the JPA
+     * entity loaded from the database.  If it does not exist, add it to the database.
      * 
-     * @param artifacts to store to the db
-     * @return List of artifacts stored in db
+     * @param List of in-memory artifacts to either insert to the database or find the matching record in the db
+     * @return List of up to date JPA artifact entities
      */
     private List<Artifact> saveArtifacts(List<Artifact> artifacts) {
-        List<Artifact> dbArtifacts = new ArrayList<>();
+        List<Artifact> savedArtifacts = new ArrayList<>();
         for (Artifact artifact : artifacts) {
             Artifact artifactFromDb = artifactRepository
                     .queryByPredicates(withIdentifierAndChecksum(artifact.getIdentifier(), artifact.getChecksum()));
             if (artifactFromDb == null) {
                 artifactFromDb = artifactRepository.save(artifact);
             }
-            dbArtifacts.add(artifactFromDb);
+            savedArtifacts.add(artifactFromDb);
         }
-        return dbArtifacts;
+        return savedArtifacts;
+    }
+
+    /**
+     * Match the built artifacts in the list to existing artifacts in the database
+     * If no matching artifact exists in the db, the artifact is kept as-is
+     * 
+     * @param artifacts to store to the db
+     * @return List of artifacts stored in db
+     */
+    private List<BuiltArtifact> saveBuiltArtifacts(List<BuiltArtifact> builtArtifacts) {
+        List<BuiltArtifact> savedArtifacts = new ArrayList<>();
+        for (BuiltArtifact builtArtifact : builtArtifacts) {
+            Artifact artifactFromDb = artifactRepository
+                    .queryByPredicates(withIdentifierAndChecksum(builtArtifact.getIdentifier(), builtArtifact.getChecksum()));
+            if (artifactFromDb == null) {
+                BuiltArtifact buildArtifactFromDb = (BuiltArtifact)artifactRepository.save(builtArtifact);
+                savedArtifacts.add(buildArtifactFromDb);
+            } else if (artifactFromDb instanceof BuiltArtifact) {
+                savedArtifacts.add((BuiltArtifact)artifactFromDb);
+            } else {
+                // TODO: how should we handle when a built artifact matches an existing imported artifact?
+            }
+        }
+        return savedArtifacts;
     }
 
     @Override

--- a/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
+++ b/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
@@ -277,6 +277,9 @@ public class DatabaseDataInitializer {
         BuiltArtifact builtArtifact2 = BuiltArtifact.Builder.newBuilder().identifier("demo:built-artifact2:jar:1.0")
                 .repoType(RepositoryType.MAVEN).filename("demo built artifact 2").checksum("abcd2345").build();
 
+        builtArtifact1 = (BuiltArtifact)artifactRepository.save(builtArtifact1);
+        builtArtifact2 = (BuiltArtifact)artifactRepository.save(builtArtifact2);
+
         Artifact importedArtifact1 = ImportedArtifact.Builder.newBuilder().identifier("demo:imported-artifact1:jar:1.0")
                 .repoType(RepositoryType.MAVEN).filename("demo imported artifact 1").originUrl("http://central/import1.jar")
                 .downloadDate(Date.from(Instant.now())).checksum("abcd1234").deployUrl("http://google.pl/imported1").build();
@@ -329,6 +332,9 @@ public class DatabaseDataInitializer {
         BuiltArtifact builtArtifact4 = BuiltArtifact.Builder.newBuilder().identifier("demo:built-artifact4:jar:1.0")
                 .repoType(RepositoryType.MAVEN).filename("demo built artifact 4").checksum("abcd1234")
                 .deployUrl("http://google.pl/built4").build();
+
+        builtArtifact3 = (BuiltArtifact)artifactRepository.save(builtArtifact3);
+        builtArtifact4 = (BuiltArtifact)artifactRepository.save(builtArtifact4);
 
         Artifact dependencyBuiltArtifact1 = artifactRepository
                 .queryByPredicates(withIdentifierAndChecksum(builtArtifact1.getIdentifier(), builtArtifact1.getChecksum()));

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildRecordsTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildRecordsTest.java
@@ -145,7 +145,10 @@ public class BuildRecordsTest {
                 .originUrl("http://central/importedArtifact1.jar")
                 .build();
 
-        artifactRepository.save(importedArtifact1);
+        builtArtifact1 = (BuiltArtifact)artifactRepository.save(builtArtifact1);
+        builtArtifact2 = (BuiltArtifact)artifactRepository.save(builtArtifact2);
+        builtArtifact3 = (BuiltArtifact)artifactRepository.save(builtArtifact3);
+        importedArtifact1 = (ImportedArtifact)artifactRepository.save(importedArtifact1);
 
         List<User> users = userRepository.queryAll();
         assertThat(users.size() > 0).isTrue();

--- a/model/src/main/java/org/jboss/pnc/model/Artifact.java
+++ b/model/src/main/java/org/jboss/pnc/model/Artifact.java
@@ -229,7 +229,7 @@ public abstract class Artifact implements GenericEntity<Integer> {
 
     @Override
     public String toString() {
-        return "Artifact [id: " + id + ", filename=" + filename + "]";
+        return "Artifact [id: " + id + ", identifier=" + identifier + ", type=" + type + "]";
     }
 
 }

--- a/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
@@ -129,19 +129,27 @@ public class BuildRecord implements GenericEntity<Integer> {
     private BuildStatus status;
 
     /**
-     * Note, each builtArtifact belongs to a single build record, so we can cascade
-     * without risk of duplicate inserts.
+     * Artifacts which were produced by this build
      */
-    @OneToMany(mappedBy = "buildRecord", cascade = CascadeType.ALL)
+    @ManyToMany
+    @JoinTable(name = "build_record_built_artifact_map", joinColumns = {
+            @JoinColumn(name = "build_record_id", referencedColumnName = "id") }, inverseJoinColumns = {
+                    @JoinColumn(name = "built_artifact_id", referencedColumnName = "id") }, uniqueConstraints = @UniqueConstraint(name = "uk_build_record_id_built_artifact_id", columnNames = {
+                            "build_record_id", "built_artifact_id" }) )
+    @ForeignKey(name = "fk_build_record_built_artifact_map")
+    @Index(name = "idx_build_record_built_artifact_map")
     private List<BuiltArtifact> builtArtifacts;
 
+    /**
+     * Artifacts which are required external dependencies of this build
+     */
     @ManyToMany
     @JoinTable(name = "build_record_artifact_dependencies_map", joinColumns = {
             @JoinColumn(name = "build_record_id", referencedColumnName = "id") }, inverseJoinColumns = {
                     @JoinColumn(name = "dependency_artifact_id", referencedColumnName = "id") }, uniqueConstraints = @UniqueConstraint(name = "uk_build_record_id_dependency_artifact_id", columnNames = {
                             "build_record_id", "dependency_artifact_id" }) )
-    @ForeignKey(name = "fk_build_record_artifact_map_dependencies")
-    @Index(name = "idx_build_record_artifact_map_dependencies")
+    @ForeignKey(name = "fk_build_record_artifact_dependencies_map")
+    @Index(name = "idx_build_record_artifact_dependencies_map")
     private List<Artifact> dependencies;
 
     /**
@@ -565,7 +573,7 @@ public class BuildRecord implements GenericEntity<Integer> {
 
             // Set the bi-directional mapping
             for (BuiltArtifact artifact : builtArtifacts) {
-                artifact.setBuildRecord(buildRecord);
+                artifact.addBuildRecord(buildRecord);
             }
             buildRecord.setBuiltArtifacts(builtArtifacts);
 

--- a/model/src/main/java/org/jboss/pnc/model/BuiltArtifact.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuiltArtifact.java
@@ -17,9 +17,6 @@
  */
 package org.jboss.pnc.model;
 
-import org.hibernate.annotations.ForeignKey;
-import org.hibernate.annotations.Index;
-
 import java.util.HashSet;
 import java.util.Set;
 
@@ -41,40 +38,39 @@ public class BuiltArtifact extends Artifact {
      * The build record of the build which produced this artifact
      */
     @NotNull
-    @ManyToOne
-    @ForeignKey(name = "fk_built_artifact_buildrecord")
-    @Index(name="idx_built_artifact_buildrecord")
-    @JoinColumn(updatable=false)
-    private BuildRecord buildRecord;
+    @ManyToMany(mappedBy = "dependencies")
+    private Set<BuildRecord> buildRecords;
 
     public BuiltArtifact() {
+        buildRecords = new HashSet<BuildRecord>();
     }
 
     /**
-     * Gets the project build record.
+     * Gets the set of build records.
      *
-     * @return the project build record
+     * @return the set of build records
      */
-    public BuildRecord getBuildRecord() {
-        return buildRecord;
+    public Set<BuildRecord> getBuildRecords() {
+        return buildRecords;
     }
 
     /**
      * Sets the project build record.
      *
-     * @param buildRecord the new project build record
+     * @param buildRecords the set of build records
      */
-    public void setBuildRecord(BuildRecord buildRecord) {
-        this.buildRecord = buildRecord;
+    public void setBuildRecords(Set<BuildRecord> buildRecords) {
+        this.buildRecords = buildRecords;
     }
 
-    /*
-     * @see java.lang.Object#toString()
+    /**
+     * Add a build record to the set of builds
+     *
+     * @param buildRecord the new project build record
+     * @return 
      */
-    @Override
-    public String toString() {
-        Integer buildRecordId = (getBuildRecord()==null)?null:getBuildRecord().getId();
-        return "Built Artifact [id: " + getId() + ", produced by build id:" + buildRecordId + "]";
+    public boolean addBuildRecord(BuildRecord buildRecord) {
+        return this.buildRecords.add(buildRecord);
     }
 
     public static class Builder {
@@ -93,10 +89,11 @@ public class BuiltArtifact extends Artifact {
 
         private Set<BuildRecord> dependantBuildRecords;
 
-        private BuildRecord buildRecord;
+        private Set<BuildRecord> buildRecords;
 
         private Builder() {
-            dependantBuildRecords = new HashSet<BuildRecord>();
+            buildRecords = new HashSet<>();
+            dependantBuildRecords = new HashSet<>();
         }
 
         public static Builder newBuilder() {
@@ -114,7 +111,7 @@ public class BuiltArtifact extends Artifact {
             if (dependantBuildRecords != null) {
                 artifact.setDependantBuildRecords(dependantBuildRecords);
             }
-            artifact.setBuildRecord(buildRecord);
+            artifact.setBuildRecords(buildRecords);
 
             return artifact;
         }
@@ -154,8 +151,8 @@ public class BuiltArtifact extends Artifact {
             return this;
         }
 
-        public Builder buildRecord(BuildRecord buildRecord) {
-            this.buildRecord = buildRecord;
+        public Builder buildRecord(Set<BuildRecord> buildRecords) {
+            this.buildRecords = buildRecords;
             return this;
         }
 

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuiltArtifactPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuiltArtifactPredicates.java
@@ -26,14 +26,14 @@ import org.jboss.pnc.spi.datastore.repositories.api.Predicate;
 import javax.persistence.criteria.Join;
 
 /**
- * Predicates for {@link org.jboss.pnc.model.Artifact} entity.
+ * Predicates for {@link org.jboss.pnc.model.BuiltArtifact} entity.
  */
 public class BuiltArtifactPredicates {
 
     public static Predicate<BuiltArtifact> withBuildRecordId(Integer buildRecordId) {
         return (root, query, cb) -> {
-            Join<BuiltArtifact, BuildRecord> buildRecord = root.join(BuiltArtifact_.buildRecord);
-            return cb.equal(buildRecord.get(BuildRecord_.id), buildRecordId);
+            Join<BuiltArtifact, BuildRecord> buildRecords = root.join(BuiltArtifact_.buildRecords);
+            return cb.equal(buildRecords.get(BuildRecord_.id), buildRecordId);
         };
     }
 


### PR DESCRIPTION
…d records

Change relation of BuildRecord to BuiltArtifact from OneToMany to ManyToMany.
If a new build generates artifacts with matching identifier and checksum
then the BuildRecord can link to the existing artifact instead of creating a
new artifact with duplicate identifiers.