### PR TITLE
NCL-2215 New paging API

### DIFF
--- a/ui/app/_pnc.js
+++ b/ui/app/_pnc.js
@@ -39,7 +39,8 @@
     'pnc.import',
     'pnc.report',
     'pnc.properties',
-    'pnc.common.authentication'
+    'pnc.common.authentication',
+    'pnc.common.pnc-client'
   ]);
 
   app.config([
@@ -108,7 +109,8 @@
       daConfigProvider.setDaUrl(pncProperties.daUrl);
       daConfigProvider.setDaImportUrl(pncProperties.daImportUrl);
       daConfigProvider.setDaImportRpcUrl(pncProperties.daImportRpcUrl);
-  }]);
+    }
+  ]);
 
   app.run([
     '$rootScope',

--- a/ui/app/common/pnc-client/_pnc-client.js
+++ b/ui/app/common/pnc-client/_pnc-client.js
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+  'use strict';
+
+  angular.module('pnc.common.pnc-client', [
+    'pnc.common.pnc-client.pagination',
+    'pnc.common.pnc-client.resources',
+    'pnc.common.pnc-client.rsql'
+  ]);
+
+})();

--- a/ui/app/common/pnc-client/pagination/Page.js
+++ b/ui/app/common/pnc-client/pagination/Page.js
@@ -1,0 +1,248 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+  'use strict';
+
+  var module = angular.module('pnc.common.pnc-client.pagination');
+
+ /**
+  * @ngdoc service
+  * @type function
+  * @name pnc.common.pnc-client.pagination:page
+  * @description
+  * A factory function for producing page objects. A page object provides methods
+  * for consuming a paginated RESTful api.
+  *
+  * @param {Object} spec - A specification object to create the page from.
+  * @param {Array} spec.data - The contents of the page.
+  * @param {Number} spec.index - The page index.
+  * @param {Number} spec.size - The page size.
+  * @param {Number} spec.total - The total number of pages.
+  * @param {Object} spec.config - The $http config object used to retrieve this
+  * resource. see: https://docs.angularjs.org/api/ng/service/$http#usage
+  * @param {Object} spec.Resource [optional] - A resource "class" object created
+  * using the $resource factory in ngResource. If one is provided then all
+  * elements of a fetched paged will be passed to this constructor before
+  * being added to the page.
+  * see: https://docs.angularjs.org/api/ngResource/service/$resource
+  * @returns {Object} - A page object
+  * @author Alex Creasy
+  */
+  module.factory('page', [
+    '$log',
+    '$http',
+    function ($log, $http) {
+
+      var proto = {};
+
+      /**
+       * Factory function to create page objects.
+       *
+       */
+       function page(spec) {
+         spec = spec || {};
+
+         var that = Object.create(proto, {
+           _config: {
+             get: function() {
+               return angular.copy(spec.config);
+             },
+             set: function(config) {
+               spec.config = angular.copy(config);
+             }
+           }
+         });
+
+         that.data = spec.data || [];
+         that.index = spec.index || 0;
+         that.size = spec.size || 0;
+         that.total = spec.total || 1;
+         that._Resource = spec.Resource;
+         that.$promise = spec.promise;
+
+         return that;
+       }
+
+     /**
+      * Iterates over all items in the page, applying the
+      * callback function to each item
+      */
+      proto.forEach = function (callback) {
+        this.data.forEach(function () {
+          callback.apply(this.data, arguments);
+        }, this);
+      };
+
+     /**
+      * Fetches a page from the same resource using the given paramaters. This
+      * may be useful for filtering pages or otherwise supplying additional
+      * querystring paramaters to this resource.
+      *
+      * @param {Object} params - Map of strings or objects which will be
+      * serialized and appended to the http request as GET parameters.
+      * @return {Promise} A promise that will be resolved with a page object
+      * representing the requested resource.
+      */
+      proto.fetch = function (params) {
+        var Resource = this._Resource;
+        var config = this._config;
+        config.params = params;
+
+        var promise = $http(config).then(function(response) {
+          var p = page({
+            index: response.data.pageIndex,
+            size: response.data.pageSize,
+            total: response.data.totalPages,
+            data: response.data.content,
+            Resource: Resource,
+            config: response.config,
+            promise: promise
+          });
+
+          // If the resource class is present convert all the data
+          // objects into resources.
+          if (Resource) {
+            for (var i = 0; i < p.data.length; i++) {
+              p.data[i] = new Resource(p.data[i]);
+            }
+          }
+
+          return p;
+        });
+
+        return promise;
+      };
+
+     /**
+      * Check if a given page index exists.
+      *
+      * @return {Boolean} Returns true if the specified page index exists.
+      * Otherwise returns false.
+      */
+      proto.has = function (index) {
+        return index >= 0 && index < this.total;
+      };
+
+     /**
+      * Fetches the page with the specified index.
+      *
+      * @param {Number} index - the page index to fetch.
+      * @return {Promise} A promise that will be resolved with a page object
+      * representing the requested resource.
+      */
+      proto.get = function (index) {
+        var params;
+        if (!this.has(index)) {
+          throw new RangeError('Requested page index out of bounds: ' + index);
+        }
+
+        params = this._config.params || {};
+        params.pageIndex = index;
+        return this.fetch(params);
+      };
+
+     /**
+      * Check if there is another page after the current one.
+      *
+      * @return {Boolean} Returns true if the nexy page index exists.
+      * Otherwise returns false.
+      */
+      proto.hasNext = function () {
+        return this.has(this.index + 1);
+      };
+
+     /**
+      * Check if there is another page before the current one.
+      *
+      * @return {Boolean} Returns true if the page index immediately prior to
+      * the current one exists. Otherwise returns false.
+      */
+      proto.hasPrevious = function () {
+        return this.has(this.index - 1);
+      };
+
+     /**
+      * Fetches the first page.
+      *
+      * @return {Promise} A promise that will be resolved with a page object
+      * representing the requested resource.
+      */
+      proto.first = function () {
+        return this.get(0);
+      };
+
+     /**
+      * Fetches the last page.
+      *
+      * @return {Promise} A promise that will be resolved with a page object
+      * representing the requested resource.
+      */
+      proto.last = function () {
+        return this.get(this.total - 1);
+      };
+
+     /**
+      * Fetches the next page.
+      *
+      * @return {Promise} A promise that will be resolved with a page object
+      * representing the requested resource.
+      */
+      proto.next = function () {
+        return this.get(this.index + 1);
+      };
+
+     /**
+      * Fetches the previous page.
+      *
+      * @return {Promise} - A promise that will be resolved with a page object
+      * representing the requested resource.
+      */
+      proto.previous = function () {
+        return this.get(this.index - 1);
+      };
+
+     /**
+      * Refreshes the current page
+      *
+      * @return {Promise} - A promise that will be resolved with a page object
+      * representing the requested resource.
+      */
+      proto.refresh = function () {
+        return this.get(this.index);
+      };
+
+     /**
+      * Fetches the first page with the given new page size.
+      *
+      * @param {Number} size - the new page size.
+      * @return {Promise} - A promise that will be resolved with a page object
+      * representing the requested resource.
+      */
+      proto.getWithNewSize = function (size) {
+        var params = this.config.params || {};
+        params.pageSize = size;
+        params.pageIndex = 0; // Reset index as it will be meaningless with new size.
+        return this.fetch(params);
+      };
+
+
+      return page;
+    }
+  ]);
+
+})();

