### PR TITLE
Removed deprecated scmMirror* fields.

### DIFF
--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigurationAuditedRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigurationAuditedRest.java
@@ -63,16 +63,6 @@ public class BuildConfigurationAuditedRest implements GenericRestEntity<Integer>
     @Setter
     private String scmExternalRevision;
 
-    @Deprecated // no longer used
-    @Getter
-    @Setter
-    private String scmMirrorRepoURL;
-
-    @Deprecated // no longer used
-    @Getter
-    @Setter
-    private String scmMirrorRevision;
-
     private Date creationTime;
 
     private Date lastModificationTime;

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigurationRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigurationRest.java
@@ -68,17 +68,6 @@ public class BuildConfigurationRest implements GenericRestEntity<Integer> {
     @Setter
     private String scmExternalRevision;
 
-    @ScmUrl(groups = { WhenCreatingNew.class, WhenUpdating.class })
-    @Deprecated // no longer used
-    @Getter
-    @Setter
-    private String scmMirrorRepoURL;
-
-    @Deprecated // no longer used
-    @Getter
-    @Setter
-    private String scmMirrorRevision;
-
     private Date creationTime;
 
     private Date lastModificationTime;

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
@@ -44,16 +44,6 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
     private String scmRepoURL;
     private String scmRevision;
 
-    @Deprecated // no longer used
-    @Getter
-    @Setter
-    private String scmMirrorRepoURL;
-
-    @Deprecated // no longer used
-    @Getter
-    @Setter
-    private String scmMirrorRevision;
-
     private String systemImageId;
     private String systemImageRepositoryUrl;
     private SystemImageType systemImageType;

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpoint.java
@@ -147,7 +147,7 @@ public class BuildConfigurationEndpoint extends AbstractEndpoint<BuildConfigurat
         return fromCollection(buildConfigurationProvider.getAllNonArchived(pageIndex, pageSize, sort, q));
     }
 
-    @ApiOperation(value = "Creates a new Build Configuration. scmMirror* fields are deprecated and values are no longer used.")
+    @ApiOperation(value = "Creates a new Build Configuration.")
     @ApiResponses(value = {
             @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION, response = BuildConfigurationSingleton.class),
             @ApiResponse(code = INVALID_CODE, message = INVALID_DESCRIPTION, response = ErrorResponseRest.class),


### PR DESCRIPTION
This change is not backwards compatible and clients should update their rest request models.