### PR TITLE
Store execution root name and version in build record.

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/datastore/DatastoreAdapter.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/datastore/DatastoreAdapter.java
@@ -97,6 +97,9 @@ public class DatastoreAdapter {
 
             BuildRecord.Builder buildRecordBuilder = initBuildRecordBuilder(buildTask);
 
+            buildResult.getExecutionRootName().ifPresent(buildRecordBuilder::executionRootName);
+            buildResult.getExecutionRootVersion().ifPresent(buildRecordBuilder::executionRootVersion);
+
             buildResult.getSshCredentials().ifPresent(
                     c -> {
                         buildRecordBuilder.sshCommand(c.getCommand());
@@ -176,6 +179,10 @@ public class DatastoreAdapter {
         StringBuilder errorLog = new StringBuilder();
 
         buildResult.ifPresent(r -> {
+
+            r.getExecutionRootName().ifPresent(buildRecordBuilder::executionRootName);
+            r.getExecutionRootVersion().ifPresent(buildRecordBuilder::executionRootVersion);
+
             r.getBuildDriverResult().ifPresent(
                 buildDriverResult -> {
                     errorLog.append(buildDriverResult.getBuildLog());

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/DatastoreAdapterTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/DatastoreAdapterTest.java
@@ -111,8 +111,9 @@ public class DatastoreAdapterTest {
                 Optional.of(repositoryManagerResult),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty()
-        );
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
 
         datastoreAdapter.storeResult(buildTask, buildResult);
     }

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/event/StatusUpdatesTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/event/StatusUpdatesTest.java
@@ -199,6 +199,7 @@ public class StatusUpdatesTest {
                 return BuildStatus.SUCCESS;
             }
         };
-        return new BuildResult(Optional.empty(), Optional.of(driverResult), Optional.of(repoManagerResult), Optional.empty(), Optional.empty(), Optional.empty());
+        return new BuildResult(Optional.empty(), Optional.of(driverResult), Optional.of(repoManagerResult),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     }
 }

--- a/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionSession.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionSession.java
@@ -131,7 +131,9 @@ public class DefaultBuildExecutionSession implements BuildExecutionSession {
                         Optional.ofNullable(repositoryManagerResult),
                         Optional.empty(),
                         Optional.empty(),
-                        sshCredentials);
+                        sshCredentials,
+                        Optional.empty(),
+                        Optional.empty());
             } else {
                 log.trace("Returning result of task " + getId() + " with failed reason {}.", failedReasonStatus);
                 return new BuildResult(
@@ -140,7 +142,9 @@ public class DefaultBuildExecutionSession implements BuildExecutionSession {
                         Optional.ofNullable(repositoryManagerResult),
                         Optional.empty(),
                         Optional.of(failedReasonStatus),
-                        sshCredentials);
+                        sshCredentials,
+                        Optional.empty(),
+                        Optional.empty());
             }
         } else {
             log.trace("Returning result of task " + getId() + " with exception.", executorException);
@@ -150,7 +154,9 @@ public class DefaultBuildExecutionSession implements BuildExecutionSession {
                     Optional.ofNullable(repositoryManagerResult),
                     Optional.of(executorException),
                     Optional.ofNullable(failedReasonStatus),
-                    sshCredentials);
+                    sshCredentials,
+                    Optional.empty(),
+                    Optional.empty());
         }
     }
 