--- a/ui/app/common/pnc-client/pagination/Paginator.js
+++ b/ui/app/common/pnc-client/pagination/Paginator.js
@@ -1,0 +1,120 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+  'use strict';
+
+  var module = angular.module('pnc.common.pnc-client.pagination');
+
+  /**
+   * @ngdoc service
+   * @name pnc.common.pnc-client.pagination:paginator
+   * @description
+   * Inherits the page interface, but stores an internal reference to the page
+   * which is updated when new pages are requested rather than returned to the
+   * user. This is useful when displaying paginated collections, the paginators
+   * data property can be bound to the view and will be updated whenever
+   * the page is changed.
+   *
+   * @author Alex Creasy
+   */
+  module.factory('paginator', [
+    '$log',
+    'page',
+    function ($log, $page) {
+
+      function paginator(page) {
+        var delegate = page; //
+
+        // The paginator inherits all of the page prototype methods,
+        // making the paginator a page in itself.
+        // The fetch method is overridden so that any actions
+        // replace the proxied page object, rather than retuning it
+        // to the user.
+        var that = Object.create(Object.getPrototypeOf($page()), {
+          // All of the paginators properties are proxied to
+          // the delegate page. However, as no setters are defined
+          // the properties cannot be altered.
+          data: {
+            get: function () {
+              return delegate.data;
+            },
+          },
+          index: {
+            get: function () {
+              return delegate.index;
+            }
+          },
+          size: {
+            get: function () {
+              return delegate.size;
+            }
+          },
+          total: {
+            get: function () {
+              return delegate.total;
+            }
+          },
+          _config: {
+            get: function () {
+              return delegate._config;
+            }
+          },
+          _Resource: {
+            get: function () {
+              return delegate._Resource;
+            }
+          }
+        });
+
+        that.isLoaded = false;
+
+        /**
+         * Overides prototype method.
+         *
+         * @returns {Promise} - A promise that is resolved with the calling
+         * paginator instance (which implements the page protoype interface).
+         */
+        that.fetch = function (params) {
+          that.isLoaded = false;
+
+          // Retrieve a new page and assign it to be the new proxied instance.
+          // Return a promise that's resolved with the paginator itself
+          // rather than the retrieved promise. As the paginator inherits from
+          // the page prototype this complies with the page interface contract
+          // without exposing the underlying page. In reality the resolved
+          // reference to the paginator is of little use, however the promise
+          // is still useful for executing asynchronous callbacks against the
+          // paginator.
+          return delegate.fetch(params).then(function(response) {
+            delegate = response;
+            that.isLoaded = true;
+          });
+        };
+
+        delegate.$promise.then(function () {
+          that.isLoaded = true;
+        });
+
+        return that;
+      }
+
+      return paginator;
+    }
+  ]);
+
+})();

