### PR TITLE
[NCL-2166] Externalize build agent templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,3 +253,19 @@ You can test the connection before saving the datasource settings.
 UI Module Compilation Errors
 ----------------------------
 Due to the need to integrate a modern frontend workflow into a maven project there can occasionally be some complications in a build. Some data is cached by the UI that is not completely cleaned by running `maven clean`. In case of strange build failures with the UI module please try running: `maven clean -Dfrontend.clean.force` and this will completely clean out all data. NOTE: with this profile enabled build times will increase by a few minutes as the ui build system will have to retrieve a large amount of previously cached data.
+
+
+Configuring the Openshift definition files
+------------------------------------------
+When the Openshift Driver is used, we send definition files to the Openshift server to tell it how we want our build agent to be setup. The default files used can be found in `openshift-environment-driver/src/main/resources/openshift.configurations`.
+
+You can override which definition files to use at runtime using Java System Property Names.
+
+To override:
+
+- pnc-builder-pod definition, pass the flag '-Dv1_pnc-builder-pod-file=<file>'
+- pnc-builder-service definition, pass the flag '-Dv1_pnc-builder-service-file=<file>'
+- pnc-builder-route definition, pass the flag '-Dv1_pnc-builder-route-file=<file>'
+- pnc-builder-ssh-service definition, pass the flag '-Dv1_pnc-builder-ssh-service-file=<file>'
+
+The flag could be set in your `standalone.conf` in your EAP deployment.

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/Configurations.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/Configurations.java
@@ -28,30 +28,49 @@ import java.lang.invoke.MethodHandles;
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
  */
