### PR TITLE
Ncl 2202

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/Artifact.java
+++ b/model/src/main/java/org/jboss/pnc/model/Artifact.java
@@ -476,13 +476,23 @@ public class Artifact implements GenericEntity<Integer> {
             return this;
         }
 
-        public Builder dependantBuildRecords(Set<BuildRecord> dependantBuildRecords) {
-            this.dependantBuildRecords = dependantBuildRecords;
+        public Builder buildRecord(BuildRecord buildRecord) {
+            this.buildRecords.add(buildRecord);
             return this;
         }
 
-        public Builder buildRecord(Set<BuildRecord> buildRecords) {
+        public Builder buildRecords(Set<BuildRecord> buildRecords) {
             this.buildRecords = buildRecords;
+            return this;
+        }
+
+        public Builder dependantBuildRecord(BuildRecord dependantBuildRecord) {
+            this.dependantBuildRecords.add(dependantBuildRecord);
+            return this;
+        }
+
+        public Builder dependantBuildRecords(Set<BuildRecord> dependantBuildRecords) {
+            this.dependantBuildRecords = dependantBuildRecords;
             return this;
         }
 

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/model/builders/ArtifactBuilder.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/model/builders/ArtifactBuilder.java
@@ -28,29 +28,34 @@ import java.util.Date;
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
  */
 public class ArtifactBuilder {
+
     public static final String IDENTIFIER_PREFIX = "org.jboss.pnc:mock.artifact";
 
-    public static Artifact mockImportedArtifact(int id) {
+    private static Artifact.Builder getArtifactBuilder(int id) {
         return Artifact.Builder.newBuilder()
                 .id(id)
                 .identifier(IDENTIFIER_PREFIX + ":" + id)
-                .checksum("ABCD1234")
-                .originUrl("http://central.maven.org/" + id + ".jar")
-                .importDate(Date.from(Instant.now()))
-                .deployUrl("deploy url " + id)
+                .checksum("ABCDABCD" + id)
+                .deployUrl("http://myrepo.com/org/jboss/mock/artifactFile" + id + ".jar")
                 .repoType(ArtifactRepo.Type.MAVEN)
-                .filename("File " + id + ".jar")
+                .filename("artifactFile" + id + ".jar");
+    }
+
+    /**
+     * Create a generic mock artifact with no associated build record or import URL
+     */
+    public static Artifact mockArtifact(int id) {
+        return getArtifactBuilder(id).build();
+    }
+
+    /**
+     * Create an artifact with an import date and origin url
+     */
+    public static Artifact mockImportedArtifact(int id) {
+        return getArtifactBuilder(id)
+                .importDate(Date.from(Instant.now()))
+                .originUrl("http://central.maven.org/org/jboss/mock/artifactFile" + id + ".jar")
                 .build();
     }
 
-    public static Artifact mockBuiltArtifact(int id) {
-        return Artifact.Builder.newBuilder()
-                .id(id)
-                .identifier(IDENTIFIER_PREFIX + ":" + id)
-                .checksum("ABCDABCD")
-                .deployUrl("deploy url " + id)
-                .repoType(ArtifactRepo.Type.MAVEN)
-                .filename("File " + id + ".jar")
-                .build();
-    }
 }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/repositorymanager/RepositoryManagerResultMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/repositorymanager/RepositoryManagerResultMock.java
@@ -33,14 +33,14 @@ public class RepositoryManagerResultMock {
         return new RepositoryManagerResult() {
             @Override
             public List<Artifact> getBuiltArtifacts() {
-                Artifact[] artifacts = {ArtifactBuilder.mockBuiltArtifact(11), ArtifactBuilder.mockBuiltArtifact(12)};
+                Artifact[] artifacts = {ArtifactBuilder.mockArtifact(11), ArtifactBuilder.mockArtifact(12)};
                 return Arrays.asList(artifacts);
             }
 
             @Override
             public List<Artifact> getDependencies() {
                 Artifact[] artifacts = { ArtifactBuilder.mockImportedArtifact(21), ArtifactBuilder.mockImportedArtifact(22),
-                        ArtifactBuilder.mockBuiltArtifact(13) };
+                        ArtifactBuilder.mockArtifact(13) };
                 return Arrays.asList(artifacts);
             }
 

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/ArtifactRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/ArtifactRest.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.rest.restmodel;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.annotations.ApiModelProperty;
 import org.jboss.pnc.model.Artifact;
 import org.jboss.pnc.model.BuildRecord;
@@ -27,6 +28,7 @@ import org.jboss.pnc.rest.validation.groups.WhenUpdating;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
 import java.util.Date;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -158,6 +160,7 @@ public class ArtifactRest implements GenericRestEntity<Integer> {
     }
 
     @Deprecated
+    @JsonIgnore
     public String getStatus() {
         if (buildRecordIds != null && buildRecordIds.size() > 0) {
             return "BINARY_BUILT";
@@ -179,6 +182,28 @@ public class ArtifactRest implements GenericRestEntity<Integer> {
 
     public void setDependantBuildRecordIds(Set<Integer> dependantBuildRecordIds) {
         this.dependantBuildRecordIds = dependantBuildRecordIds;
+    }
+
+    public Artifact.Builder toDBEntityBuilder() {
+        Artifact.Builder builder = Artifact.Builder.newBuilder()
+                .id(this.getId())
+                .identifier(this.getIdentifier())
+                .checksum(this.getChecksum())
+                .repoType(this.getRepoType())
+                .artifactQuality(this.getArtifactQuality())
+                .deployUrl(this.getDeployUrl())
+                .importDate(this.getImportDate())
+                .originUrl(this.getOriginUrl())
+                .filename(this.getFilename());
+
+        nullableStreamOf(this.getBuildRecordIds()).forEach(buildRecordId -> {
+            builder.buildRecord(BuildRecord.Builder.newBuilder().id(buildRecordId).build());
+        });
+        nullableStreamOf(this.getDependantBuildRecordIds()).forEach(depBuildRecordId -> {
+            builder.dependantBuildRecord(BuildRecord.Builder.newBuilder().id(depBuildRecordId).build());
+        });
+
+        return builder;
     }
 
     @Override

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/ArtifactRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/ArtifactRest.java
@@ -159,6 +159,11 @@ public class ArtifactRest implements GenericRestEntity<Integer> {
         this.originUrl = originUrl;
     }
 
+    @JsonIgnore
+    public boolean isImported() {
+        return (originUrl != null && !originUrl.isEmpty());
+    }
+
     @Deprecated
     @JsonIgnore
     public String getStatus() {
@@ -174,6 +179,11 @@ public class ArtifactRest implements GenericRestEntity<Integer> {
 
     public void setBuildRecordIds(Set<Integer> buildRecordIds) {
         this.buildRecordIds = buildRecordIds;
+    }
+
+    @JsonIgnore
+    public boolean isBuilt() {
+        return (buildRecordIds != null && buildRecordIds.size() > 0);
     }
 
     public Set<Integer> getDependantBuildRecordIds() {

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildResultRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildResultRest.java
@@ -82,7 +82,7 @@ public class BuildResultRest implements Serializable {
         return new BuildResult(
                 Optional.ofNullable(buildExecutionConfiguration),
                 Optional.ofNullable(buildDriverResult),
-                Optional.ofNullable(repositoryManagerResult),
+                Optional.ofNullable(repositoryManagerResult.toRepositoryManagerResult()),
                 Optional.ofNullable(exception),
                 Optional.ofNullable(failedReasonStatus));
     }

--- a/rest-model/src/test/java/org/jboss/pnc/restmodel/serialization/RepositoryManagerResultSerializationTest.java
+++ b/rest-model/src/test/java/org/jboss/pnc/restmodel/serialization/RepositoryManagerResultSerializationTest.java
@@ -1,0 +1,64 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.restmodel.serialization;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jboss.pnc.mock.repositorymanager.RepositoryManagerResultMock;
+import org.jboss.pnc.rest.restmodel.RepositoryManagerResultRest;
+import org.jboss.pnc.rest.utils.JsonOutputConverterMapper;
+import org.jboss.pnc.spi.builddriver.exception.BuildDriverException;
+import org.jboss.pnc.spi.repositorymanager.RepositoryManagerResult;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Test serialization of Repository manager rest
+ */
+public class RepositoryManagerResultSerializationTest {
+
+    private final Logger log = LoggerFactory.getLogger(RepositoryManagerResultSerializationTest.class);
+
+    @Test
+    public void serializeAndDeserializeRepositoryManagerResult() throws IOException, BuildDriverException {
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        RepositoryManagerResult repoMngrResult = RepositoryManagerResultMock.mockResult();
+        RepositoryManagerResultRest repoMngrResultRest = new RepositoryManagerResultRest(repoMngrResult);
+
+        String repoMngrResultJson = JsonOutputConverterMapper.apply(repoMngrResultRest);
+        log.debug("RepoManagerResultJson : {}", repoMngrResultJson);
+
+        RepositoryManagerResultRest deserializedRepoManResultRest = mapper.readValue(repoMngrResultJson, RepositoryManagerResultRest.class);
+        RepositoryManagerResult deserializedRepoMngrResult = deserializedRepoManResultRest.toRepositoryManagerResult();
+        String message = "Deserialized object does not match the original.";
+
+        Assert.assertEquals(message, repoMngrResult.getBuildContentId(), deserializedRepoMngrResult.getBuildContentId());
+        Assert.assertEquals(message, repoMngrResult.getBuiltArtifacts().get(0), deserializedRepoMngrResult.getBuiltArtifacts().get(0));
+        Assert.assertEquals(message, repoMngrResult.getBuiltArtifacts().get(0).getChecksum(), deserializedRepoMngrResult.getBuiltArtifacts().get(0).getChecksum());
+        Assert.assertEquals(message, repoMngrResult.getBuiltArtifacts().get(0).isBuilt(), deserializedRepoMngrResult.getBuiltArtifacts().get(0).isBuilt());
+        Assert.assertEquals(message, repoMngrResult.getDependencies().get(0), deserializedRepoMngrResult.getDependencies().get(0));
+        Assert.assertEquals(message, repoMngrResult.getDependencies().get(0).getDeployUrl(), deserializedRepoMngrResult.getDependencies().get(0).getDeployUrl());
+        Assert.assertEquals(message, repoMngrResult.getDependencies().get(0).isImported(), deserializedRepoMngrResult.getDependencies().get(0).isImported());
+    }
+}


### PR DESCRIPTION
Use ArtifactRest objects in RepositoryManagerResultRest instead of using model Artifact directly.  This prevents issues with serializing to json.