--- a/ui/app/common/pnc-client/pagination/_pagination.js
+++ b/ui/app/common/pnc-client/pagination/_pagination.js
@@ -1,0 +1,111 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+  'use strict';
+
+  var module = angular.module('pnc.common.pnc-client.pagination', [
+    'ngResource'
+  ]);
+
+  module.config([
+    '$provide',
+    '$resourceProvider',
+    function ($provide, $resourceProvider) {
+
+      /**
+       * Decorate the $resource service to register pagination interceptors with
+       * correct resource actions. This also allows us to grab the resource
+       * constructor so we can pass it to the created page.
+       */
+      $provide.decorator('$resource', function ($delegate) {
+        return function (url, paramDefaults, actions, options) {
+          var Resource;
+
+          var pagedActions = [];
+
+          Object.keys($resourceProvider.defaults.actions).forEach(function (key) {
+            if (!actions.hasOwnProperty(key)) {
+              actions[key] = $resourceProvider.defaults.actions[key];
+            }
+          });
+
+          Object.keys(actions).forEach(function (key) {
+            var action = actions[key];
+            var delegateInterceptor;
+
+            if(action.isPaged) {
+              pagedActions.push(key);
+
+              // If the dev provided an interceptor save it so we can apply it after ours.
+              if (action.interceptor && angular.isFunction(action.interceptor.response)) {
+                delegateInterceptor = action.interceptor.response;
+              }
+
+              action.interceptor = action.interceptor || {};
+              action.interceptor.response = function (response) {
+                if (delegateInterceptor) {
+                  delegateInterceptor.apply(delegateInterceptor, arguments);
+                }
+                return response;
+              };
+            }
+          });
+
+          Resource = $delegate(url, paramDefaults, actions, options);
+
+          // Decorate the paged action methods
+          pagedActions.forEach(function(action) {
+            var delegate = Resource[action];
+
+            Resource[action] = function () {
+              var response = delegate.apply(delegate, arguments);
+
+              var page = angular.injector(['pnc.common.pnc-client.pagination']).get('page');
+
+              var p = page({
+                Resource: Resource
+              });
+
+              p.$resolved = false;
+
+              p.$promise = response.$promise.then(function(response) {
+                var content = response.data.content || [];
+                for (var i = 0; i < content.length; i++) {
+                  content[i] = new Resource(content[i]);
+                }
+
+                p.index = response.data.pageIndex;
+                p.size = response.data.pageSize;
+                p.total = response.data.totalPages;
+                p._config = response.config;
+                p.data = content;
+                p.$resolved = true;
+              });
+
+              return p;
+
+            };
+          });
+
+          return Resource;
+        };
+      });
+    }
+  ]);
+
+})();

