### PR TITLE
NCL-1646 Use local URL from tracking record for origin URL with hosted artifact refs

### DIFF
--- a/maven-repository-manager/pom.xml
+++ b/maven-repository-manager/pom.xml
@@ -70,25 +70,25 @@
       <artifactId>weld-se</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.commonjava.aprox</groupId>
-      <artifactId>aprox-promote-client-java</artifactId>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-promote-client-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.commonjava.aprox</groupId>
-      <artifactId>aprox-folo-client-java</artifactId>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-folo-client-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.commonjava.aprox</groupId>
-      <artifactId>aprox-client-core-java</artifactId>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-client-core-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.commonjava.aprox.embed</groupId>
-      <artifactId>aprox-embedder-savant</artifactId>
+      <groupId>org.commonjava.indy.embed</groupId>
+      <artifactId>indy-embedder-savant</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.commonjava.aprox</groupId>
-      <artifactId>aprox-test-fixtures-core</artifactId>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-test-fixtures-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
+++ b/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
@@ -18,20 +18,20 @@
 package org.jboss.pnc.mavenrepositorymanager;
 
 import org.apache.commons.lang.StringUtils;
-import org.commonjava.aprox.client.core.Aprox;
-import org.commonjava.aprox.client.core.AproxClientException;
-import org.commonjava.aprox.client.core.module.AproxContentClientModule;
-import org.commonjava.aprox.folo.client.AproxFoloAdminClientModule;
-import org.commonjava.aprox.folo.dto.TrackedContentDTO;
-import org.commonjava.aprox.folo.dto.TrackedContentEntryDTO;
-import org.commonjava.aprox.model.core.StoreKey;
-import org.commonjava.aprox.model.core.StoreType;
-import org.commonjava.aprox.promote.client.AproxPromoteClientModule;
-import org.commonjava.aprox.promote.model.GroupPromoteRequest;
-import org.commonjava.aprox.promote.model.GroupPromoteResult;
-import org.commonjava.aprox.promote.model.PathsPromoteRequest;
-import org.commonjava.aprox.promote.model.PathsPromoteResult;
-import org.commonjava.aprox.promote.model.ValidationResult;
+import org.commonjava.indy.client.core.Indy;
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.client.core.module.IndyContentClientModule;
+import org.commonjava.indy.folo.client.IndyFoloAdminClientModule;
+import org.commonjava.indy.folo.dto.TrackedContentDTO;
+import org.commonjava.indy.folo.dto.TrackedContentEntryDTO;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.promote.client.IndyPromoteClientModule;
+import org.commonjava.indy.promote.model.GroupPromoteRequest;
+import org.commonjava.indy.promote.model.GroupPromoteResult;
+import org.commonjava.indy.promote.model.PathsPromoteRequest;
+import org.commonjava.indy.promote.model.PathsPromoteResult;
+import org.commonjava.indy.promote.model.ValidationResult;
 import org.commonjava.maven.atlas.ident.ref.ArtifactRef;
 import org.commonjava.maven.atlas.ident.ref.SimpleArtifactRef;
 import org.commonjava.maven.atlas.ident.util.ArtifactPathInfo;
