### PR TITLE
[NCL-2168] Make build agent route configurable

### DIFF
--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftEnvironmentDriverModuleConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftEnvironmentDriverModuleConfig.java
@@ -34,6 +34,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
     public static String MODULE_NAME = "openshift-environment-driver";
 
     private String restEndpointUrl;
+    private String buildAgentHost;
     private String buildAgentBindPath;
 
     private String podNamespace;
@@ -43,6 +44,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
     private boolean exposeBuildAgentOnPublicUrl;
 
     public OpenshiftEnvironmentDriverModuleConfig(@JsonProperty("restEndpointUrl") String restEndpointUrl,
+                                                  @JsonProperty("buildAgentHost") String buildAgentHost,
                                                   @JsonProperty("imageId") String imageId,
                                                   @JsonProperty("firewallAllowedDestinations") String firewallAllowedDestinations,
                                                   @JsonProperty("proxyServer") String proxyServer,
@@ -59,6 +61,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
         super(imageId, firewallAllowedDestinations, proxyServer, proxyPort, nonProxyHosts,workingDirectory, disabled);
 
         this.restEndpointUrl = restEndpointUrl;
+        this.buildAgentHost = buildAgentHost;
         this.buildAgentBindPath = buildAgentBindPath;
         this.podNamespace = podNamespace;
         this.restAuthToken = restAuthToken;
@@ -71,6 +74,10 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
 
     public String getRestEndpointUrl() {
         return restEndpointUrl;
+    }
+
+    public String getBuildAgentHost() {
+        return buildAgentHost;
     }
 
     public String getPncNamespace() {
@@ -107,6 +114,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
                 ", proxyPort='" + proxyPort + '\'' +
                 ", nonProxyHosts='" + nonProxyHosts + '\'' +
                 ", podNamespace='" + podNamespace + '\'' +
+                ", buildAgentHost='" + buildAgentHost + '\'' +
                 ", buildAgentBindPath='" + buildAgentBindPath + '\'' +
                 ", restAuthToken= HIDDEN " +
                 ", containerPort='" + containerPort + '\'' +

--- a/moduleconfig/src/main/resources/pnc-config.json
+++ b/moduleconfig/src/main/resources/pnc-config.json
@@ -40,6 +40,7 @@
                     "firewallAllowedDestinations": "${env.PNC_FIREWALL_ALLOWED_DESTINATIONS}",
                     "restEndpointUrl": "${env.PNC_REST_ENDPOINT_URL}",
                     "restAuthToken": "${env.PNC_REST_AUTH_TOKEN}",
+                    "buildAgentHost": "${env.PNC_BUILD_AGENT_HOST}",
                     "buildAgentBindPath": "${env.PNC_BUILD_AGENT_BIND_PATH}",
                     "podNamespace": "${env.PNC_POD_NAMESPACE}",
                     "containerPort": "${env.PNC_CONTAINER_PORT}",

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -98,9 +98,12 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         String randString = RandomUtils.randString(6);//note the 24 char limit
         buildAgentContextPath = "pnc-ba-" + randString;
 
+        final String buildAgentHost = environmentConfiguration.getBuildAgentHost();
+
+        runtimeProperties.put("build-agent-host", buildAgentHost);
         runtimeProperties.put("pod-name", "pnc-ba-pod-" + randString);
         runtimeProperties.put("service-name", "pnc-ba-service-" + randString);
-        runtimeProperties.put("route-name", "pnc-ba-route-" + randString);
+        runtimeProperties.put("route-name", "pnc-ba-route-" + buildAgentHost + "-" + randString);
         runtimeProperties.put("route-path", "/" + buildAgentContextPath);
         runtimeProperties.put("buildAgentContextPath", "/" + buildAgentContextPath);
         runtimeProperties.put("containerPort", environmentConfiguration.getContainerPort());

--- a/openshift-environment-driver/src/main/resources/openshift.configurations/v1_pnc-builder-route.json
+++ b/openshift-environment-driver/src/main/resources/openshift.configurations/v1_pnc-builder-route.json
@@ -5,7 +5,7 @@
         "name": "${route-name}"
     },
     "spec": {
-        "host" : "ncl-test-os-01.host.prod.eng.bos.redhat.com",
+        "host" : "${build-agent-host}",
         "path" : "${route-path}",
         "to" : {
             "kind" : "Service",


### PR DESCRIPTION
Changes made:

- Add 'buildAgentHost' variable into openshift driver configuration
- Use that new variable to setup routes
- Use that new variable to setup the service name