--- a/ui/app/common/pnc-client/pagination/filteringPaginator.js
+++ b/ui/app/common/pnc-client/pagination/filteringPaginator.js
@@ -1,0 +1,251 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+  'use strict';
+
+  var module = angular.module('pnc.common.pnc-client.pagination');
+
+  /**
+   * @ngdoc service
+   * @name pnc.common.pnc-client.pagination:filteringPaginator
+   * @description
+   * A paginator that provides additional methods for filtering and
+   * searching.
+   *
+   * @author Alex Creasy
+   */
+  module.factory('filteringPaginator', [
+    '$log',
+    'page',
+    'paginator',
+    'rsqlQuery',
+    function ($log, $page, paginator, rsqlQuery) {
+
+      var SEARCH_WILDCARD_CHAR = '%';
+
+      function filteringPaginator(page, search) {
+        var prototype = paginator(page);
+        var that = Object.create(prototype);
+
+        // Filters applied by the user.
+        var activeFilters = [];
+
+        var sortBy = null;
+
+        // List of properties to be used in a general search
+        var searchProperties = search || [];
+
+        // Search term the user has queried for.
+        var activeSearch = null;
+
+
+        /*
+         * Generates an RSQL query string based on the current internal state.
+         */
+        function generateQ() {
+          var q = rsqlQuery();
+
+          if (activeFilters.length > 0) {
+
+            // Apply filters
+            activeFilters.forEach(function (filter) {
+              if (!q.where) {
+                q = q.and();
+              }
+              q = q.where(filter.field).like(filter.value);
+            });
+
+          }
+
+          if (!_.isEmpty(activeSearch) && searchProperties.length > 0) {
+
+            // Apply search fields
+            if (!q.where) {
+              q = q.and();
+            }
+
+            searchProperties.forEach(function (field) {
+              if (!q.where) {
+                q = q.or();
+              }
+
+              q = q.where(field).like(activeSearch);
+            });
+          }
+
+          return q.end ? q.end() : undefined;
+        }
+
+
+       /**
+        * Overides prototype method.
+        */
+        that.fetch = function (params) {
+          params = params || {};
+
+          params.q = generateQ();
+
+          if (!_.isEmpty(sortBy)) {
+            params.sort = sortBy;
+          }
+
+          return prototype.fetch(params);
+        };
+
+
+        /**
+         * Adds the active filter to the paginator but does not refresh the
+         * internal page state. Call apply() afterwards to update the page.
+         *
+         *
+         * e.g.
+         * fp.addFilter({ field: 'buildConfiguration.name', value: 'jboss*'}).apply();
+         *
+         * @param {object|array} filter - One or more filter objects, or an array
+         * of filter objects.
+         * @param {string} filter.field - the field to filter
+         * @param {string} filter.value - the value of the query to filter by, supports
+         * wildcards using the '*' character.
+         * @returns this - to support method chaining.
+         */
+        that.addFilter = function (filter) {
+          if (_.isUndefined(filter)) {
+            throw new Error('Undefined argument passed to method addFilter');
+          }
+
+          if (!_.isArray()) {
+            filter = [ filter ];
+          } else if (arguments.length > 1) {
+            filter = arguments;
+          }
+
+          filter.forEach(function (f) {
+            if (!f.field || !f.value) {
+              throw new Error('Invalid filter, must contain properties `field` and `value`: ' + JSON.stringify(f));
+            }
+            f.value = f.value.replace(/\*/g, '%');
+            activeFilters.push(f);
+          });
+          return this;
+        };
+
+        /**
+         * Removes the given active filter but does not refresh the internal
+         * page state, call apply() afterwards to update the page.
+         *
+         * @param {object} filter - the filter object to remove.
+         * @returns this - to support method chaining.
+         */
+        that.removeFilter = function (filter) {
+          activeFilters.splice(activeFilters.findIndex(function(elem) {
+            return filter.name === elem.name && filter.value === elem.value;
+          }), 1);
+          return this;
+        };
+
+        /**
+         * Clears any active filters but does not refresh the internal page state,
+         * call apply() afterwards to update the page
+         *
+         * @returns this - to support method chaining.
+         */
+        that.clearFilters = function () {
+          activeFilters = [];
+          return this;
+        };
+
+        /**
+         * Sorts the page by the given field but does not refresh the internal
+         * page state, call apply() afterwards to update the page.
+         *
+         * e.g. fp.addFilter({ field: 'user.username', value: 'bobby_tables'})
+         *        .sortBy('buildConfiguration.id', true)
+         *        .apply();
+         *
+         * @param {string} field - the name of the field to order by.
+         * @param {boolean} desc - if true sort descending, otherwise sortBy
+         * ascending.
+         * @returns this - to allow method chaining.
+         */
+        that.sortBy = function (field, desc) {
+          var order = desc ? 'desc' : 'asc';
+          sortBy = 'sort=' + order + '=' + field;
+          return this;
+        };
+
+        /**
+         * Clears the current sort paramaters by does not refresh the internal
+         * page state, call apply() afterwards to update the page.
+         *
+         * e.g. fp.clearSort().apply();
+         *
+         * @returns this - to allow method chaining.
+         */
+        that.clearSort = function () {
+          sortBy = null;
+          return this;
+        };
+
+       /**
+        * Applies any filter / search terms and refreshes the internal
+        * page state.
+        *
+        * @returns {promise} - a promise which is resolved with the paginator
+        * instance itself.
+        */
+        that.apply = function () {
+          return this.get(0);
+        };
+
+        /**
+         * Searches for a term against the configured search fields and
+         * refreshes the internal page state.
+         *
+         * @param {string} query - the term to search for
+         * @param {boolean} wrapInWildCards - if true, prefixes and suffixes
+         * the search term with wildcards.
+         * @returns {promise} - a promise which is resolved with the paginator
+         * instance itself.
+         */
+        that.search = function (query, wrapInWildCards) {
+          if (wrapInWildCards) {
+            query = SEARCH_WILDCARD_CHAR + query + SEARCH_WILDCARD_CHAR;
+          }
+          activeSearch = query;
+          return this.apply();
+        };
+
+        /**
+         * Clears the current search and refreshes the internal page state.
+         *
+         * @returns {promise} - a promise which is resolved with the paginator
+         * instance itself.
+         */
+         that.clearSearch = function () {
+           activeSearch = null;
+           return this.apply();
+         };
+
+        return that;
+      }
+
+      return filteringPaginator;
+    }
+  ]);
+
+})();

