### PR TITLE
[NCL-2168] Don't specify host in route-name

### DIFF
--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -103,7 +103,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         runtimeProperties.put("build-agent-host", buildAgentHost);
         runtimeProperties.put("pod-name", "pnc-ba-pod-" + randString);
         runtimeProperties.put("service-name", "pnc-ba-service-" + randString);
-        runtimeProperties.put("route-name", "pnc-ba-route-" + buildAgentHost + "-" + randString);
+        runtimeProperties.put("route-name", "pnc-ba-route-" + randString);
         runtimeProperties.put("route-path", "/" + buildAgentContextPath);
         runtimeProperties.put("buildAgentContextPath", "/" + buildAgentContextPath);
         runtimeProperties.put("containerPort", environmentConfiguration.getContainerPort());


### PR DESCRIPTION
We shouldn't do that since Openshift will complain that the new route
name does not conform to the DNS convention. We are going to revert that
change