-public enum Configurations {
+public class Configurations {
 
-    V1_PNC_BUILDER_POD("v1_pnc-builder-pod.json"),
-    V1_PNC_BUILDER_SERVICE("v1_pnc-builder-service.json"),
-    V1_PNC_BUILDER_ROUTE("v1_pnc-builder-route.json"),
-    V1_PNC_BUILDER_SSH_SERVICE("v1_pnc-builder-ssh-service.json");
+    private static final String DEFAULT_V1_PNC_BUILDER_POD = "v1_pnc-builder-pod.json";
+    private static final String DEFAULT_V1_PNC_BUILDER_SERVICE_FILE = "v1_pnc-builder-service.json";
+    private static final String DEFAULT_V1_PNC_BUILDER_ROUTE_FILE = "v1_pnc-builder-route.json";
+    private static final String DEFAULT_V1_PNC_BUILDER_SSH_SERVICE_FILE = "v1_pnc-builder-ssh-service.json";
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass().getName());
 
     private static final String CONFIGURATIONS_FOLDER = "openshift.configurations/";
 
-    private final String filePath;
+    private static final String CUSTOM_V1_PNC_BUILDER_POD_PROPERTY = "v1_pnc-builder-pod-file";
+    private static final String CUSTOM_V1_PNC_BUILDER_SERVICE_PROPERTY = "v1_pnc-builder-service-file";
+    private static final String CUSTOM_V1_PNC_BUILDER_ROUTE_PROPERTY = "v1_pnc-builder-route-file";
+    private static final String CUSTOM_V1_PNC_BUILDER_SSH_SERVICE_PROPERTY = "v1_pnc-builder-ssh-service-file";
 
-    Configurations(String fileName) {
-        this.filePath = CONFIGURATIONS_FOLDER + fileName;
+    public static String get_V1_PNC_BUILDER_POD_Content() {
+        return getContentAsString(CUSTOM_V1_PNC_BUILDER_POD_PROPERTY, DEFAULT_V1_PNC_BUILDER_POD);
     }
 
-    public String getContentAsString() {
+    public static String get_V1_PNC_BUILDER_SERVICE_Content() {
+        return getContentAsString(CUSTOM_V1_PNC_BUILDER_SERVICE_PROPERTY, DEFAULT_V1_PNC_BUILDER_SERVICE_FILE);
+    }
+
+    public static String get_V1_PNC_BUILDER_ROUTE_Content() {
+        return getContentAsString(CUSTOM_V1_PNC_BUILDER_ROUTE_PROPERTY, DEFAULT_V1_PNC_BUILDER_ROUTE_FILE);
+    }
+
+    public static String get_V1_PNC_BUILDER_SSH_SERVICE_Content() {
+        return getContentAsString(CUSTOM_V1_PNC_BUILDER_SSH_SERVICE_PROPERTY, DEFAULT_V1_PNC_BUILDER_SSH_SERVICE_FILE);
+    }
+
+    private static String getContentAsString(String customPropertyName, String defaultResourceFile) {
+        String filePath = CONFIGURATIONS_FOLDER + defaultResourceFile;
         String content;
         try {
-            content = IoUtils.readResource(filePath, Configurations.class.getClassLoader());
+            content = IoUtils.readFileOrResource(customPropertyName, filePath, Configurations.class.getClassLoader());
         } catch (IOException e) {
-            logger.error("Cannot read configuration file " + filePath, e);
-            throw new RuntimeException("Could not read configuration file " + filePath + ": " + e.getMessage());
+            String fileCannotRead = filePath;
+            if (System.getProperty(customPropertyName) != null) {
+                fileCannotRead = System.getProperty(customPropertyName);
+            }
+            throw new RuntimeException("Could not read configuration file " + fileCannotRead + ": " + e.getMessage());
         }
         return content;
     }

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -120,7 +120,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
 
         initDebug();
 
-        ModelNode podConfigurationNode = createModelNode(Configurations.V1_PNC_BUILDER_POD.getContentAsString(), runtimeProperties);
+        ModelNode podConfigurationNode = createModelNode(Configurations.get_V1_PNC_BUILDER_POD_Content(), runtimeProperties);
         pod = new Pod(podConfigurationNode, client, ResourcePropertiesRegistry.getInstance().get(OSE_API_VERSION, ResourceKind.POD));
         pod.setNamespace(environmentConfiguration.getPncNamespace());
         Runnable createPod = () -> {
@@ -133,7 +133,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         };
         executor.submit(createPod);
 
-        ModelNode serviceConfigurationNode = createModelNode(Configurations.V1_PNC_BUILDER_SERVICE.getContentAsString(), runtimeProperties);
+        ModelNode serviceConfigurationNode = createModelNode(Configurations.get_V1_PNC_BUILDER_SERVICE_Content(), runtimeProperties);
         service = new Service(serviceConfigurationNode, client, ResourcePropertiesRegistry.getInstance().get(OSE_API_VERSION, ResourceKind.SERVICE));
         service.setNamespace(environmentConfiguration.getPncNamespace());
         Runnable createService = () -> {
@@ -147,7 +147,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         executor.submit(createService);
 
         if (createRoute) {
-            ModelNode routeConfigurationNode = createModelNode(Configurations.V1_PNC_BUILDER_ROUTE.getContentAsString(), runtimeProperties);
+            ModelNode routeConfigurationNode = createModelNode(Configurations.get_V1_PNC_BUILDER_ROUTE_Content(), runtimeProperties);
             route = new Route(routeConfigurationNode, client, ResourcePropertiesRegistry.getInstance().get(OSE_API_VERSION, ResourceKind.ROUTE));
             route.setNamespace(environmentConfiguration.getPncNamespace());
             Runnable createRoute = () -> {
@@ -362,7 +362,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
      * @return port, to which ssh is forwarded
      */
     private Integer startSshService() {
-        ModelNode serviceConfigurationNode = createModelNode(Configurations.V1_PNC_BUILDER_SSH_SERVICE.getContentAsString(), runtimeProperties);
+        ModelNode serviceConfigurationNode = createModelNode(Configurations.get_V1_PNC_BUILDER_SSH_SERVICE_Content(), runtimeProperties);
         sshService = new Service(serviceConfigurationNode, client, ResourcePropertiesRegistry.getInstance().get(OSE_API_VERSION, ResourceKind.SERVICE));
         sshService.setNamespace(environmentConfiguration.getPncNamespace());
         try {


### PR DESCRIPTION
With this commit, you can now override which definition file to use for
the Openshift Driver at runtime.

To override:

- pnc-builder-pod definition, pass the flag '-Dv1_pnc-builder-pod-file=<file>'
- pnc-builder-service definition, pass the flag '-Dv1_pnc-builder-service-file=<file>'
- pnc-builder-route definition, pass the flag '-Dv1_pnc-builder-route-file=<file>'
- pnc-builder-ssh-service definition, pass the flag '-Dv1_pnc-builder-ssh-service-file=<file>'

The flag could be set in your `standalone.conf` in your EAP deployment.