### PR TITLE
Update to latest openshift rest client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -582,7 +582,7 @@
       <dependency>
         <groupId>com.openshift</groupId>
         <artifactId>openshift-restclient-java</artifactId>
-        <version>3.0.1.Final</version>
+        <version>4.0.5.Final</version>
         <exclusions>
           <exclusion>
             <groupId>log4j</groupId>


### PR DESCRIPTION
We want to update to the latest openshift rest client because of issues
experienced with the 3.0.1.Final version with Openshift 3.2.

The request type was not set in that version.

```
{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"the
body of the request was in an unknown format - accepted media types
include: application/json,
application/yaml","reason":"UnsupportedMediaType","code":415}
```

We hope that by upgrading to the latest version, this error will
disappear.