### PR TITLE
[NCL-2410] External pnc-build-agent defs are null

### DIFF
--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftBuildAgentConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftBuildAgentConfig.java
@@ -49,18 +49,30 @@ public class OpenshiftBuildAgentConfig extends AbstractModuleConfig {
     }
 
     public String getBuilderPod() {
+        if (pncBuilderPod.isNull()) {
+            return null;
+        }
         return pncBuilderPod.toString();
     }
 
     public String getPncBuilderService() {
+        if (pncBuilderService.isNull()) {
+            return null;
+        }
         return pncBuilderService.toString();
     }
 
     public String getPncBuilderRoute() {
+        if (pncBuilderRoute.isNull()) {
+            return null;
+        }
         return pncBuilderRoute.toString();
     }
 
     public String getPncBuilderSshRoute() {
+        if (pncBuilderSshRoute.isNull()) {
+            return null;
+        }
         return pncBuilderSshRoute.toString();
     }
 }


### PR DESCRIPTION
Linked to NCL-2166

In NCL-2166, we add the ability to externalize pnc-build-agent pod
definitions in pnc-config.json, and the ability to only specify one
definition, not all of them.

Unfortunately, the second ability doesn't work. If one pod definition is
defined, but the others are not, the final definition used will be 'null'

This commit fixes this issue.