### PR TITLE
[NCL-1957] Define coordinatorThreadPoolSize in config

### DIFF
--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/SystemConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/SystemConfig.java
@@ -30,12 +30,27 @@ public class SystemConfig extends AbstractModuleConfig {
 
     private String buildSchedulerId;
 
+    /**
+     * Number of threads that are used to run executor operations
+     * (setting up the repos, configuring the build, triggering the build, collecting the results)
+     */
     private String executorThreadPoolSize;
 
+    /**
+     * Number of threads that are used to run the build and listen for completion.
+     */
     private String builderThreadPoolSize;
 
+    /**
+     * number of threads that are taking a build task to be build and starting the building process
+     * (their job finishes at starting bpm build, then they go back to grab the next build task)
+     */
     private int coordinatorThreadPoolSize;
 
+    /**
+     * maximum number of build tasks processed at a time (build tasks that are in progress,
+     * regardless of whether they are starting bpm process, being build by executor, etc)
+     */
     private int coordinatorMaxConcurrentBuilds;
 
     public SystemConfig(
@@ -48,7 +63,7 @@ public class SystemConfig extends AbstractModuleConfig {
         this.buildDriverId = buildDriverId;
         this.buildSchedulerId = buildSchedulerId;
         this.executorThreadPoolSize = executorThreadPoolSize;
-        this.executorThreadPoolSize = builderThreadPoolSize;
+        this.builderThreadPoolSize = builderThreadPoolSize;
         this.coordinatorThreadPoolSize = toIntWithDefault("coordinatorThreadPoolSize", coordinatorThreadPoolSize, 1);
         this.coordinatorMaxConcurrentBuilds = toIntWithDefault("coordinatorMaxConcurrentBuilds", coordinatorMaxConcurrentBuilds, 10);
     }

--- a/moduleconfig/src/main/resources/pnc-config.json
+++ b/moduleconfig/src/main/resources/pnc-config.json
@@ -20,7 +20,9 @@
                     "buildDriverId": "termd-build-driver",
                     "buildSchedulerId": "local-build-scheduler",
                     "executorThreadPoolSize": "1",
-                    "builderThreadPoolSize": "1"
+                    "builderThreadPoolSize": "1",
+                    "coordinatorThreadPoolSize": "1",
+                    "coordinatorMaxConcurrentBuilds": "10"
                 },
                 {
                     "@module-config": "termd-build-driver",

--- a/termd-build-driver/src/test/java/org/jboss/pnc/termdbuilddriver/TermdBuildDriverTest.java
+++ b/termd-build-driver/src/test/java/org/jboss/pnc/termdbuilddriver/TermdBuildDriverTest.java
@@ -64,7 +64,7 @@ public class TermdBuildDriverTest extends AbstractLocalBuildAgentTest {
         doReturn("mvn validate").when(jsr107BuildConfig).getBuildScript();
         doReturn("jsr107-test").when(jsr107BuildConfig).getName();
         
-        doReturn(new SystemConfig(null, null, null, "", null, null)).when(configuration).getModuleConfig(any());
+        doReturn(new SystemConfig(null, null, null, null, null, null)).when(configuration).getModuleConfig(any());
         
         
         buildExecutionMock = mock(BuildExecutionSession.class);


### PR DESCRIPTION
This commit does 2 changes:

- Fix issue where the wrong field is set:
  * executorThreadPoolSize is set instead of builderThreadPoolSize

- Add fields 'coordinatorThreadPoolSize' and
  'coordinatorMaxConcurrentBuilds' to the pnc-config.json