### PR TITLE
[NCL-2204] Change DNS policy of build agent pod

### DIFF
--- a/openshift-environment-driver/src/main/resources/openshift.configurations/v1_pnc-builder-pod.json
+++ b/openshift-environment-driver/src/main/resources/openshift.configurations/v1_pnc-builder-pod.json
@@ -89,7 +89,7 @@
         ],
         "restartPolicy": "Never",
         "activeDeadlineSeconds": 10800,
-        "dnsPolicy": "Default"
+        "dnsPolicy": "ClusterFirst"
     }
 }
 


### PR DESCRIPTION
The current DNS policy for the build agent pod created by PNC on
Openshift is Default.

This causes us issues since the 'Default' policy doesn't add the
internal DNS nameserver of Openshift inside the build agent pod. We
would really like to have the internal DNS nameserver to solve NCL-2201.

Using the dns policy of 'ClusterFirst' should add to `/etc/resolv.conf`
the internal DNS nameserver of Openshift