### PR TITLE
Add some test dirs to .gitignore, adjust buildRepoId, use Indy 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ settings.xml
 
 # DB test file
 maven-repository-manager/derby.log
+maven-repository-manager/indexedStorePath
+maven-repository-manager/org.commonjava.indy.folo.model.TrackedContentEntry

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AbstractRepositoryManagerDriverTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AbstractRepositoryManagerDriverTest.java
@@ -145,6 +145,7 @@ public class AbstractRepositoryManagerDriverTest {
             throws IOException
     {
         writeConfigFile( "conf.d/scheduler.conf", "[scheduler]\nenabled=false" );
+        writeConfigFile( "conf.d/threadpools.conf", "[threadpools]\nenabled=false" );
     }
 
     protected String readTestResource( String resource )

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/UploadOneThenDownloadAndVerifyArtifactHasOriginUrlTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/UploadOneThenDownloadAndVerifyArtifactHasOriginUrlTest.java
@@ -29,6 +29,7 @@ import org.jboss.pnc.spi.repositorymanager.BuildExecution;
 import org.jboss.pnc.spi.repositorymanager.RepositoryManagerResult;
 import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
 import org.jboss.pnc.test.category.ContainerTest;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -40,6 +41,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @Category(ContainerTest.class)
+@Ignore("Uploaded/Built paths should NOT be contained in downloaded/dependency listing!")
 public class UploadOneThenDownloadAndVerifyArtifactHasOriginUrlTest
     extends AbstractImportTest
 {

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <jdk.min.version>1.8</jdk.min.version>
     <maven.min.version>3.2</maven.min.version>
     <atlasVersion>0.16.0</atlasVersion>
-    <indyVersion>0.99.2.1</indyVersion>
+    <indyVersion>1.0.0</indyVersion>
     <version.jboss.maven.plugin>7.5.Final</version.jboss.maven.plugin>
     <version.jboss.bom>1.0.7.Final</version.jboss.bom>
     <version.junit>4.11</version.junit>


### PR DESCRIPTION
* @Ignore UploadOneThenDownloadAndVerifyArtifactHasOriginalUrlTest, since it requires registration of file as both upload and download, which doesn't make sense.
* Rename buildRepoId in MavenRepositorySession to be more consistent with the rest of PNC (buildContentId)
* Disable multi-threaded event processing in Indy for integration tests (new for Indy 1.0.0)
* Upgrade Indy to 1.0.0