### PR TITLE
NCL-1243 first part of update of container tests configuration.

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -83,11 +83,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jboss.pnc</groupId>
-      <artifactId>test-arquillian-container</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <scope>test</scope>
@@ -108,6 +103,38 @@
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.as</groupId>
+      <artifactId>jboss-as-arquillian-container-managed</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.protocol</groupId>
+      <artifactId>arquillian-protocol-servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.extension</groupId>
+      <artifactId>arquillian-transaction-jta</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.websocket</groupId>
+      <artifactId>jboss-websocket-api_1.0_spec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.shrinkwrap</groupId>
+      <artifactId>shrinkwrap-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.shrinkwrap.resolver</groupId>
+      <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+    </dependency>
+    <dependency> <!--Required to add lib to Arquillian deployment. -->
+      <groupId>org.jboss</groupId>
+      <artifactId>jboss-common-core</artifactId>
     </dependency>
   </dependencies>
 
@@ -145,6 +172,274 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>download-server</id>
+      <activation>
+        <property>
+          <name>eap6.zip.url</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>download-and-extract-eap-server</id>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>test-compile</phase>
+                <configuration>
+                  <target>
+                    <!-- If JBOSS_HOME is set it causes obscure errors with CLI in -->
+                    <!-- jboss-as-maven-plugin. -->
+                    <property environment="env" />
+                    <fail message="JBOSS_HOME must not be set" if="env.JBOSS_HOME" />
+
+                    <echo>Preparing EAP 6.4 application server</echo>
+                    <echo>EAP URL ${eap6.zip.url}</echo>
+                    <fail message="Please specify EAP 6.4 zip file URL via: -Deap6.zip.url=" unless="eap6.zip.url" />
+                    <mkdir dir="${test.server.unpack.dir}" />
+                    <get usetimestamp="true" src="${eap6.zip.url}" skipexisting="true" dest="${test.server.unpack.dir}/${app.server}-${jboss.version}.zip" />
+                    <unzip src="${test.server.unpack.dir}/${app.server}-${jboss.version}.zip" dest="${test.server.unpack.dir}/" overwrite="true" />
+
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>configure-test-container</id>
+      <activation>
+        <property>
+          <name>eap6.zip.url</name>
+        </property>
+      </activation>
+      <properties>
+        <postgresql.server.address>localhost</postgresql.server.address>
+        <postgresql.server.username>newcastle</postgresql.server.username>
+        <postgresql.server.password>newcastle</postgresql.server.password>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.hsqldb</groupId>
+          <artifactId>hsqldb</artifactId>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.postgresql</groupId>
+          <artifactId>postgresql</artifactId>
+          <scope>compile</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-keycloak-adapter</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.keycloak</groupId>
+                      <artifactId>keycloak-eap6-adapter-dist</artifactId>
+                      <version>${version.keycloak}</version>
+                      <type>zip</type>
+                      <overWrite>true</overWrite>
+                      <outputDirectory>${test.server.build.dir}</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                  <!-- other configurations here -->
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.jboss.as.plugins</groupId>
+            <artifactId>jboss-as-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>start-server</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+                <configuration>
+                  <jbossHome>${test.server.build.dir}</jbossHome>
+                </configuration>
+              </execution>
+              <execution>
+                <id>add-nio</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>execute-commands</goal>
+                </goals>
+                <configuration>
+                  <execute-commands>
+                    <batch>true</batch>
+                    <commands>
+                      <command>
+                        /subsystem=web/connector=http/:write-attribute(name=protocol,value=org.apache.coyote.http11.Http11NioProtocol)
+                      </command>
+                    </commands>
+                  </execute-commands>
+                </configuration>
+              </execution>
+              <execution>
+                <id>add-keycloak</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>execute-commands</goal>
+                </goals>
+                <configuration>
+                  <execute-commands>
+                    <commands>
+                      <command>
+                        /extension=org.keycloak.keycloak-subsystem:add
+                      </command>
+                      <command>
+                        /subsystem=keycloak:add
+                      </command>
+                      <command>
+                        /subsystem=security/security-domain=keycloak:add
+                      </command>
+                      <command>
+                        /subsystem=security/security-domain=keycloak/authentication=classic:add(login-modules=[{"code"=&gt;"org.keycloak.adapters.jboss.KeycloakLoginModule", "flag"=&gt;"required"}])
+                      </command>
+                    </commands>
+                  </execute-commands>
+                </configuration>
+              </execution>
+              <!-- HSQLDB JDBC driver installation and datasource configuration -->
+              <execution>
+                <id>deploy-hsql-jdbc-driver</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>deploy-artifact</goal>
+                </goals>
+                <configuration>
+                  <groupId>org.hsqldb</groupId>
+                  <artifactId>hsqldb</artifactId>
+                  <name>hsqldb.jar</name>
+                </configuration>
+              </execution>
+              <execution>
+                <id>add-hsql-datasource</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>add-resource</goal>
+                </goals>
+                <configuration>
+                  <address>subsystem=datasources,data-source=java:jboss/datasources/NewcastleTestDS</address>
+                  <resource>
+                    <enable-resource>true</enable-resource>
+                    <properties>
+                      <jndi-name>java:jboss/datasources/NewcastleTestDS</jndi-name>
+                      <enabled>true</enabled>
+                      <connection-url>jdbc:hsqldb:mem:newcastletestmemdb</connection-url>
+                      <driver-class>org.hsqldb.jdbc.JDBCDriver</driver-class>
+                      <driver-name>hsqldb.jar</driver-name>
+                    </properties>
+                  </resource>
+                </configuration>
+              </execution>
+              <!-- End HSQLDB configuraiton -->
+              <!-- Postgresql JDBC driver installation and datasource configuration -->
+              <execution>
+                <id>deploy-postgresql-jdbc-driver</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>deploy-artifact</goal>
+                </goals>
+                <configuration>
+                  <groupId>org.postgresql</groupId>
+                  <artifactId>postgresql</artifactId>
+                  <name>postgresql-jdbc.jar</name>
+                </configuration>
+              </execution>
+              <execution>
+                <id>add-postgresql-datasource</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>add-resource</goal>
+                </goals>
+                <configuration>
+                  <address>subsystem=datasources</address>
+                  <resources>
+                    <resource>
+                      <enable-resource>true</enable-resource>
+                      <address>xa-data-source=java:jboss/datasources/NewcastleDS</address>
+                      <properties>
+                        <xa-datasource-class>org.postgresql.xa.PGXADataSource</xa-datasource-class>
+                        <jndi-name>java:jboss/datasources/NewcastleDS</jndi-name>
+                        <enabled>true</enabled>
+                        <driver-name>postgresql-jdbc.jar</driver-name>
+                      </properties>
+                      <resources>
+                        <resource>
+                          <address>
+                            xa-datasource-properties=DatabaseName
+                          </address>
+                          <properties>
+                            <value>newcastle</value>
+                          </properties>
+                        </resource>
+                        <resource>
+                          <address>
+                            xa-datasource-properties=ServerName
+                          </address>
+                          <properties>
+                            <value>${postgresql.server.address}</value>
+                          </properties>
+                        </resource>
+                        <resource>
+                          <address>
+                            xa-datasource-properties=User
+                          </address>
+                          <properties>
+                            <value>${postgresql.server.username}</value>
+                          </properties>
+                        </resource>
+                        <resource>
+                          <address>
+                            xa-datasource-properties=Password
+                          </address>
+                          <properties>
+                            <value>${postgresql.server.password}</value>
+                          </properties>
+                        </resource>
+                      </resources>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+              <!-- End PostgreSQL configuration -->
+              <execution>
+                <id>shutdown-server</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>shutdown</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
   </profiles>
   <build>
     <finalName>integration-test</finalName>