--- a/ui/app/common/pnc-client/resources/BuildRecord.js
+++ b/ui/app/common/pnc-client/resources/BuildRecord.js
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+  'use strict';
+
+  var module = angular.module('pnc.common.pnc-client.resources');
+
+  module.value('BUILD_RECORD_ENDPOINT2', '/build-records/:id');
+
+  /**
+   *
+   */
+  module.factory('BuildRecord', [
+    '$resource',
+    'restConfig',
+    'BUILD_RECORD_ENDPOINT2',
+    function($resource, restConfig, BUILD_RECORD_ENDPOINT2) {
+      var ENDPOINT = restConfig.getPncUrl() + BUILD_RECORD_ENDPOINT2;
+
+      var resource = $resource(ENDPOINT, {
+        id: '@id',
+      }, {
+        getArtifacts: {
+          isPaged: true,
+          method: 'GET',
+          url: ENDPOINT + '/artifacts'
+        },
+        getDependencyArtifacts: {
+          isPaged: true,
+          method: 'GET',
+          url: ENDPOINT + '/dependency-artifacts' //+ qh.searchOnly(['identifier', 'filename', 'checksum'])
+        },
+        getBuiltArtifacts: {
+          isPaged: true,
+          method: 'GET',
+          url: ENDPOINT + '/built-artifacts', //+ qh.searchOnly(['identifier', 'filename', 'checksum'])
+        },
+      });
+
+      return resource;
+    }
+
+  ]);
+
+
+})();

