### PR TITLE
NCL-1922

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/BuildCoordinator.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/BuildCoordinator.java
@@ -106,7 +106,8 @@ public class BuildCoordinator {
         BuildConfigurationAudited buildConfigAudited = datastoreAdapter.getLatestBuildConfigurationAudited(buildConfiguration.getId());
         Optional<BuildTask> alreadyActiveBuildTask = this.getActiveBuildTask(buildConfigAudited);
         if (alreadyActiveBuildTask.isPresent()) {
-            throw new BuildConflictException("Active build task found using the same configuration", alreadyActiveBuildTask.get().getId());
+            throw new BuildConflictException("Active build task found using the same configuration",
+                    alreadyActiveBuildTask.get().getId());
         }
 
         BuildTask buildTask = BuildTask.build(

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/response/error/ErrorResponseRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/response/error/ErrorResponseRest.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.rest.restmodel.response.error;
 
 import org.jboss.pnc.rest.validation.exceptions.ValidationException;
+import org.jboss.pnc.spi.exception.BuildConflictException;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -41,6 +42,12 @@ public class ErrorResponseRest {
         this.errorType = e.getClass().getSimpleName();
         this.errorMessage = e.getMessage();
         this.details = e.getRestModelForException().orElse(null);
+    }
+
+    public ErrorResponseRest(BuildConflictException e) {
+        this.errorType = e.getClass().getSimpleName();
+        this.errorMessage = e.getMessage() + ": " +  e.getBuildTaskId();
+        this.details = null;
     }
 
     public String getErrorType() {

--- a/rest/src/main/java/org/jboss/pnc/rest/configuration/BuildConflictExceptionMapper.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/configuration/BuildConflictExceptionMapper.java
@@ -1,0 +1,59 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.configuration;
+
+import org.jboss.pnc.rest.restmodel.response.error.ErrorResponseRest;
+import org.jboss.pnc.spi.exception.BuildConflictException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import java.lang.invoke.MethodHandles;
+
+@Provider
+public class BuildConflictExceptionMapper implements ExceptionMapper<BuildConflictException> {
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    @Override
+    public Response toResponse(BuildConflictException e) {
+        Response.Status status = Response.Status.CONFLICT;
+        logger.debug("A BuildConflict error occurred when processing REST call", e);
+        return Response.status(status).entity(new ErrorResponseRest(e)).build();
+    }
+}

--- a/rest/src/main/java/org/jboss/pnc/rest/configuration/JaxRsActivator.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/configuration/JaxRsActivator.java
@@ -69,6 +69,11 @@ public class JaxRsActivator extends Application {
     }
 
     private void addProjectResources(Set<Class<?>> resources) {
+        addEndpoints(resources);
+        addExceptionMappers(resources);
+    }
+
+    private void addEndpoints(Set<Class<?>> resources) {
         resources.add(ProductEndpoint.class);
         resources.add(ProductVersionEndpoint.class);
         resources.add(ProductMilestoneEndpoint.class);
@@ -83,11 +88,16 @@ public class JaxRsActivator extends Application {
         resources.add(LicenseEndpoint.class);
         resources.add(BuildEnvironmentEndpoint.class);
         resources.add(TestEndpoint.class);
-        resources.add(ValidationExceptionExceptionMapper.class);
-        resources.add(AllOtherExceptionsMapper.class);
         resources.add(BuildTaskEndpoint.class);
         resources.add(BuildEndpoint.class);
     }
+
+    private void addExceptionMappers(Set<Class<?>> resources) {
+        resources.add(ValidationExceptionExceptionMapper.class);
+        resources.add(BuildConflictExceptionMapper.class);
+        resources.add(AllOtherExceptionsMapper.class);
+    }
+
 
     private void addSwaggerResources(Set<Class<?>> resources) {
         resources.add(io.swagger.jaxrs.listing.ApiListingResource.class);


### PR DESCRIPTION
Map BuildConflictExceptions to error responses. This is done by adding a new the BuildConflictExceptionMapper, and adding a new constructor for ErrorResponseRest that takes BuildConflictExceptions. Lastly, the try-catch block that catches BuildConflictExceptions in the trigger method of BuildConfigurationEndpoint has been removed so the BuildConflictException can be thrown to the mapper.