@@ -74,25 +74,25 @@ public class MavenRepositorySession implements RepositorySession {
     private static Set<String> IGNORED_PATH_SUFFIXES =
             Collections.unmodifiableSet(new HashSet<>(Arrays.asList("maven-metadata.xml", ".sha1", ".md5", ".asc")));
 
-    private Aprox aprox;
+    private Indy indy;
     private final String buildRepoId;
 
     private final RepositoryConnectionInfo connectionInfo;
     private boolean isSetBuild;
 
-    // TODO: Create and pass in suitable parameters to Aprox to create the
+    // TODO: Create and pass in suitable parameters to Indy to create the
     //       proxy repository.
     @Deprecated
-    public MavenRepositorySession(Aprox aprox, String buildRepoId, boolean isSetBuild,
+    public MavenRepositorySession(Indy indy, String buildRepoId, boolean isSetBuild,
                                   MavenRepositoryConnectionInfo info) {
-        this.aprox = aprox;
+        this.indy = indy;
         this.buildRepoId = buildRepoId;
         this.isSetBuild = isSetBuild;
         this.connectionInfo = info;
     }
 
-    public MavenRepositorySession(Aprox aprox, String buildRepoId, MavenRepositoryConnectionInfo info) {
-        this.aprox = aprox;
+    public MavenRepositorySession(Indy indy, String buildRepoId, MavenRepositoryConnectionInfo info) {
+        this.indy = indy;
         this.buildRepoId = buildRepoId;
         this.isSetBuild = false; //TODO remove
         this.connectionInfo = info;
@@ -130,8 +130,8 @@ public class MavenRepositorySession implements RepositorySession {
     public RepositoryManagerResult extractBuildArtifacts() throws RepositoryManagerException {
         TrackedContentDTO report;
         try {
-            report = aprox.module(AproxFoloAdminClientModule.class).getTrackingReport(buildRepoId);
-        } catch (AproxClientException e) {
+            report = indy.module(IndyFoloAdminClientModule.class).getTrackingReport(buildRepoId);
+        } catch (IndyClientException e) {
             throw new RepositoryManagerException("Failed to retrieve tracking report for: %s. Reason: %s", e, buildRepoId,
                     e.getMessage());
         }
@@ -148,8 +148,8 @@ public class MavenRepositorySession implements RepositorySession {
         Collections.sort(downloads, comp);
 
         try {
-            aprox.stores().delete(StoreType.group, buildRepoId, "[Post-Build] Removing build aggregation group: " + buildRepoId );
-        } catch (AproxClientException e) {
+            indy.stores().delete(StoreType.group, buildRepoId, "[Post-Build] Removing build aggregation group: " + buildRepoId );
+        } catch (IndyClientException e) {
             throw new RepositoryManagerException("Failed to retrieve AProx stores module. Reason: %s", e, e.getMessage());
         }
 
@@ -173,10 +173,10 @@ public class MavenRepositorySession implements RepositorySession {
     private List<Artifact> processDownloads(TrackedContentDTO report) throws RepositoryManagerException {
         Logger logger = LoggerFactory.getLogger(getClass());
 
-        AproxContentClientModule content;
+        IndyContentClientModule content;
         try {
-            content = aprox.content();
-        } catch (AproxClientException e) {
+            content = indy.content();
+        } catch (IndyClientException e) {
             throw new RepositoryManagerException("Failed to retrieve AProx client module. Reason: %s", e, e.getMessage());
         }
 
@@ -221,12 +221,18 @@ public class MavenRepositorySession implements RepositorySession {
                     continue;
                 }
 
-                ArtifactRef aref = new SimpleArtifactRef(pathInfo.getProjectId(), pathInfo.getType(), pathInfo.getClassifier(), false);
+                ArtifactRef aref = new SimpleArtifactRef(pathInfo.getProjectId(), pathInfo.getType(), pathInfo.getClassifier());
                 logger.info("Recording download: {}", aref);
+
+                String originUrl = download.getOriginUrl();
+                if (originUrl == null) {
+                    // this is from a hosted repository, either shared-imports or a build, or something like that.
+                    originUrl = download.getLocalUrl();
+                }
 
                 ImportedArtifact.Builder artifactBuilder = ImportedArtifact.Builder.newBuilder().checksum(download.getMd5())
                         .deployUrl(content.contentUrl(download.getStoreKey(), download.getPath()))
-                        .originUrl(download.getOriginUrl()).downloadDate(Date.from(Instant.now()))
+                        .originUrl(originUrl).downloadDate(Date.from(Instant.now()))
                         .filename(new File(path).getName()).identifier(aref.toString()).repoType(RepositoryType.MAVEN);
 
                 deps.add(artifactBuilder.build());
@@ -270,7 +276,7 @@ public class MavenRepositorySession implements RepositorySession {
                     continue;
                 }
 
-                ArtifactRef aref = new SimpleArtifactRef(pathInfo.getProjectId(), pathInfo.getType(), pathInfo.getClassifier(), false);
+                ArtifactRef aref = new SimpleArtifactRef(pathInfo.getProjectId(), pathInfo.getType(), pathInfo.getClassifier());
                 logger.info("Recording upload: {}", aref);
 
                 BuiltArtifact.Builder artifactBuilder = BuiltArtifact.Builder.newBuilder().checksum(upload.getSha256())
@@ -297,10 +303,10 @@ public class MavenRepositorySession implements RepositorySession {
      *         transport, or if the promotion process results in an error.
      */
     private void doPromoteByPath(PathsPromoteRequest req) throws RepositoryManagerException {
-        AproxPromoteClientModule promoter;
+        IndyPromoteClientModule promoter;
         try {
-            promoter = aprox.module(AproxPromoteClientModule.class);
-        } catch (AproxClientException e) {
+            promoter = indy.module(IndyPromoteClientModule.class);
+        } catch (IndyClientException e) {
             throw new RepositoryManagerException("Failed to retrieve AProx client module. Reason: %s", e, e.getMessage());
         }
 
@@ -314,7 +320,7 @@ public class MavenRepositorySession implements RepositorySession {
                         addendum = "\nROLLBACK WARNING: Promotion rollback also failed! Reason given: " + result.getError();
                     }
 
-                } catch (AproxClientException e) {
+                } catch (IndyClientException e) {
                     throw new RepositoryManagerException("Rollback failed for promotion of: %s. Reason: %s", e, req,
                             e.getMessage());
                 }
@@ -322,7 +328,7 @@ public class MavenRepositorySession implements RepositorySession {
                 throw new RepositoryManagerException("Failed to promote: %s. Reason given was: %s%s", req, result.getError(),
                         addendum);
             }
-        } catch (AproxClientException e) {
+        } catch (IndyClientException e) {
             throw new RepositoryManagerException("Failed to promote: %s. Reason: %s", e, req, e.getMessage());
         }
     }
@@ -333,10 +339,10 @@ public class MavenRepositorySession implements RepositorySession {
      * membership).
      */
     public void promoteToBuildContentSet() throws RepositoryManagerException {
-        AproxPromoteClientModule promoter;
+        IndyPromoteClientModule promoter;
         try {
-            promoter = aprox.module(AproxPromoteClientModule.class);
-        } catch (AproxClientException e) {
+            promoter = indy.module(IndyPromoteClientModule.class);
+        } catch (IndyClientException e) {
             throw new RepositoryManagerException("Failed to retrieve AProx client module. Reason: %s", e, e.getMessage());
         }
 
@@ -361,7 +367,7 @@ public class MavenRepositorySession implements RepositorySession {
 
                 throw new RepositoryManagerException("Failed to promote: %s to group: %s. Reason given was: %s", request.getSource(), request.getTargetGroup(), reason);
             }
-        } catch (AproxClientException e) {
+        } catch (IndyClientException e) {
             throw new RepositoryManagerException("Failed to promote: %s. Reason: %s", e, request, e.getMessage());
         }
     }

--- a/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRunningDeletion.java
+++ b/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRunningDeletion.java
@@ -17,9 +17,9 @@
  */
 package org.jboss.pnc.mavenrepositorymanager;
 
-import org.commonjava.aprox.client.core.Aprox;
-import org.commonjava.aprox.client.core.AproxClientException;
-import org.commonjava.aprox.model.core.StoreType;
+import org.commonjava.indy.client.core.Indy;
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.model.core.StoreType;
 import org.jboss.pnc.spi.repositorymanager.model.CompletedRepositoryDeletion;
 import org.jboss.pnc.spi.repositorymanager.model.RunningRepositoryDeletion;
 
@@ -29,12 +29,12 @@ public class MavenRunningDeletion implements RunningRepositoryDeletion {
 
     private StoreType fromType;
     private String fromId;
-    private Aprox aprox;
+    private Indy indy;
 
-    public MavenRunningDeletion(StoreType fromType, String fromId, Aprox aprox) {
+    public MavenRunningDeletion(StoreType fromType, String fromId, Indy indy) {
         this.fromType = fromType;
         this.fromId = fromId;
-        this.aprox = aprox;
+        this.indy = indy;
     }
 
     /**
@@ -46,13 +46,13 @@ public class MavenRunningDeletion implements RunningRepositoryDeletion {
     @Override
     public void monitor(Consumer<CompletedRepositoryDeletion> onComplete, Consumer<Exception> onError) {
         try {
-            if (aprox.stores().exists(fromType, fromId)) {
-                aprox.stores().delete(fromType, fromId, "Deleting artifacts for PNC build");
+            if (indy.stores().exists(fromType, fromId)) {
+                indy.stores().delete(fromType, fromId, "Deleting artifacts for PNC build");
             }
 
             onComplete.accept(new MavenCompletedDeletion(true));
 
-        } catch (AproxClientException e) {
+        } catch (IndyClientException e) {
             onError.accept(e);
         }
     }

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AbstractImportTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AbstractImportTest.java
@@ -25,11 +25,11 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.commonjava.aprox.client.core.Aprox;
-import org.commonjava.aprox.model.core.Group;
-import org.commonjava.aprox.model.core.RemoteRepository;
-import org.commonjava.aprox.model.core.StoreKey;
-import org.commonjava.aprox.model.core.StoreType;
+import org.commonjava.indy.client.core.Indy;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
 import org.jboss.pnc.mavenrepositorymanager.fixture.TestHttpServer;
 import org.junit.Before;
 import org.junit.Rule;
@@ -48,24 +48,24 @@ public class AbstractImportTest extends AbstractRepositoryManagerDriverTest {
     @Rule
     public TestHttpServer server = new TestHttpServer("repos");
 
-    protected Aprox aprox;
+    protected Indy indy;
     
     @Before
     public void before() throws Exception
     {
-        aprox = driver.getAprox();
+        indy = driver.getIndy();
 
         // create a remote repo pointing at our server fixture's 'repo/test' directory.
-        aprox.stores().create(new RemoteRepository(STORE, server.formatUrl(STORE)), "Creating test remote repo",
+        indy.stores().create(new RemoteRepository(STORE, server.formatUrl(STORE)), "Creating test remote repo",
                 RemoteRepository.class);
         
-        Group publicGroup = aprox.stores().load(StoreType.group, PUBLIC, Group.class);
+        Group publicGroup = indy.stores().load(StoreType.group, PUBLIC, Group.class);
         if (publicGroup == null) {
             publicGroup = new Group(PUBLIC, new StoreKey(StoreType.remote, STORE));
-            aprox.stores().create(publicGroup, "creating public group", Group.class);
+            indy.stores().create(publicGroup, "creating public group", Group.class);
         } else {
             publicGroup.setConstituents(Collections.singletonList(new StoreKey(StoreType.remote, STORE)));
-            aprox.stores().update(publicGroup, "adding test remote to public group");
+            indy.stores().update(publicGroup, "adding test remote to public group");
         }
     }
 

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AbstractRepositoryManagerDriverTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AbstractRepositoryManagerDriverTest.java
@@ -20,10 +20,10 @@ package org.jboss.pnc.mavenrepositorymanager;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.commonjava.aprox.boot.BootStatus;
-import org.commonjava.aprox.model.core.Group;
-import org.commonjava.aprox.model.core.StoreKey;
-import org.commonjava.aprox.test.fixture.core.CoreServerFixture;
+import org.commonjava.indy.boot.BootStatus;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
 import org.jboss.pnc.common.Configuration;
 import org.jboss.pnc.common.json.ModuleConfigJson;
 import org.jboss.pnc.common.json.moduleconfig.MavenRepoDriverModuleConfig;
@@ -118,8 +118,8 @@ public class AbstractRepositoryManagerDriverTest {
     {
         final CoreServerFixture fixture = new CoreServerFixture( temp );
 
-        etcDir = new File( fixture.getBootOptions().getAproxHome(), "etc/aprox" );
-        dataDir = new File( fixture.getBootOptions().getAproxHome(), "var/lib/aprox/data" );
+        etcDir = new File( fixture.getBootOptions().getIndyHome(), "etc/indy" );
+        dataDir = new File( fixture.getBootOptions().getIndyHome(), "var/lib/indy/data" );
 
         initBaseTestConfig( fixture );
         initTestConfig( fixture );

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/BuildGroupIncludesConfSetGroupTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/BuildGroupIncludesConfSetGroupTest.java
@@ -17,10 +17,10 @@
  */
 package org.jboss.pnc.mavenrepositorymanager;
 
-import org.commonjava.aprox.client.core.Aprox;
-import org.commonjava.aprox.model.core.Group;
-import org.commonjava.aprox.model.core.StoreKey;
-import org.commonjava.aprox.model.core.StoreType;
+import org.commonjava.indy.client.core.Indy;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
 import org.jboss.pnc.mavenrepositorymanager.fixture.TestBuildExecution;
 import org.jboss.pnc.spi.repositorymanager.BuildExecution;
 import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
@@ -39,7 +39,7 @@ public class BuildGroupIncludesConfSetGroupTest extends AbstractRepositoryManage
     public void verifyGroupComposition_ProductVersion_WithConfSet() throws Exception {
         // create a dummy composed (chained) build execution and a repo session based on it
         BuildExecution execution = new TestBuildExecution("build_myproject_67890");
-        Aprox aprox = driver.getAprox();
+        Indy indy = driver.getIndy();
 
         RepositorySession repositoryConfiguration = driver.createBuildRepository(execution);
         String repoId = repositoryConfiguration.getBuildRepositoryId();
@@ -54,7 +54,7 @@ public class BuildGroupIncludesConfSetGroupTest extends AbstractRepositoryManage
         // - the "shared-imports" repo
         // - the public group
         // ...in that order
-        Group buildGroup = aprox.stores().load(StoreType.group, repoId, Group.class);
+        Group buildGroup = indy.stores().load(StoreType.group, repoId, Group.class);
 
         System.out.printf("Constituents:\n  %s\n", join(buildGroup.getConstituents(), "\n  "));
         assertGroupConstituents(buildGroup, new StoreKey(StoreType.hosted, execution.getBuildContentId()),

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/BuildGroupIncludesProductVersionGroupTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/BuildGroupIncludesProductVersionGroupTest.java
@@ -17,10 +17,10 @@
  */
 package org.jboss.pnc.mavenrepositorymanager;
 
-import org.commonjava.aprox.client.core.Aprox;
-import org.commonjava.aprox.model.core.Group;
-import org.commonjava.aprox.model.core.StoreKey;
-import org.commonjava.aprox.model.core.StoreType;
+import org.commonjava.indy.client.core.Indy;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
 import org.jboss.pnc.mavenrepositorymanager.fixture.TestBuildExecution;
 import org.jboss.pnc.spi.repositorymanager.BuildExecution;
 import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
@@ -39,7 +39,7 @@ public class BuildGroupIncludesProductVersionGroupTest extends AbstractRepositor
     public void verifyGroupComposition_ProductVersion_NoConfSet() throws Exception {
         // create a dummy non-chained build execution and repo session based on it
         BuildExecution execution = new TestBuildExecution("build_myproject_12345");
-        Aprox aprox = driver.getAprox();
+        Indy indy = driver.getIndy();
 
         RepositorySession repositoryConfiguration = driver.createBuildRepository(execution);
         String repoId = repositoryConfiguration.getBuildRepositoryId();
@@ -53,7 +53,7 @@ public class BuildGroupIncludesProductVersionGroupTest extends AbstractRepositor
         // - the "shared-imports" repo
         // - the public group
         // ...in that order
-        Group buildGroup = aprox.stores().load(StoreType.group, repoId, Group.class);
+        Group buildGroup = indy.stores().load(StoreType.group, repoId, Group.class);
 
         System.out.printf("Constituents:\n  %s\n", join(buildGroup.getConstituents(), "\n  "));
         assertGroupConstituents(buildGroup, new StoreKey(StoreType.hosted, execution.getBuildContentId()),

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/DownloadTwoThenVerifyExtractedArtifactsContainThemTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/DownloadTwoThenVerifyExtractedArtifactsContainThemTest.java
@@ -18,9 +18,9 @@
 package org.jboss.pnc.mavenrepositorymanager;
 
 import org.apache.commons.io.IOUtils;
-import org.commonjava.aprox.client.core.Aprox;
-import org.commonjava.aprox.client.core.util.UrlUtils;
-import org.commonjava.aprox.model.core.StoreType;
+import org.commonjava.indy.client.core.Indy;
+import org.commonjava.indy.client.core.util.UrlUtils;
+import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.commonjava.maven.atlas.ident.ref.SimpleArtifactRef;
 import org.commonjava.maven.atlas.ident.ref.SimpleProjectVersionRef;
@@ -49,8 +49,8 @@ public class DownloadTwoThenVerifyExtractedArtifactsContainThemTest
 
     @Test
     public void extractBuildArtifacts_ContainsTwoDownloads() throws Exception {
-        String pomPath = "org/commonjava/aprox/aprox-core/0.17.0/aprox-core-0.17.0.pom";
-        String jarPath = "org/commonjava/aprox/aprox-core/0.17.0/aprox-core-0.17.0.jar";
+        String pomPath = "org/commonjava/indy/indy-core/0.17.0/indy-core-0.17.0.pom";
+        String jarPath = "org/commonjava/indy/indy-core/0.17.0/indy-core-0.17.0.jar";
         String content = "This is a test " + System.currentTimeMillis();
 
         // setup the expectation that the remote repo pointing at this server will request this file...and define its content.
@@ -80,10 +80,10 @@ public class DownloadTwoThenVerifyExtractedArtifactsContainThemTest
         assertThat(deps, notNullValue());
         assertThat(deps.size(), equalTo(2));
 
-        ProjectVersionRef pvr = new SimpleProjectVersionRef("org.commonjava.aprox", "aprox-core", "0.17.0");
+        ProjectVersionRef pvr = new SimpleProjectVersionRef("org.commonjava.indy", "indy-core", "0.17.0");
         Set<String> refs = new HashSet<>();
-        refs.add(new SimpleArtifactRef(pvr, "pom", null, false).toString());
-        refs.add(new SimpleArtifactRef(pvr, "jar", null, false).toString());
+        refs.add(new SimpleArtifactRef(pvr, "pom", null).toString());
+        refs.add(new SimpleArtifactRef(pvr, "jar", null).toString());
 
         // check that both files are in the dep artifacts list using getIdentifier() to match on GAVT[C]
         for (Artifact artifact : deps) {
@@ -91,11 +91,11 @@ public class DownloadTwoThenVerifyExtractedArtifactsContainThemTest
                     equalTo(true));
         }
 
-        Aprox aprox = driver.getAprox();
+        Indy indy = driver.getIndy();
 
         // check that the new imports are available from shared-imports
         for (String path : new String[] { pomPath, jarPath }) {
-            InputStream stream = aprox.content().get(StoreType.hosted, SHARED_IMPORTS, path);
+            InputStream stream = indy.content().get(StoreType.hosted, SHARED_IMPORTS, path);
             String downloaded = IOUtils.toString(stream);
             assertThat(downloaded, equalTo(content));
         }

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/ImportDepVerifyPromotionToSharedImportsTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/ImportDepVerifyPromotionToSharedImportsTest.java
@@ -17,8 +17,8 @@
  */
 package org.jboss.pnc.mavenrepositorymanager;
 
-import org.commonjava.aprox.client.core.util.UrlUtils;
-import org.commonjava.aprox.model.core.StoreType;
+import org.commonjava.indy.client.core.util.UrlUtils;
+import org.commonjava.indy.model.core.StoreType;
 import org.jboss.pnc.mavenrepositorymanager.fixture.TestBuildExecution;
 import org.jboss.pnc.model.Artifact;
 import org.jboss.pnc.spi.repositorymanager.BuildExecution;
@@ -63,7 +63,7 @@ public class ImportDepVerifyPromotionToSharedImportsTest extends AbstractImportT
         assertThat(a.getFilename(), equalTo(new File(path).getName()));
 
         // end result: you should be able to download this artifact from shared-imports now.
-        assertThat(download(aprox.content().contentUrl(StoreType.hosted, SHARED_IMPORTS, path)), equalTo(content));
+        assertThat(download(indy.content().contentUrl(StoreType.hosted, SHARED_IMPORTS, path)), equalTo(content));
     }
 
 }

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyBuildGroupRemovedAfterArtifactExtractionTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyBuildGroupRemovedAfterArtifactExtractionTest.java
@@ -17,8 +17,8 @@
  */
 package org.jboss.pnc.mavenrepositorymanager;
 
-import org.commonjava.aprox.folo.client.AproxFoloContentClientModule;
-import org.commonjava.aprox.model.core.StoreType;
+import org.commonjava.indy.folo.client.IndyFoloContentClientModule;
+import org.commonjava.indy.model.core.StoreType;
 import org.jboss.pnc.mavenrepositorymanager.fixture.TestBuildExecution;
 import org.jboss.pnc.model.Artifact;
 import org.jboss.pnc.model.BuiltArtifact;
@@ -51,7 +51,7 @@ public class VerifyBuildGroupRemovedAfterArtifactExtractionTest extends Abstract
         RepositorySession session = driver.createBuildRepository(execution);
 
         // simulate a build deploying a file.
-        driver.getAprox().module(AproxFoloContentClientModule.class)
+        driver.getIndy().module(IndyFoloContentClientModule.class)
                 .store(buildId, StoreType.hosted, buildId, path, new ByteArrayInputStream(content.getBytes()));
 
         // now, extract the build artifacts. This will trigger promotion of the build hosted repo to the chain group.
@@ -65,7 +65,7 @@ public class VerifyBuildGroupRemovedAfterArtifactExtractionTest extends Abstract
         assertThat(a.getFilename(), equalTo(new File(path).getName()));
 
         // end result: the build aggregation group should have been garbage collected
-        boolean buildGroupExists = driver.getAprox().stores().exists(StoreType.group, buildId);
+        boolean buildGroupExists = driver.getIndy().stores().exists(StoreType.group, buildId);
         assertThat(buildGroupExists, equalTo(false));
     }
 

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyBuildRepoPromotionToUntestedBuildsGroupTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyBuildRepoPromotionToUntestedBuildsGroupTest.java
@@ -17,10 +17,10 @@
  */
 package org.jboss.pnc.mavenrepositorymanager;
 
-import org.commonjava.aprox.folo.client.AproxFoloContentClientModule;
-import org.commonjava.aprox.model.core.Group;
-import org.commonjava.aprox.model.core.StoreKey;
-import org.commonjava.aprox.model.core.StoreType;
+import org.commonjava.indy.folo.client.IndyFoloContentClientModule;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
 import org.jboss.pnc.mavenrepositorymanager.fixture.TestBuildExecution;
 import org.jboss.pnc.model.Artifact;
 import org.jboss.pnc.model.BuiltArtifact;
@@ -53,7 +53,7 @@ public class VerifyBuildRepoPromotionToUntestedBuildsGroupTest extends AbstractR
         RepositorySession session = driver.createBuildRepository(execution);
 
         // simulate a build deploying a file.
-        driver.getAprox().module(AproxFoloContentClientModule.class)
+        driver.getIndy().module(IndyFoloContentClientModule.class)
                 .store(buildId, StoreType.hosted, buildId, path, new ByteArrayInputStream(content.getBytes()));
 
         // now, extract the build artifacts. This will trigger promotion of the build hosted repo to the untested-builds group.
@@ -67,7 +67,7 @@ public class VerifyBuildRepoPromotionToUntestedBuildsGroupTest extends AbstractR
         assertThat(a.getFilename(), equalTo(new File(path).getName()));
 
         // end result: the untested-builds group should contain the build hosted repo.
-        Group untestedBuildsGroup = driver.getAprox().stores().load(StoreType.group, MavenRepositoryConstants.UNTESTED_BUILDS_GROUP, Group.class);
+        Group untestedBuildsGroup = driver.getIndy().stores().load(StoreType.group, MavenRepositoryConstants.UNTESTED_BUILDS_GROUP, Group.class);
         assertThat(untestedBuildsGroup.getConstituents().contains(new StoreKey(StoreType.hosted, buildId)), equalTo(true));
     }
 

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyManualDeletionOfBuildRepoTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyManualDeletionOfBuildRepoTest.java
@@ -17,8 +17,8 @@
  */
 package org.jboss.pnc.mavenrepositorymanager;
 
-import org.commonjava.aprox.folo.client.AproxFoloContentClientModule;
-import org.commonjava.aprox.model.core.StoreType;
+import org.commonjava.indy.folo.client.IndyFoloContentClientModule;
+import org.commonjava.indy.model.core.StoreType;
 import org.jboss.pnc.mavenrepositorymanager.fixture.TestBuildExecution;
 import org.jboss.pnc.model.Artifact;
 import org.jboss.pnc.model.BuildRecord;
@@ -54,7 +54,7 @@ public class VerifyManualDeletionOfBuildRepoTest extends AbstractRepositoryManag
         RepositorySession session = driver.createBuildRepository(execution);
 
         // simulate a build deploying a file.
-        driver.getAprox().module(AproxFoloContentClientModule.class)
+        driver.getIndy().module(IndyFoloContentClientModule.class)
                 .store(buildId, StoreType.hosted, buildId, path, new ByteArrayInputStream(content.getBytes()));
 
         // now, extract the build artifacts. This will trigger promotion of the build hosted repo to the chain group.
@@ -81,7 +81,7 @@ public class VerifyManualDeletionOfBuildRepoTest extends AbstractRepositoryManag
         });
 
         // end result: the build hosted repo should no longer exist.
-        assertThat(driver.getAprox().stores().exists(StoreType.hosted, buildId), equalTo(false));
+        assertThat(driver.getIndy().stores().exists(StoreType.hosted, buildId), equalTo(false));
     }
 
 }

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyManualPromotionOfBuildRepoTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyManualPromotionOfBuildRepoTest.java
@@ -17,10 +17,10 @@
  */
 package org.jboss.pnc.mavenrepositorymanager;
 
-import org.commonjava.aprox.folo.client.AproxFoloContentClientModule;
-import org.commonjava.aprox.model.core.Group;
-import org.commonjava.aprox.model.core.StoreKey;
-import org.commonjava.aprox.model.core.StoreType;
+import org.commonjava.indy.folo.client.IndyFoloContentClientModule;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
 import org.jboss.pnc.mavenrepositorymanager.fixture.TestBuildExecution;
 import org.jboss.pnc.model.Artifact;
 import org.jboss.pnc.model.BuildRecord;
@@ -59,7 +59,7 @@ public class VerifyManualPromotionOfBuildRepoTest extends AbstractRepositoryMana
         RepositorySession session = driver.createBuildRepository(execution);
 
         // simulate a build deploying a file.
-        driver.getAprox().module(AproxFoloContentClientModule.class)
+        driver.getIndy().module(IndyFoloContentClientModule.class)
                 .store(buildId, StoreType.hosted, buildId, path, new ByteArrayInputStream(content.getBytes()));
 
         // now, extract the build artifacts. This will trigger promotion of the build hosted repo to the chain group.
@@ -86,7 +86,7 @@ public class VerifyManualPromotionOfBuildRepoTest extends AbstractRepositoryMana
         });
 
         // end result: the chain group should contain the build hosted repo.
-        Group publicGroup = driver.getAprox().stores().load(StoreType.group, PUBLIC, Group.class);
+        Group publicGroup = driver.getIndy().stores().load(StoreType.group, PUBLIC, Group.class);
         System.out.println("public group constituents: " + publicGroup.getConstituents());
         assertThat(publicGroup.getConstituents().contains(new StoreKey(StoreType.hosted, buildId)), equalTo(true));
     }

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/fixture/Producer.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/fixture/Producer.java
@@ -17,10 +17,10 @@
  */
 package org.jboss.pnc.mavenrepositorymanager.fixture;
 
-import org.commonjava.aprox.core.expire.ScheduleManager;
-import org.commonjava.aprox.inject.TestData;
-import org.commonjava.aprox.model.core.io.AproxObjectMapper;
-import org.commonjava.aprox.subsys.maven.MavenComponentManager;
+import org.commonjava.indy.core.expire.ScheduleManager;
+import org.commonjava.indy.inject.TestData;
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.commonjava.indy.subsys.maven.MavenComponentManager;
 import org.commonjava.maven.galley.auth.AttributePasswordManager;
 import org.commonjava.maven.galley.spi.auth.PasswordManager;
 import org.commonjava.maven.galley.transport.htcli.Http;
@@ -33,7 +33,7 @@ import javax.enterprise.inject.Produces;
 @ApplicationScoped
 public class Producer {
 
-    private AproxObjectMapper objectMapper;
+    private IndyObjectMapper objectMapper;
 
     private MavenComponentManager componentManager;
 
@@ -42,7 +42,7 @@ public class Producer {
     private Http http;
 
     public Producer() {
-        objectMapper = new AproxObjectMapper(true);
+        objectMapper = new IndyObjectMapper(true);
         PasswordManager passman = new AttributePasswordManager();
         http = new HttpImpl(passman);
 
@@ -71,7 +71,7 @@ public class Producer {
     @Produces
     @Default
     @TestData
-    public AproxObjectMapper getObjectMapper() {
+    public IndyObjectMapper getObjectMapper() {
         return objectMapper;
     }
 

--- a/maven-repository-manager/src/test/resources/META-INF/beans.xml
+++ b/maven-repository-manager/src/test/resources/META-INF/beans.xml
@@ -21,6 +21,6 @@
 <beans xmlns="http://java.sun.com/xml/ns/javaee"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://jboss.org/schema/cdi/beans_1_0.xsd">
   <alternatives>
-    <stereotype>org.commonjava.aprox.inject.TestData</stereotype>
+    <stereotype>org.commonjava.indy.inject.TestData</stereotype>
   </alternatives>
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
     <!-- minimum jdk and maven versions -->
     <jdk.min.version>1.8</jdk.min.version>
     <maven.min.version>3.2</maven.min.version>
-    <atlasVersion>0.15.0</atlasVersion>
-    <aproxVersion>0.25.0</aproxVersion>
+    <atlasVersion>0.16.0</atlasVersion>
+    <indyVersion>0.99.0</indyVersion>
     <version.jboss.maven.plugin>7.5.Final</version.jboss.maven.plugin>
     <version.jboss.bom>1.0.7.Final</version.jboss.bom>
     <version.junit>4.11</version.junit>
@@ -86,8 +86,8 @@
     <version.mockito-all>1.10.8</version.mockito-all>
     <version.catch-exception>1.2.0</version.catch-exception>
     <version.guava>17.0</version.guava>
-    <version.org.apache.httpcomponents.httpclient>4.3.6</version.org.apache.httpcomponents.httpclient>
-    <version.org.apache.httpcomponents.httpcore>4.3.3</version.org.apache.httpcomponents.httpcore>
+    <version.org.apache.httpcomponents.httpclient>4.4</version.org.apache.httpcomponents.httpclient>
+    <version.org.apache.httpcomponents.httpcore>4.4</version.org.apache.httpcomponents.httpcore>
     <version.org.postgresql>9.3-1102-jdbc41</version.org.postgresql>
     <version.org.jboss.logging>3.1.0.GA</version.org.jboss.logging>
     <version.org.json>20141113</version.org.json>
@@ -604,6 +604,16 @@
         <groupId>com.openshift</groupId>
         <artifactId>openshift-restclient-java</artifactId>
         <version>3.0.1.Final</version>
+        <exclusions>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -705,35 +715,35 @@
 
 
       <dependency>
-        <groupId>org.commonjava.aprox</groupId>
-        <artifactId>aprox-promote-client-java</artifactId>
-        <version>${aproxVersion}</version>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-promote-client-java</artifactId>
+        <version>${indyVersion}</version>
       </dependency>
       <dependency>
-        <groupId>org.commonjava.aprox</groupId>
-        <artifactId>aprox-folo-client-java</artifactId>
-        <version>${aproxVersion}</version>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-folo-client-java</artifactId>
+        <version>${indyVersion}</version>
       </dependency>
       <dependency>
-        <groupId>org.commonjava.aprox</groupId>
-        <artifactId>aprox-client-core-java</artifactId>
-        <version>${aproxVersion}</version>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-client-core-java</artifactId>
+        <version>${indyVersion}</version>
       </dependency>
       <dependency>
-        <groupId>org.commonjava.aprox.embed</groupId>
-        <artifactId>aprox-embedder-savant</artifactId>
-        <version>${aproxVersion}</version>
+        <groupId>org.commonjava.indy.embed</groupId>
+        <artifactId>indy-embedder-savant</artifactId>
+        <version>${indyVersion}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.commonjava.aprox</groupId>
-        <artifactId>aprox-test-fixtures-core</artifactId>
-        <version>${aproxVersion}</version>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-test-fixtures-core</artifactId>
+        <version>${indyVersion}</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
-            <groupId>org.commonjava.aprox.boot</groupId>
-            <artifactId>aprox-booter-api</artifactId>
+            <groupId>org.commonjava.indy.boot</groupId>
+            <artifactId>indy-booter-api</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
Also, update client library from AProx to Indy, and use the approaching-final 0.99.0 version. Minor changes to httpclient and log4j deps to clean up depgraph and make things work again.