--- a/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
@@ -164,6 +164,24 @@ public class BuildRecord implements GenericEntity<Integer> {
     @Setter
     private String sshPassword;
 
+    /**
+     * This is and identifier of the built project sources.
+     * In case of Maven, it is GA of the POM being built.
+     * This information comes from Repour/PME and has to be stored in the build record
+     * to be used in the release process.
+     */
+    @Getter
+    @Setter
+    private String executionRootName;
+
+    /**
+     * See {@link BuildRecord#executionRootName}.
+     * Contains corresponding version.
+     */
+    @Getter
+    @Setter
+    private String executionRootVersion;
+
     private boolean tested;
 
     private boolean deprecated;
@@ -546,6 +564,10 @@ public class BuildRecord implements GenericEntity<Integer> {
 
         private String sshPassword;
 
+        private String executionRootName;
+
+        private String executionRootVersion;
+
         private Map<String, String> attributes = new HashMap<>();
 
         public Builder() {
@@ -576,6 +598,8 @@ public class BuildRecord implements GenericEntity<Integer> {
             buildRecord.setAttributes(attributes);
             buildRecord.setSshCommand(sshCommand);
             buildRecord.setSshPassword(sshPassword);
+            buildRecord.setExecutionRootName(executionRootName);
+            buildRecord.setExecutionRootVersion(executionRootVersion);
 
             if (buildConfigSetRecord != null) {
                 buildRecord.setBuildConfigSetRecord(buildConfigSetRecord);
@@ -718,6 +742,16 @@ public class BuildRecord implements GenericEntity<Integer> {
 
         public BuildRecord.Builder sshPassword(String sshPassword) {
             this.sshPassword = sshPassword;
+            return this;
+        }
+
+        public BuildRecord.Builder executionRootName(String executionRootName) {
+            this.executionRootName = executionRootName;
+            return this;
+        }
+
+        public BuildRecord.Builder executionRootVersion(String executionRootVersion) {
+            this.executionRootVersion = executionRootVersion;
             return this;
         }
 

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionSessionMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionSessionMock.java
@@ -121,6 +121,8 @@ public class BuildExecutionSessionMock implements BuildExecutionSession {
                         Optional.ofNullable(repositoryManagerResult),
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
                         Optional.empty());
             } else {
                 log.trace("Returning result of task " + getId() + " with failed reason {}.", failedReasonStatus);
@@ -129,6 +131,8 @@ public class BuildExecutionSessionMock implements BuildExecutionSession {
                         Optional.ofNullable(repositoryManagerResult),
                         Optional.empty(),
                         Optional.of(failedReasonStatus),
+                        Optional.empty(),
+                        Optional.empty(),
                         Optional.empty());
             }
         } else {
@@ -138,6 +142,8 @@ public class BuildExecutionSessionMock implements BuildExecutionSession {
                     Optional.ofNullable(repositoryManagerResult),
                     Optional.of(executorException),
                     Optional.ofNullable(failedReasonStatus),
+                    Optional.empty(),
+                    Optional.empty(),
                     Optional.empty());
         }
     }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/spi/BuildResultMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/spi/BuildResultMock.java
@@ -58,7 +58,7 @@ public class BuildResultMock {
                 Optional.ofNullable(repositoryManagerResult),
                 Optional.ofNullable(exception),
                 Optional.ofNullable(buildExecutionStatus),
-                Optional.empty());
+                Optional.empty(), Optional.empty(), Optional.empty());
 
     }
 

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildRecordRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildRecordRest.java
@@ -18,6 +18,8 @@
 package org.jboss.pnc.rest.restmodel;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.Setter;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.rest.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.rest.validation.groups.WhenUpdating;
@@ -92,6 +94,15 @@ public class BuildRecordRest implements GenericRestEntity<Integer> {
 
     private SshCredentials sshCredentials;
 
+    @Getter
+    @Setter
+    private String executionRootName;
+
+    @Getter
+    @Setter
+    private String executionRootVersion;
+
+
     public BuildRecordRest() {
     }
 
@@ -133,6 +144,9 @@ public class BuildRecordRest implements GenericRestEntity<Integer> {
             sshCredentials.setCommand(buildRecord.getSshCommand());
             sshCredentials.setPassword(buildRecord.getSshPassword());
         }
+
+        executionRootName = buildRecord.getExecutionRootName();
+        executionRootVersion = buildRecord.getExecutionRootVersion();
     }
 
     public BuildRecordRest(BuildExecutionSession buildExecutionSession, Date submitTime, UserRest user,

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/bpm/BuildResultRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/bpm/BuildResultRest.java
@@ -18,6 +18,8 @@
 
 package org.jboss.pnc.rest.restmodel.bpm;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.jboss.pnc.rest.restmodel.BuildDriverResultRest;
 import org.jboss.pnc.rest.restmodel.BuildExecutionConfigurationRest;
 import org.jboss.pnc.rest.restmodel.RepositoryManagerResultRest;
@@ -34,23 +36,45 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Optional;
 
+import static java.util.Optional.*;
+
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
  */
 @XmlRootElement(name = "buildResult")
 public class BuildResultRest extends BpmNotificationRest implements Serializable {
 
+    @Getter
+    @Setter
     private BuildExecutionConfigurationRest buildExecutionConfiguration;
 
+    @Getter
+    @Setter
     private BuildDriverResultRest buildDriverResult;
 
+    @Getter
+    @Setter
     private RepositoryManagerResultRest repositoryManagerResult;
 
+    @Getter
+    @Setter
     private ExecutorException exception;
 
+    @Getter
+    @Setter
     private BuildExecutionStatus failedReasonStatus;
 
+    @Getter
+    @Setter
     private SshCredentials sshCredentials;
+
+    @Getter
+    @Setter
+    private String executionRootName;
+
+    @Getter
+    @Setter
+    private String executionRootVersion;
 
     public BuildResultRest() {
     }
@@ -63,6 +87,8 @@ public class BuildResultRest extends BpmNotificationRest implements Serializable
         this.exception = buildResultRest.getException();
         this.failedReasonStatus = buildResultRest.getFailedReasonStatus();
         this.sshCredentials = buildResultRest.getSshCredentials();
+        this.executionRootName = buildResultRest.getExecutionRootName();
+        this.executionRootVersion = buildResultRest.getExecutionRootVersion();
     }
 
     public BuildResultRest(BuildResult buildResult) {
@@ -93,61 +119,16 @@ public class BuildResultRest extends BpmNotificationRest implements Serializable
             repositoryManagerResult = getRepositoryManagerResult().toRepositoryManagerResult();
         }
         return new BuildResult(
-                Optional.ofNullable(buildExecutionConfiguration),
-                Optional.ofNullable(buildDriverResult),
-                Optional.ofNullable(repositoryManagerResult),
-                Optional.ofNullable(exception),
-                Optional.ofNullable(failedReasonStatus),
-                Optional.ofNullable(sshCredentials));
+                ofNullable(buildExecutionConfiguration),
+                ofNullable(buildDriverResult),
+                ofNullable(repositoryManagerResult),
+                ofNullable(exception),
+                ofNullable(failedReasonStatus),
+                ofNullable(sshCredentials),
+                ofNullable(executionRootName),
+                ofNullable(executionRootVersion));
     }
 
