### PR TITLE
NCL-1771 - Bump version of i in npm-shrinkwrap to 0.3.3

### DIFF
--- a/ui/npm-shrinkwrap.json
+++ b/ui/npm-shrinkwrap.json
@@ -13811,9 +13811,9 @@
                   "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz"
                 },
                 "i": {
-                  "version": "0.3.2",
-                  "from": "https://registry.npmjs.org/i/-/i-0.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.2.tgz"
+                  "version": "0.3.3",
+                  "from": "https://registry.npmjs.org/i/-/i-0.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
                 },
                 "mkdirp": {
                   "version": "0.5.0",


### PR DESCRIPTION
(cherry picked from commit aee3a5157b4f85d4d18b3b38d8018540c5c67afe)