### PR TITLE
[NCL-2164] Always mark the build as finished if the status is changed…

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
@@ -196,6 +196,9 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
         log.debug("Updating build task {} status to {}", task.getId(), buildStatusChanged);
         task.setStatus(status);
         task.setStatusDescription(statusDescription);
+        if (status.isCompleted()) {
+            markFinished(task);
+        }
         buildStatusChangedEventNotifier.fire(buildStatusChanged);
         log.debug("Fired buildStatusChangedEventNotifier after task {} status update to {}.", task.getId(), status);
     }
@@ -247,7 +250,6 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
                 if(!task.getRebuildAll() && prepareBuildTaskFilterPredicate().test(task)) {
                     log.info("[{}] Marking task as REJECTED_ALREADY_BUILT, because it has been already built", task.getId());
                     updateBuildTaskStatus(task, BuildCoordinationStatus.REJECTED_ALREADY_BUILT, "The configuration has already been built.");
-                    markFinished(task);
                     return;
                 }
                 task.setStartTime(new Date());


### PR DESCRIPTION
… to a completed status

This fixes an issue where a failure in the scheduler could cause a build to not be removed from the build queue