-    public void setBuildExecutionConfiguration(BuildExecutionConfigurationRest buildExecutionConfiguration) {
-        this.buildExecutionConfiguration = buildExecutionConfiguration;
-    }
-
-    public BuildExecutionConfigurationRest getBuildExecutionConfiguration() {
-        return buildExecutionConfiguration;
-    }
-
-    public BuildDriverResultRest getBuildDriverResult() {
-        return buildDriverResult;
-    }
-
-    public void setBuildDriverResult(BuildDriverResultRest buildDriverResult) {
-        this.buildDriverResult = buildDriverResult;
-    }
-
-    public RepositoryManagerResultRest getRepositoryManagerResult() {
-        return repositoryManagerResult;
-    }
-
-    public void setRepositoryManagerResult(RepositoryManagerResultRest repositoryManagerResult) {
-        this.repositoryManagerResult = repositoryManagerResult;
-    }
-
-    public ExecutorException getException() {
-        return exception;
-    }
-
-    public void setException(ExecutorException exception) {
-        this.exception = exception;
-    }
-
-    public BuildExecutionStatus getFailedReasonStatus() {
-        return failedReasonStatus;
-    }
-
-    public void setFailedReasonStatus(BuildExecutionStatus failedReasonStatus) {
-        this.failedReasonStatus = failedReasonStatus;
-    }
-
-    public SshCredentials getSshCredentials() {
-        return sshCredentials;
-    }
-
-    public void setSshCredentials(SshCredentials sshCredentials) {
-        this.sshCredentials = sshCredentials;
-    }
 
     @Override
     public String getEventType() {

--- a/spi/src/main/java/org/jboss/pnc/spi/BuildResult.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/BuildResult.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.spi;
 
+import lombok.Getter;
 import org.jboss.pnc.spi.builddriver.BuildDriverResult;
 import org.jboss.pnc.spi.executor.BuildExecutionConfiguration;
 import org.jboss.pnc.spi.executor.exceptions.ExecutorException;
@@ -29,55 +30,56 @@ import java.util.Optional;
  */
 public class BuildResult {
 
+    @Getter
     private final Optional<BuildExecutionConfiguration> buildExecutionConfiguration;
+
+    @Getter
     private final Optional<BuildDriverResult> buildDriverResult;
+
+    /**
+     * Note that RepositoryManagerResult can return nul if build was not successful completed.
+     */
+    @Getter
     private final Optional<RepositoryManagerResult> repositoryManagerResult;
+
     private final Optional<ExecutorException> executorException;
+
+    @Getter
     private final Optional<BuildExecutionStatus> failedReasonStatus;
+
+    @Getter
     private final Optional<SshCredentials> sshCredentials;
+
+    @Getter
+    private final Optional<String> executionRootName;
+
+    @Getter
+    private final Optional<String> executionRootVersion;
 
     public BuildResult(Optional<BuildExecutionConfiguration> generatedBuildConfig,
                        Optional<BuildDriverResult> buildDriverResult,
                        Optional<RepositoryManagerResult> repositoryManagerResult,
                        Optional<ExecutorException> executorException,
                        Optional<BuildExecutionStatus> failedReasonStatus,
-                       Optional<SshCredentials> sshCredentials) {
+                       Optional<SshCredentials> sshCredentials,
+                       Optional<String> executionRootName,
+                       Optional<String> executionRootVersion) {
         this.buildExecutionConfiguration = generatedBuildConfig;
         this.buildDriverResult = buildDriverResult;
         this.repositoryManagerResult = repositoryManagerResult;
         this.executorException = executorException;
         this.failedReasonStatus = failedReasonStatus;
         this.sshCredentials = sshCredentials;
-    }
-
-    public Optional<BuildExecutionConfiguration> getBuildExecutionConfiguration() {
-        return buildExecutionConfiguration;
-    }
-
-    public Optional<BuildDriverResult> getBuildDriverResult() {
-        return buildDriverResult;
-    }
-
-    /**
-     * @return Note that RepositoryManagerResult can return nul if build was not successful completed.
-     */
-    public Optional<RepositoryManagerResult> getRepositoryManagerResult() {
-        return repositoryManagerResult;
-    }
-
-    public boolean hasFailed() {
-        return executorException.isPresent() || failedReasonStatus.isPresent();
+        this.executionRootName = executionRootName;
+        this.executionRootVersion = executionRootVersion;
     }
 
     public Optional<ExecutorException> getException() {
         return executorException;
     }
 
-    public Optional<BuildExecutionStatus> getFailedReasonStatus() {
-        return failedReasonStatus;
+    public boolean hasFailed() {
+        return executorException.isPresent() || failedReasonStatus.isPresent();
     }
 
-    public Optional<SshCredentials> getSshCredentials() {
-        return sshCredentials;
-    }
 }


### PR DESCRIPTION
 - This is (in case of Maven) GAV of the POM being built. This information comes
   from Repour/PME and has to be stored in the build record to be used in ~~brew bridge push~~ release process.
 - NCL-2345