### PR TITLE
[NCL-2144] keep the build alive after failure

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/bpm/BpmBuildScheduler.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/bpm/BpmBuildScheduler.java
@@ -155,7 +155,8 @@ public class BpmBuildScheduler implements BuildScheduler {
                 buildConfiguration.getScmMirrorRevision(),
                 buildConfiguration.getBuildEnvironment().getSystemImageId(),
                 buildConfiguration.getBuildEnvironment().getSystemImageRepositoryUrl(),
-                buildConfiguration.getBuildEnvironment().getSystemImageType());
+                buildConfiguration.getBuildEnvironment().getSystemImageType(),
+                buildTask.isPodKeptAfterFailure());
 
         BuildExecutionConfigurationRest buildExecutionConfigurationREST = new BuildExecutionConfigurationRest(buildExecutionConfiguration);
 

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/local/LocalBuildScheduler.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/local/LocalBuildScheduler.java
@@ -87,7 +87,8 @@ public class LocalBuildScheduler implements BuildScheduler {
                 configuration.getScmMirrorRevision(),
                 configuration.getBuildEnvironment().getSystemImageId(),
                 configuration.getBuildEnvironment().getSystemImageRepositoryUrl(),
-                configuration.getBuildEnvironment().getSystemImageType());
+                configuration.getBuildEnvironment().getSystemImageType(),
+                buildTask.isPodKeptAfterFailure());
 
         try {
             buildExecutor.startBuilding(buildExecutionConfiguration, onBuildExecutionStatusChangedEvent);

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/BuildCoordinationTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/BuildCoordinationTest.java
@@ -92,7 +92,7 @@ public class BuildCoordinationTest {
 
         ObjectWrapper<BuildSetStatus> lastBuildSetStatus = registerCallback(buildConfigurationSet);
 
-        BuildSetTask buildSetTask = buildCoordinator.build(buildConfigurationSet, TestEntitiesFactory.newUser(), true);
+        BuildSetTask buildSetTask = buildCoordinator.build(buildConfigurationSet, TestEntitiesFactory.newUser(), false, true);
 
         Wait.forCondition(lastBuildSetStatus::isSet, 5, ChronoUnit.SECONDS);
 
@@ -109,7 +109,7 @@ public class BuildCoordinationTest {
 
         ObjectWrapper<BuildSetStatus> lastBuildSetStatus = registerCallback(buildConfigurationSet);
 
-        BuildSetTask buildSetTask = buildCoordinator.build(buildConfigurationSet, TestEntitiesFactory.newUser(), true);
+        BuildSetTask buildSetTask = buildCoordinator.build(buildConfigurationSet, TestEntitiesFactory.newUser(), false, true);
 
         Wait.forCondition(lastBuildSetStatus::isSet, 5, ChronoUnit.SECONDS);
 
@@ -138,7 +138,7 @@ public class BuildCoordinationTest {
 
         log.info("Running builds ...");
 
-        buildCoordinator.build(buildConfigurationSet, TestEntitiesFactory.newUser(), true);
+        buildCoordinator.build(buildConfigurationSet, TestEntitiesFactory.newUser(), false, true);
 
         Wait.forCondition(() -> contains(buildSetStatusChangedEvents, BuildSetStatus.NEW), 2000, ChronoUnit.MILLIS, "Did not receive status update to NEW for task set.");
         Wait.forCondition(() -> contains(buildSetStatusChangedEvents, BuildSetStatus.DONE), 2000, ChronoUnit.MILLIS, "Did not receive status update to DONE for task set.");

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/ConfigurationsTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/ConfigurationsTest.java
@@ -51,7 +51,7 @@ public class ConfigurationsTest extends ProjectBuilder {
 
         User user = User.Builder.newBuilder().id(1).build();
 
-        BuildTask buildTask = buildCoordinator.build(buildConfiguration, user, false);
+        BuildTask buildTask = buildCoordinator.build(buildConfiguration, user, false, false);
         Assert.assertEquals(BuildCoordinationStatus.REJECTED, buildTask.getStatus());
         Assert.assertTrue("Invalid status description: " + buildTask.getStatusDescription(), buildTask.getStatusDescription().contains("itself"));
     }
@@ -64,7 +64,7 @@ public class ConfigurationsTest extends ProjectBuilder {
 
         User user = User.Builder.newBuilder().id(1).build();
 
-        BuildSetTask buildSetTask = buildCoordinator.build(buildConfigurationSet, user, true);
+        BuildSetTask buildSetTask = buildCoordinator.build(buildConfigurationSet, user, false, true);
         Assert.assertEquals(BuildSetStatus.REJECTED, buildSetTask.getStatus());
         Assert.assertTrue("Invalid status description: " + buildSetTask.getStatusDescription(), buildSetTask.getStatusDescription().contains("Cycle dependencies found"));
     }

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/ProjectBuilder.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/ProjectBuilder.java
@@ -98,7 +98,7 @@ public class ProjectBuilder {
         final Semaphore semaphore = registerReleaseListenersAndAcquireSemaphore(receivedStatuses, N_STATUS_UPDATES_PER_TASK);
 
 
-        BuildTask buildTask = buildCoordinator.build(buildConfiguration, MockUser.newTestUser(1), false);
+        BuildTask buildTask = buildCoordinator.build(buildConfiguration, MockUser.newTestUser(1), false, false);
         log.info("Started build task {}", buildTask);
 
         assertBuildStartedSuccessfully(buildTask);
@@ -145,7 +145,7 @@ public class ProjectBuilder {
         final Semaphore semaphore = registerReleaseListenersAndAcquireSemaphore(receivedStatuses, nStatusUpdates);
         final Semaphore buildSetSemaphore = registerBuildSetListeners(receivedSetStatuses, BUILD_SET_STATUS_UPDATES);
 
-        BuildSetTask buildSetTask = buildCoordinator.build(buildConfigurationSet, MockUser.newTestUser(1), true);
+        BuildSetTask buildSetTask = buildCoordinator.build(buildConfigurationSet, MockUser.newTestUser(1), false, true);
 
         assertBuildStartedSuccessfully(buildSetTask);
 

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/ReadDependenciesTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/ReadDependenciesTest.java
@@ -33,7 +33,6 @@ import org.junit.runner.RunWith;
 
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -75,7 +74,7 @@ public class ReadDependenciesTest extends ProjectBuilder {
                 buildConfigurationSet,
                 user,
                 true,
-                buildStatusChangedEventNotifier,
+                false,
                 atomicInteger::getAndIncrement);
     }
 }

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/SkippingDependentBuildsTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/SkippingDependentBuildsTest.java
@@ -80,10 +80,10 @@ public class SkippingDependentBuildsTest extends ProjectBuilder {
         BuildCoordinator buildCoordinator = coordinator.coordinator;
 
         //when
-        buildCoordinator.build(testConfiguration, testUser, false);
+        buildCoordinator.build(testConfiguration, testUser, false, false);
         waitForBuild(coordinator.queue);
 
-        buildCoordinator.build(testConfiguration, testUser, false);
+        buildCoordinator.build(testConfiguration, testUser, false, false);
         waitForBuild(coordinator.queue);
 
         //then
@@ -101,10 +101,10 @@ public class SkippingDependentBuildsTest extends ProjectBuilder {
         BuildCoordinator buildCoordinator = coordinator.coordinator;
 
         //when
-        buildCoordinator.build(testConfiguration, testUser, true);
+        buildCoordinator.build(testConfiguration, testUser, false, true);
         waitForBuild(coordinator.queue);
 
-        buildCoordinator.build(testConfiguration, testUser, true);
+        buildCoordinator.build(testConfiguration, testUser, false, true);
         waitForBuild(coordinator.queue);
 
         //then
@@ -124,10 +124,10 @@ public class SkippingDependentBuildsTest extends ProjectBuilder {
         BuildCoordinator buildCoordinator = coordinator.coordinator;
 
         //when
-        buildCoordinator.build(testConfigurationSet, testUser, false); //first build
+        buildCoordinator.build(testConfigurationSet, testUser, false, false); //first build
         waitForBuild(coordinator.queue);
 
-        buildCoordinator.build(testConfigurationSet, testUser, false); //forced rebuild build
+        buildCoordinator.build(testConfigurationSet, testUser, false, false); //forced rebuild build
         waitForBuild(coordinator.queue);
 
         //then
@@ -146,10 +146,10 @@ public class SkippingDependentBuildsTest extends ProjectBuilder {
         BuildCoordinator buildCoordinator = coordinator.coordinator;
 
         //when
-        buildCoordinator.build(testConfigurationSet, testUser, true); //first build
+        buildCoordinator.build(testConfigurationSet, testUser, false, true); //first build
         waitForBuild(coordinator.queue);
 
-        buildCoordinator.build(testConfigurationSet, testUser, true); //forced rebuild build
+        buildCoordinator.build(testConfigurationSet, testUser, false, true); //forced rebuild build
         waitForBuild(coordinator.queue);
 
         //then

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/builder/bpm/BpmBuildSchedulerTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/builder/bpm/BpmBuildSchedulerTest.java
@@ -80,8 +80,8 @@ public class BpmBuildSchedulerTest {
         User user = User.Builder.newBuilder().username("demo").id(1).build();
         user.setLoginToken("no-token");
 
-        BuildTask buildTask = BuildTask.build(buildConfiguration, buildConfigurationAudited, user,
-                null, 1, mock(BuildSetTask.class), new Date(), null, true);
+        BuildTask buildTask = BuildTask.build(buildConfiguration, buildConfigurationAudited, false, user,
+                1, mock(BuildSetTask.class), new Date(), null, true);
 
         BpmModuleConfig bpmConfiguration = mock(BpmModuleConfig.class);
         doReturn("http://localhost/aprox").when(bpmConfiguration).getAproxBaseUrl();

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/event/StatusUpdatesTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/event/StatusUpdatesTest.java
@@ -166,7 +166,7 @@ public class StatusUpdatesTest {
                 buildConfigurationSet,
                 user,
                 true,
-                buildStatusChangedEventNotifier,
+                false,
                 () -> atomicInteger.getAndIncrement());
     }
 

--- a/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionConfiguration.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionConfiguration.java
@@ -38,6 +38,7 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
     private final String systemImageId;
     private final String systemImageRepositoryUrl;
     private final SystemImageType systemImageType;
+    private final boolean podKeptAfterFailure;
 
     public DefaultBuildExecutionConfiguration(
             int id,
@@ -51,7 +52,8 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
             String scmRevision,
             String systemImageId,
             String systemImageRepositoryUrl,
-            SystemImageType systemImageType) {
+            SystemImageType systemImageType,
+            boolean podKeptAfterFailure) {
 
         this.id = id;
         this.buildContentId = buildContentId;
@@ -65,6 +67,7 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
         this.systemImageId = systemImageId;
         this.systemImageRepositoryUrl = systemImageRepositoryUrl;
         this.systemImageType = systemImageType;
+        this.podKeptAfterFailure = podKeptAfterFailure;
     }
 
     @Override
@@ -125,5 +128,10 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
     @Override
     public SystemImageType getSystemImageType() {
         return systemImageType;
+    }
+
+    @Override
+    public boolean isPodKeptOnFailure() {
+        return podKeptAfterFailure;
     }
 }

--- a/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutor.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutor.java
@@ -245,9 +245,12 @@ public class DefaultBuildExecutor implements BuildExecutor {
 
     private void destroyEnvironment(BuildExecutionSession buildExecutionSession) {
         try {
-            buildExecutionSession.setStatus(BuildExecutionStatus.BUILD_ENV_DESTROYING);
-            buildExecutionSession.getRunningEnvironment().destroyEnvironment();
-            buildExecutionSession.setStatus(BuildExecutionStatus.BUILD_ENV_DESTROYED);
+            if (!buildExecutionSession.hasFailed()
+                    || !buildExecutionSession.getBuildExecutionConfiguration().isPodKeptOnFailure()) {
+                buildExecutionSession.setStatus(BuildExecutionStatus.BUILD_ENV_DESTROYING);
+                buildExecutionSession.getRunningEnvironment().destroyEnvironment();
+                buildExecutionSession.setStatus(BuildExecutionStatus.BUILD_ENV_DESTROYED);
+            }
         } catch (Throwable e) {
             throw new BuildProcessException(e);
         }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/coordinator/BuildCoordinatorMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/coordinator/BuildCoordinatorMock.java
@@ -69,13 +69,13 @@ public class BuildCoordinatorMock implements BuildCoordinator {
     }
 
     @Override
-    public BuildTask build(BuildConfiguration buildConfiguration, User user, boolean rebuildAll) throws BuildConflictException {
+    public BuildTask build(BuildConfiguration buildConfiguration, User user, boolean keepAliveOnFailure, boolean rebuildAll) throws BuildConflictException {
         logger.warn("Invoking unimplemented method build");
         return Mockito.mock(BuildTask.class);
     }
 
     @Override
-    public BuildSetTask build(BuildConfigurationSet buildConfigurationSet, User user, boolean rebuildAll) throws CoreException {
+    public BuildSetTask build(BuildConfigurationSet buildConfigurationSet, User user, boolean keepAliveOnFailure, boolean rebuildAll) throws CoreException {
         logger.warn("Invoking unimplemented method build");
         return Mockito.mock(BuildSetTask.class);
     }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionConfigurationMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionConfigurationMock.java
@@ -138,6 +138,11 @@ public class BuildExecutionConfigurationMock implements BuildExecutionConfigurat
         return systemImageType;
     }
 
+    @Override
+    public boolean isPodKeptOnFailure() {
+        return false;
+    }
+
     public void setSystemImageType(SystemImageType systemImageType) {
         this.systemImageType = systemImageType;
     }

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
@@ -47,6 +47,7 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
     private String systemImageId;
     private String systemImageRepositoryUrl;
     private SystemImageType systemImageType;
+    private boolean podKeptOnFailure = false;
 
     public BuildExecutionConfigurationRest() {}
 
@@ -67,6 +68,7 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
         systemImageRepositoryUrl = buildExecutionConfiguration.getSystemImageRepositoryUrl();
         systemImageType = buildExecutionConfiguration.getSystemImageType();
         user = new UserRest(buildExecutionConfiguration.getUserId());
+        podKeptOnFailure = buildExecutionConfiguration.isPodKeptOnFailure();
 
     }
 
@@ -83,6 +85,7 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
         systemImageRepositoryUrl = buildExecutionConfiguration.getSystemImageRepositoryUrl();
         systemImageType = buildExecutionConfiguration.getSystemImageType();
         user = new UserRest(buildExecutionConfiguration.getUserId());
+        podKeptOnFailure = buildExecutionConfiguration.isPodKeptOnFailure();
     }
 
     public BuildExecutionConfiguration toBuildExecutionConfiguration() {
@@ -98,7 +101,8 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
                 scmMirrorRevision,
                 systemImageId,
                 systemImageRepositoryUrl,
-                systemImageType
+                systemImageType,
+                podKeptOnFailure
         );
     }
 
@@ -230,6 +234,15 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
 
     public SystemImageType getSystemImageType() {
         return systemImageType;
+    }
+
+    @Override
+    public boolean isPodKeptOnFailure() {
+        return podKeptOnFailure;
+    }
+
+    public void setPodKeptOnFailure(boolean podKeptOnFailure) {
+        this.podKeptOnFailure = podKeptOnFailure;
     }
 
     public void setSystemImageType(SystemImageType systemImageType) {

--- a/rest-model/src/test/java/org/jboss/pnc/restmodel/serialization/BuildExecutionConfigurationTest.java
+++ b/rest-model/src/test/java/org/jboss/pnc/restmodel/serialization/BuildExecutionConfigurationTest.java
@@ -50,7 +50,8 @@ public class BuildExecutionConfigurationTest {
                 "2222222",
                 "abcd1234",
                 "image.repo.url/repo",
-                SystemImageType.DOCKER_IMAGE
+                SystemImageType.DOCKER_IMAGE,
+                false
         );
         BuildExecutionConfigurationRest buildExecutionConfigurationREST = new BuildExecutionConfigurationRest(buildExecutionConfiguration);
 

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
@@ -34,8 +34,8 @@ import org.jboss.pnc.rest.restmodel.BuildConfigurationRest;
 import org.jboss.pnc.rest.restmodel.ProductVersionRest;
 import org.jboss.pnc.rest.restmodel.response.Singleton;
 import org.jboss.pnc.rest.restmodel.response.error.ErrorResponseRest;
-import org.jboss.pnc.rest.swagger.response.BuildConfigurationAuditedSingleton;
 import org.jboss.pnc.rest.swagger.response.BuildConfigurationAuditedPage;
+import org.jboss.pnc.rest.swagger.response.BuildConfigurationAuditedSingleton;
 import org.jboss.pnc.rest.swagger.response.BuildConfigurationPage;
 import org.jboss.pnc.rest.swagger.response.BuildConfigurationSetPage;
 import org.jboss.pnc.rest.swagger.response.BuildConfigurationSingleton;
@@ -74,8 +74,8 @@ import java.net.URL;
 
 import static org.jboss.pnc.rest.configuration.SwaggerConstants.CONFLICTED_CODE;
 import static org.jboss.pnc.rest.configuration.SwaggerConstants.CONFLICTED_DESCRIPTION;
-import static org.jboss.pnc.rest.configuration.SwaggerConstants.INVALID_DESCRIPTION;
 import static org.jboss.pnc.rest.configuration.SwaggerConstants.INVALID_CODE;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.INVALID_DESCRIPTION;
 import static org.jboss.pnc.rest.configuration.SwaggerConstants.NOT_FOUND_CODE;
 import static org.jboss.pnc.rest.configuration.SwaggerConstants.NOT_FOUND_DESCRIPTION;
 import static org.jboss.pnc.rest.configuration.SwaggerConstants.NO_CONTENT_CODE;
@@ -233,6 +233,7 @@ public class BuildConfigurationEndpoint extends AbstractEndpoint<BuildConfigurat
     public Response trigger(@ApiParam(value = "Build Configuration id", required = true) @PathParam("id") Integer id,
             @ApiParam(value = "Optional Callback URL") @QueryParam("callbackUrl") String callbackUrl,
             @ApiParam(value = "Rebuild all dependencies") @QueryParam("rebuildAll") @DefaultValue("false") boolean rebuildAll,
+            @ApiParam(value = "Keep pod alive when the build fails") @QueryParam("keepPodAliveOnFailure") @DefaultValue("false") boolean keepPodAliveOnFailure,
             @Context UriInfo uriInfo,
             @Context HttpServletRequest request) throws InvalidEntityException, MalformedURLException, BuildConflictException {
 
@@ -256,10 +257,10 @@ public class BuildConfigurationEndpoint extends AbstractEndpoint<BuildConfigurat
         // if callbackUrl is provided trigger build accordingly
         if (callbackUrl == null || callbackUrl.isEmpty()) {
             logger.debug("Triggering build for buildConfigurationId {} without callback URL.", id);
-            runningBuildId = buildTriggerer.triggerBuild(id, currentUser, rebuildAll);
+            runningBuildId = buildTriggerer.triggerBuild(id, currentUser, keepPodAliveOnFailure, rebuildAll);
         } else {
             logger.debug("Triggering build for buildConfigurationId {} with callback URL {}.", id, callbackUrl);
-            runningBuildId = buildTriggerer.triggerBuild(id, currentUser, rebuildAll, new URL(callbackUrl));
+            runningBuildId = buildTriggerer.triggerBuild(id, currentUser, keepPodAliveOnFailure, rebuildAll, new URL(callbackUrl));
         }
 
         UriBuilder uriBuilder = UriBuilder.fromUri(uriInfo.getBaseUri()).path("/build-config-set-records/{id}");

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationSetEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationSetEndpoint.java
@@ -311,12 +311,13 @@ public class BuildConfigurationSetEndpoint extends AbstractEndpoint<BuildConfigu
                     .email(authProvider.getEmail()).build();
             datastore.createNewUser(currentUser);
         }
+
         BuildTriggerer.BuildConfigurationSetTriggerResult result;
         // if callbackUrl is provided trigger build accordingly
         if (callbackUrl == null || callbackUrl.isEmpty()) {
-            result = buildTriggerer.triggerBuildConfigurationSet(id, currentUser, rebuildAll);
+            result = buildTriggerer.triggerBuildConfigurationSet(id, currentUser, false, rebuildAll);
         } else {
-            result = buildTriggerer.triggerBuildConfigurationSet(id, currentUser, rebuildAll, new URL(callbackUrl));
+            result = buildTriggerer.triggerBuildConfigurationSet(id, currentUser, false, rebuildAll, new URL(callbackUrl));
         }
 
         UriBuilder uriBuilder = UriBuilder.fromUri(uriInfo.getBaseUri()).path("/build-config-set-records/{id}");

--- a/rest/src/test/java/org/jboss/pnc/rest/endpoint/BuildRecordEndpointTest.java
+++ b/rest/src/test/java/org/jboss/pnc/rest/endpoint/BuildRecordEndpointTest.java
@@ -94,7 +94,8 @@ public class BuildRecordEndpointTest {
                 "",
                 "",
                 "",
-                SystemImageType.DOCKER_IMAGE);
+                SystemImageType.DOCKER_IMAGE,
+                false);
 
         BuildExecutionSession buildExecutionSession = new DefaultBuildExecutionSession(buildExecutionConfiguration, null);
         when(buildExecutor.getRunningExecution(buildExecutionTaskId)).thenReturn(buildExecutionSession);

--- a/rest/src/test/java/org/jboss/pnc/rest/serialization/BuildExecutionConfigurationTest.java
+++ b/rest/src/test/java/org/jboss/pnc/rest/serialization/BuildExecutionConfigurationTest.java
@@ -20,8 +20,8 @@ package org.jboss.pnc.rest.serialization;
 
 import org.jboss.pnc.executor.DefaultBuildExecutionConfiguration;
 import org.jboss.pnc.model.SystemImageType;
-import org.jboss.pnc.rest.restmodel.BuildExecutionConfigurationRest;
 import org.jboss.pnc.rest.notifications.websockets.JSonOutputConverter;
+import org.jboss.pnc.rest.restmodel.BuildExecutionConfigurationRest;
 import org.jboss.pnc.spi.builddriver.exception.BuildDriverException;
 import org.jboss.pnc.spi.executor.BuildExecutionConfiguration;
 import org.junit.Assert;
@@ -52,7 +52,8 @@ public class BuildExecutionConfigurationTest {
                 "1111111",
                 "abcd1234",
                 "image.repo.url/repo",
-                SystemImageType.DOCKER_IMAGE
+                SystemImageType.DOCKER_IMAGE,
+                false
         );
         BuildExecutionConfigurationRest buildExecutionConfigurationREST = new BuildExecutionConfigurationRest(buildExecutionConfiguration);
 

--- a/spi/src/main/java/org/jboss/pnc/spi/coordinator/BuildCoordinator.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/coordinator/BuildCoordinator.java
@@ -29,9 +29,9 @@ import java.util.List;
 
 public interface BuildCoordinator {
 
-    BuildTask build(BuildConfiguration buildConfiguration, User user, boolean forceRebuild) throws BuildConflictException;
+    BuildTask build(BuildConfiguration buildConfiguration, User user, boolean keepPodAliveAfterFailure, boolean forceRebuild) throws BuildConflictException;
 
-    BuildSetTask build(BuildConfigurationSet buildConfigurationSet, User user, boolean forceRebuildAll) throws CoreException;
+    BuildSetTask build(BuildConfigurationSet buildConfigurationSet, User user, boolean keepPodAliveAfterFailure, boolean forceRebuild) throws CoreException;
 
     List<BuildTask> getSubmittedBuildTasks();
 

--- a/spi/src/main/java/org/jboss/pnc/spi/coordinator/BuildSetTask.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/coordinator/BuildSetTask.java
@@ -42,6 +42,7 @@ public class BuildSetTask {
     private final BuildConfigSetRecord buildConfigSetRecord;
 
     private final boolean forceRebuildAll;
+    private final boolean keepAfterFailure;
 
     private BuildSetStatus status;
 
@@ -54,12 +55,15 @@ public class BuildSetTask {
      * 
      * @param buildConfigSetRecord The config set record which will be stored to the db
      * @param forceRebuildAll Rebuild all configs in the set regardless of whether they were built previously
+     * @param keepAfterFailure Don't stop the pod after build failure
      */
     public BuildSetTask(
             BuildConfigSetRecord buildConfigSetRecord, //TODO decouple datastore entity
-            boolean forceRebuildAll) {
+            boolean forceRebuildAll,
+            boolean keepAfterFailure) {
         this.buildConfigSetRecord = buildConfigSetRecord;
         this.forceRebuildAll = forceRebuildAll;
+        this.keepAfterFailure = keepAfterFailure;
     }
 
     public BuildConfigurationSet getBuildConfigurationSet() {
@@ -152,6 +156,10 @@ public class BuildSetTask {
 
     public boolean getForceRebuildAll() {
         return forceRebuildAll;
+    }
+
+    public boolean isKeepAfterFailure() {
+        return keepAfterFailure;
     }
 
     @Override

--- a/spi/src/main/java/org/jboss/pnc/spi/coordinator/BuildTask.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/coordinator/BuildTask.java
@@ -22,11 +22,9 @@ import org.jboss.pnc.model.BuildConfigurationAudited;
 import org.jboss.pnc.model.ProductMilestone;
 import org.jboss.pnc.model.User;
 import org.jboss.pnc.spi.BuildCoordinationStatus;
-import org.jboss.pnc.spi.events.BuildCoordinationStatusChangedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.enterprise.event.Event;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -41,6 +39,9 @@ public class BuildTask {
     private final Integer id;
     private final BuildConfiguration buildConfiguration;
     private final BuildConfigurationAudited buildConfigurationAudited;
+
+    private final boolean podKeptAfterFailure;
+
     private final User user;
     private final Date submitTime;
     private Date startTime;
@@ -72,11 +73,11 @@ public class BuildTask {
 
     private BuildTask(BuildConfiguration buildConfiguration,
                       BuildConfigurationAudited buildConfigurationAudited,
+                      boolean podKeptAfterFailure,
                       User user,
                       Date submitTime,
                       BuildSetTask buildSetTask,
                       int id,
-                      Event<BuildCoordinationStatusChangedEvent> buildStatusChangedEventNotifier,
                       Integer buildConfigSetRecordId,
                       ProductMilestone productMilestone,
                       boolean forceRebuild) {
@@ -84,6 +85,7 @@ public class BuildTask {
         this.id = id;
         this.buildConfiguration = buildConfiguration;
         this.buildConfigurationAudited = buildConfigurationAudited;
+        this.podKeptAfterFailure = podKeptAfterFailure;
         this.user = user;
         this.submitTime = submitTime;
 
@@ -234,8 +236,8 @@ public class BuildTask {
 
     public static BuildTask build(BuildConfiguration buildConfiguration,
             BuildConfigurationAudited buildConfigAudited,
+            boolean podKeptAfterFailure,
             User user,
-            Event<BuildCoordinationStatusChangedEvent> buildStatusChangedEventNotifier,
             int buildTaskId,
             BuildSetTask buildSetTask,
             Date submitTime,
@@ -250,11 +252,11 @@ public class BuildTask {
         return new BuildTask(
                 buildConfiguration,
                 buildConfigAudited,
+                podKeptAfterFailure,
                 user,
                 submitTime,
                 buildSetTask,
                 buildTaskId,
-                buildStatusChangedEventNotifier,
                 buildConfigSetRecordId,
                 productMilestone,
                 forceRebuild);
@@ -267,5 +269,9 @@ public class BuildTask {
 
     public boolean getForceRebuild() {
         return forceRebuild;
+    }
+
+    public boolean isPodKeptAfterFailure() {
+        return podKeptAfterFailure;
     }
 }

--- a/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionConfiguration.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionConfiguration.java
@@ -50,6 +50,8 @@ public interface BuildExecutionConfiguration extends BuildExecution {
 
     SystemImageType getSystemImageType();
 
+    boolean isPodKeptOnFailure();
+
     static BuildExecutionConfiguration build(
             int id,
             String buildContentId,
@@ -62,7 +64,8 @@ public interface BuildExecutionConfiguration extends BuildExecution {
             String scmMirrorRevision,
             String systemImageId,
             String systemImageRepositoryUrl,
-            SystemImageType systemImageType) {
+            SystemImageType systemImageType,
+            boolean podKeptAfterFailure) {
 
         return new BuildExecutionConfiguration() {
 
@@ -126,6 +129,11 @@ public interface BuildExecutionConfiguration extends BuildExecution {
             @Override
             public SystemImageType getSystemImageType() {
                 return systemImageType;
+            }
+
+            @Override
+            public boolean isPodKeptOnFailure() {
+                return podKeptAfterFailure;
             }
         };
     }

--- a/ui/app/common/restclient/services/BuildConfigurationDAO.js
+++ b/ui/app/common/restclient/services/BuildConfigurationDAO.js
@@ -56,6 +56,15 @@
           method: 'POST',
           url: ENDPOINT + '/clone'
         },
+        buildAndKeepAliveOnError: {
+          method: 'POST',
+          url: ENDPOINT + '/build',
+          successNotification: false,
+          params: {
+            rebuildAll: true,
+            keepPodAliveOnFailure: true
+          }
+        },
         forceBuild: {
           method: 'POST',
           url: ENDPOINT + '/build',

--- a/ui/app/configuration/configuration-controllers.js
+++ b/ui/app/configuration/configuration-controllers.js
@@ -86,6 +86,13 @@
         }, {});
       };
 
+      that.buildAndKeepAliveOnError = function() {
+        $log.debug('Initiating FORCED build of :%0 with keeping pod alive on failure enabled', that.configuration);
+        BuildConfigurationDAO.buildAndKeepAliveOnError({
+          configurationId: that.configuration.id
+        }, {});
+      };
+
       // Executing a build of a configuration
       that.build = function() {
         $log.debug('Initiating build of: %O', that.configuration);

--- a/ui/app/configuration/views/configuration.detail-main.html
+++ b/ui/app/configuration/views/configuration.detail-main.html
@@ -33,6 +33,7 @@
           <ul class="dropdown-menu">
             <li>
               <a href ng-click="detailCtrl.forceBuild()" uib-tooltip="Start a build of this configuration, forcing a rebuild if a successful build already exists" tooltip-popup-delay="2500" tooltip-append-to-body="true"><span><i class="fa fa-play fa-color-red"></i> Force Rebuild</span></a>
+              <a href ng-click="detailCtrl.buildAndKeepAliveOnError()" uib-tooltip="Start a build of this configuration, and keep its pod alive in the case of failure"><span><i class="fa fa-play fa-color-red"></i>Build and keep alive on failure</span></a>
             </li>
           </ul>
       </div>


### PR DESCRIPTION
1. added a UI option: "Build and keep alive after failure" (in the same menu where "Build forcing all rebuilds" is). If the option is selected, it also forces rebuilds
1. added a query param for `/build-configurations/{id}/build`: `keepPodAliveOnFailure`. The parameter is independent of `rebuildAll` - the two params are passed together if user selects "Build and keep alive after failure"
1. Environment destroying is skipped when `keepPodAliveOnFailure` is enabled