--- a/ui/app/common/pnc-client/resources/_resources.js
+++ b/ui/app/common/pnc-client/resources/_resources.js
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+  'use strict';
+
+  angular.module('pnc.common.pnc-client.resources', [
+    'ngResource'
+  ]);
+
+})();

--- a/ui/app/common/pnc-client/rsql/_rsql.js
+++ b/ui/app/common/pnc-client/rsql/_rsql.js
@@ -1,0 +1,23 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+  'use strict';
+
+  angular.module('pnc.common.pnc-client.rsql', []);
+
+})();

--- a/ui/app/common/pnc-client/rsql/comparator.js
+++ b/ui/app/common/pnc-client/rsql/comparator.js
@@ -1,0 +1,77 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+  'use strict';
+
+  var module = angular.module('pnc.common.pnc-client.rsql');
+
+  /**
+   * @ngdoc service
+   * @kind function
+   * @name pnc.common.pnc-client.rsql:comparator
+   * @description
+   * This is an internal class used by rsqlQuery, see that for usage instructions.
+   *
+   * @author Alex Creasy
+   */
+  module.factory('comparator', [
+    function () {
+      return function comparator(ctx) {
+        var that = {};
+
+        that.eq = function (value) {
+          ctx.addToQuery('==' + value);
+          return ctx.next();
+        };
+
+        that.neq = function (value) {
+          ctx.addToQuery('!=' + value);
+          return ctx.next();
+        };
+
+        that.lt = function (value) {
+          ctx.addToQuery('=lt=' + value);
+          return ctx.next();
+        };
+
+        that.le = function (value) {
+          ctx.addToQuery('=le=' + value);
+          return ctx.next();
+        };
+
+        that.gt = function (value) {
+          ctx.addToQuery('=gt=' + value);
+          return ctx.next();
+        };
+
+        that.ge = function (value) {
+          ctx.addToQuery('=ge=' + value);
+          return ctx.next();
+        };
+
+        that.like = function (value) {
+          ctx.addToQuery('=like="' + value +'"');
+          return ctx.next();
+        };
+
+        return that;
+      };
+    }
+  ]);
+
+})();

