### PR TITLE
[NCL-1820] Store md5 checksum in artifact database

### DIFF
--- a/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
+++ b/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
@@ -284,7 +284,7 @@ public class MavenRepositorySession implements RepositorySession {
                 ArtifactRef aref = new SimpleArtifactRef(pathInfo.getProjectId(), pathInfo.getType(), pathInfo.getClassifier());
                 logger.info("Recording upload: {}", aref);
 
-                Artifact.Builder artifactBuilder = Artifact.Builder.newBuilder().checksum(upload.getSha256())
+                Artifact.Builder artifactBuilder = Artifact.Builder.newBuilder().checksum(upload.getMd5())
                         .artifactQuality(ArtifactQuality.BUILT).deployUrl(upload.getLocalUrl())
                         .filename(new File(path).getName()).identifier(aref.toString()).repoType(RepositoryType.MAVEN);
 


### PR DESCRIPTION
This is easier to verify than the sha256 checksum