### PR TITLE
fix for NCL-1728

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductReleaseEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductReleaseEndpoint.java
@@ -113,8 +113,8 @@ public class ProductReleaseEndpoint extends AbstractEndpoint<ProductRelease, Pro
 
     @ApiOperation(value = "Gets all Product Releases of the Specified Product Version")
     @ApiResponses(value = {
-            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION, response = ProductReleaseSingleton.class),
-            @ApiResponse(code = NO_CONTENT_CODE, message = NO_CONTENT_DESCRIPTION, response = ProductReleaseSingleton.class),
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION, response = ProductReleasePage.class),
+            @ApiResponse(code = NO_CONTENT_CODE, message = NO_CONTENT_DESCRIPTION, response = ProductReleasePage.class),
             @ApiResponse(code = INVLID_CODE, message = INVALID_DESCRIPTION, response = ErrorResponseRest.class),
             @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = ErrorResponseRest.class)
     })


### PR DESCRIPTION
This changes the return declaration of the swagger annotations to match what is actually being returned by the provider.