--- a/ui/app/common/pnc-client/rsql/context.js
+++ b/ui/app/common/pnc-client/rsql/context.js
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+  'use strict';
+
+  var module = angular.module('pnc.common.pnc-client.rsql');
+
+  /**
+   * @ngdoc service
+   * @kind function
+   * @name pnc.common.pnc-client.rsql:context
+   * @description
+   * This is an internal class used by rsqlQuery, see that for usage instructions.
+   *
+   * @author Alex Creasy
+   */
+  module.factory('context', [
+    'selector',
+    'comparator',
+    'operator',
+    function (selector, comparator, operator) {
+      return function context() {
+        var that = {};
+        var q = [];
+
+        var nodes = {
+          selector: function () {
+            this.next = this.comparator;
+            return selector(that);
+          },
+          comparator: function () {
+            this.next = this.operator;
+            return comparator(that);
+          },
+          operator: function () {
+            this.next = this.selector;
+            return operator(that);
+          },
+        };
+
+        nodes.next = nodes.selector.bind(nodes);
+
+        that.addToQuery = function (str) {
+          q.push(str);
+        };
+
+        that.next = function () {
+          return nodes.next();
+        };
+
+        that.end = function () {
+          return q.join('');
+        };
+
+        return that;
+      };
+    }
+  ]);
+
+})();

--- a/ui/app/common/pnc-client/rsql/operator.js
+++ b/ui/app/common/pnc-client/rsql/operator.js
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+  'use strict';
+
+  var module = angular.module('pnc.common.pnc-client.rsql');
+
+  /**
+   * @ngdoc service
+   * @kind function
+   * @name pnc.common.pnc-client.rsql:operator
+   * @description
+   * This is an internal class used by rsqlQuery, see that for usage instructions.
+   *
+   * @author Alex Creasy
+   */
+  module.factory('operator', [
+    function () {
+      return function operator(ctx) {
+        var that = {};
+
+        that.and = function () {
+          ctx.addToQuery(';');
+          return ctx.next();
+        };
+
+        that.or = function () {
+          ctx.addToQuery(',');
+          return ctx.next();
+        };
+
+        that.end = function () {
+          return ctx.end();
+        };
+
+        return that;
+      };
+    }
+  ]);
+
+})();

--- a/ui/app/common/pnc-client/rsql/rsqlQuery.js
+++ b/ui/app/common/pnc-client/rsql/rsqlQuery.js
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+  'use strict';
+
+  var module = angular.module('pnc.common.pnc-client.rsql');
+
+  /**
+   * @ngdoc service
+   * @kind function
+   * @name pnc.common.pnc-client.rsql:rsqlQuery
+   * @description
+   * Provides a fluent API for creating RSQL queries
+   *
+   * @example
+   * rsqlQuery().where('buildConfiguration.name').like('jboss%').and().where('id').gt(4).end();
+   *
+   * @author Alex Creasy
+   */
+  module.factory('rsqlQuery', [
+    'context',
+    function (context) {
+      return function rsqlQuery() {
+        var ctx = context();
+        return ctx.next();
+      };
+    }
+  ]);
+
+})();

--- a/ui/app/common/pnc-client/rsql/selector.js
+++ b/ui/app/common/pnc-client/rsql/selector.js
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function () {
+  'use strict';
+
+  var module = angular.module('pnc.common.pnc-client.rsql');
+
+  /**
+   * @ngdoc service
+   * @kind function
+   * @name pnc.common.pnc-client.rsql:selector
+   * @description
+   * This is an internal class used by rsqlQuery, see that for usage instructions.
+   *
+   * @author Alex Creasy
+   */
+  module.factory('selector', [
+    function () {
+      /*
+       * For selecting a field to operate on e.g. `.where('name')`
+       */
+      return function selector(ctx) {
+        var that = {};
+
+        that.where = function (field) {
+          ctx.addToQuery(field);
+          return ctx.next();
+        };
+
+        return that;
+      };
+    }
+  ]);
+
+})();


### PR DESCRIPTION
This addresses a number of issues with the current API:
    - Automatically applies paging functionality where necessary, there's no need to add decorating functions calls to ng-resource services.
    - Adds ability to filter queries by a field, order by a field and change page size.
    - Returns promises so as doesn't mess up ui router resolves
    - decouples paging and pagination API.
    - decouples searching and pagination. 
    - Adds new features such as ability to change page size, or add query parameters to the search.
    - Doesn't always cause a wildcard RSQL query to be performed even when there is no search term.

