### PR TITLE
NCL-2300: Fix BPM manager cleanups, which caused a bottleneck in BPM …

### DIFF
--- a/bpm/pom.xml
+++ b/bpm/pom.xml
@@ -62,6 +62,11 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jboss.spec.javax.ejb</groupId>
+      <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
       <scope>provided</scope>

--- a/bpm/src/main/java/org/jboss/pnc/bpm/BpmManager.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/BpmManager.java
@@ -161,12 +161,12 @@ public class BpmManager {
      */
     public void cleanup() {
         log.debug("Bpm manager tasks cleanup started");
-        Map<Integer, BpmTask> clonnedTasks = null;
+        Map<Integer, BpmTask> clonedTasks = null;
         synchronized(this) {
-            clonnedTasks = new HashMap<>(this.tasks);
+            clonedTasks = new HashMap<>(this.tasks);
         }
         
-        Set<Integer> toBeRemoved = clonnedTasks.values().stream()
+        Set<Integer> toBeRemoved = clonedTasks.values().stream()
                 .filter(t -> {
                     log.debug("attempting to fetch process instance from bpm");
                     ProcessInstance processInstance = session.getProcessInstance(t.getProcessInstanceId());

--- a/bpm/src/main/java/org/jboss/pnc/bpm/BpmManager.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/BpmManager.java
@@ -162,7 +162,7 @@ public class BpmManager {
     public void cleanup() {
         log.debug("Bpm manager tasks cleanup started");
         Map<Integer, BpmTask> clonnedTasks = null;
-        synchronized(this.tasks) {
+        synchronized(this) {
             clonnedTasks = new HashMap<>(this.tasks);
         }
         

--- a/bpm/src/main/java/org/jboss/pnc/bpm/BpmScheduler.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/BpmScheduler.java
@@ -1,3 +1,20 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.pnc.bpm;
 
 import javax.ejb.Schedule;

--- a/bpm/src/main/java/org/jboss/pnc/bpm/BpmScheduler.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/BpmScheduler.java
@@ -1,0 +1,28 @@
+package org.jboss.pnc.bpm;
+
+import javax.ejb.Schedule;
+import javax.ejb.Singleton;
+import javax.inject.Inject;
+
+/**
+ * Performs scheduled regular events on the BPM classes
+ * 
+ * @author Jakub Bartecek &lt;jbartece@redhat.com&gt;
+ *
+ */
+@Singleton
+public class BpmScheduler {
+    
+    @Inject
+    private BpmManager bpmManager;
+    
+    /**
+     * The finished BPM tasks has to be cleaned up regularly
+     * Immediate cleanup is not usable because of NCL-2300
+     */
+    @Schedule(hour = "*")
+    public void bpmTasksCleanup() {
+        bpmManager.cleanup();
+    }
+
+}


### PR DESCRIPTION
…manager

The cleanups caused timeouts, because of blocking cleanups in BPM manager.
The cleanups of finished tasks will be done regularly every hour.