--- a/openshift-environment-driver/pom.xml
+++ b/openshift-environment-driver/pom.xml
@@ -78,12 +78,17 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
-      <groupId>org.jboss.pnc</groupId>
-      <artifactId>test-arquillian-container</artifactId>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>test-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- /Test dependencies -->
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
 
   <modules>
     <module>test-common</module>
-    <module>test-arquillian-container</module>
     <module>common</module>
     <module>moduleconfig</module>
     <module>auth</module>
@@ -1397,6 +1396,7 @@
             </property>
           </properties>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          <excludedGroups>org.jboss.pnc.test.category.ContainerTest, org.jboss.pnc.test.category.RemoteTest</excludedGroups>
         </configuration>
         <executions>
           <execution>
@@ -1410,17 +1410,6 @@
               <!--<threadCount>2</threadCount>-->
               <!--<perCoreThreadCount>true</perCoreThreadCount>-->
               <excludedGroups>org.jboss.pnc.test.category.ContainerTest, org.jboss.pnc.test.category.RemoteTest</excludedGroups>
-            </configuration>
-          </execution>
-          <execution>
-            <id>remote-test</id>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <groups>org.jboss.pnc.test.category.RemoteTest</groups>
-              <excludedGroups>org.jboss.pnc.test.category.ContainerTest</excludedGroups>
-              <skip>${surefire.test.remote.skip}</skip>
             </configuration>
           </execution>
         </executions>
@@ -1446,19 +1435,6 @@
           </systemPropertyVariables>
         </configuration>
         <executions>
-          <execution>
-            <!-- Invoked when there is no remote tests -->
-            <id>container-tests</id>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-            <configuration>
-              <skip>${failsafe.test.integration.skip}</skip>
-              <groups>org.jboss.pnc.test.category.ContainerTest</groups>
-              <excludedGroups>org.jboss.pnc.test.category.RemoteTest</excludedGroups>
-            </configuration>
-          </execution>
           <execution>
             <!-- Invoked for container AND remote tests -->
             <id>container-and-remote-tests</id>
@@ -1551,6 +1527,22 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-test</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <excludedGroups>org.jboss.pnc.test.category.RemoteTest</excludedGroups>
+                  <test>${test}</test>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>
@@ -1564,6 +1556,26 @@
         <failsafe.test.integration.skip>true</failsafe.test.integration.skip>
         <surefire.test.remote.skip>false</surefire.test.remote.skip>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-test</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <excludedGroups>org.jboss.pnc.test.category.ContainerTest</excludedGroups>
+                  <test>${test}</test>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -1697,7 +1709,6 @@
         </plugins>
       </build>
     </profile>
-
   </profiles>
 
 </project>


### PR DESCRIPTION
first part includes:
- possible to run single tests (still terribly slow)
- download and configure EAP always when needed
- `container-tests` and `remote-tests` are trigered according to property usage (README changed)