### PR TITLE
[NCL-2198] Remove the text type definition from the buildscript column

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/BuildConfigurationAudited.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildConfigurationAudited.java
@@ -55,6 +55,7 @@ public class BuildConfigurationAudited implements GenericEntity<IdRev> {
     private String name;
 
     @Lob
+    @Type(type = "org.hibernate.type.TextType")
     private String buildScript;
 
     private String scmRepoURL;


### PR DESCRIPTION
This seems to be causing postgresql to create a "long" type column for some reason