### PR TITLE
Fix for NCL-1878

### DIFF
--- a/ui/app/services.js
+++ b/ui/app/services.js
@@ -208,9 +208,6 @@
             case 404:
               Notifications.error('Requested resource not found');
               break;
-            case 409:
-              Notifications.error('Build rejected because the same build configuration is already running', rejection);
-              break;
             default:
               handleError(rejection);
               break;


### PR DESCRIPTION
Remove hard-coding of the 409 response code error message. This allows the correct error message from the REST API to be displayed.