### PR TITLE
Replace PullingMonitor timeout constants with config parameters.

### DIFF
--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/EnvironmentDriverModuleConfigBase.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/EnvironmentDriverModuleConfigBase.java
@@ -59,6 +59,16 @@ public class EnvironmentDriverModuleConfigBase extends AbstractModuleConfig {
     private String workingDirectory;
     protected boolean disabled;
 
+    /**
+     * Time how long to wait until all services are fully up and running (in seconds)
+     */
+    private final int buildStartTimeoutSeconds;
+
+    /**
+     * Interval between two checks if the services are fully up and running (in second)
+     */
+    private final int buildStartCheckIntervalSeconds;
+
     public EnvironmentDriverModuleConfigBase(
             String imageId,
             String firewallAllowedDestinations,
@@ -66,7 +76,9 @@ public class EnvironmentDriverModuleConfigBase extends AbstractModuleConfig {
             String proxyPort,
             String nonProxyHosts,
             String workingDirectory,
-            boolean disabled) {
+            boolean disabled,
+            String buildStartTimeoutSeconds,
+            String buildStartCheckIntervalSeconds) {
 
         this.imageId = imageId;
         this.firewallAllowedDestinations = firewallAllowedDestinations;
@@ -75,6 +87,8 @@ public class EnvironmentDriverModuleConfigBase extends AbstractModuleConfig {
         this.nonProxyHosts = nonProxyHosts;
         this.workingDirectory = workingDirectory;
         this.disabled = disabled;
+        this.buildStartTimeoutSeconds = Integer.valueOf(buildStartTimeoutSeconds);
+        this.buildStartCheckIntervalSeconds = Integer.valueOf(buildStartCheckIntervalSeconds);
     }
 
     public String getImageId() {
@@ -104,4 +118,11 @@ public class EnvironmentDriverModuleConfigBase extends AbstractModuleConfig {
         return disabled;
     }
 
+    public int getBuildStartTimeoutSeconds() {
+        return buildStartTimeoutSeconds;
+    }
+
+    public int getBuildStartCheckIntervalSeconds() {
+        return buildStartCheckIntervalSeconds;
+    }
 }

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftEnvironmentDriverModuleConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftEnvironmentDriverModuleConfig.java
@@ -57,8 +57,10 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
                                                   @JsonProperty("workingDirectory") String workingDirectory,
                                                   @JsonProperty("disabled") Boolean disabled,
                                                   @JsonProperty("keepBuildAgentInstance") Boolean keepBuildAgentInstance,
-                                                  @JsonProperty("exposeBuildAgentOnPublicUrl") Boolean exposeBuildAgentOnPublicUrl) {
-        super(imageId, firewallAllowedDestinations, proxyServer, proxyPort, nonProxyHosts,workingDirectory, disabled);
+                                                  @JsonProperty("exposeBuildAgentOnPublicUrl") Boolean exposeBuildAgentOnPublicUrl,
+                                                  @JsonProperty("buildStartTimeoutSeconds") String buildStartTimeoutSeconds,
+                                                  @JsonProperty("buildStartCheckIntervalSeconds") String buildStartCheckIntervalSeconds) {
+        super(imageId, firewallAllowedDestinations, proxyServer, proxyPort, nonProxyHosts,workingDirectory, disabled, buildStartTimeoutSeconds, buildStartCheckIntervalSeconds);
 
         this.restEndpointUrl = restEndpointUrl;
         this.buildAgentHost = buildAgentHost;

--- a/moduleconfig/src/main/resources/pnc-config.json
+++ b/moduleconfig/src/main/resources/pnc-config.json
@@ -47,7 +47,9 @@
                     "imageId": "${env.PNC_BUILDER_IMAGE_ID}",
                     "disabled": "false",
                     "keepBuildAgentInstance": true,
-                    "exposeBuildAgentOnPublicUrl": false
+                    "exposeBuildAgentOnPublicUrl": false,
+                    "buildStartTimeoutSeconds": "30",
+                    "buildStartCheckIntervalSeconds": "1"
                 },
                 {
                     "@module-config": "authentication-config",

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/monitor/MonitorException.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/monitor/MonitorException.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.jboss.pnc.common.monitor;
+package org.jboss.pnc.environment.monitor;
 
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/monitor/RunningTask.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/monitor/RunningTask.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.jboss.pnc.common.monitor;
+package org.jboss.pnc.environment.monitor;
 
 import java.time.Duration;
 import java.time.Instant;

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriver.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriver.java
@@ -22,7 +22,7 @@ import org.jboss.pnc.common.Configuration;
 import org.jboss.pnc.common.json.ConfigurationParseException;
 import org.jboss.pnc.common.json.moduleconfig.OpenshiftEnvironmentDriverModuleConfig;
 import org.jboss.pnc.common.json.moduleprovider.PncConfigProvider;
-import org.jboss.pnc.common.monitor.PullingMonitor;
+import org.jboss.pnc.environment.monitor.PullingMonitor;
 import org.jboss.pnc.common.util.NamedThreadFactory;
 import org.jboss.pnc.model.SystemImageType;
 import org.jboss.pnc.spi.builddriver.DebugData;

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -29,7 +29,7 @@ import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
 import org.apache.commons.lang.RandomStringUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.pnc.common.json.moduleconfig.OpenshiftEnvironmentDriverModuleConfig;
-import org.jboss.pnc.common.monitor.PullingMonitor;
+import org.jboss.pnc.environment.monitor.PullingMonitor;
 import org.jboss.pnc.common.util.RandomUtils;
 import org.jboss.pnc.common.util.StringUtils;
 import org.jboss.pnc.spi.builddriver.DebugData;

--- a/openshift-environment-driver/src/test/java/org/jboss/pnc/environment/monitor/PullingMonitorTest.java
+++ b/openshift-environment-driver/src/test/java/org/jboss/pnc/environment/monitor/PullingMonitorTest.java
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-package org.jboss.pnc.common.test.monitor;
+package org.jboss.pnc.environment.monitor;
 
-import org.jboss.pnc.common.monitor.PullingMonitor;
+import org.jboss.pnc.common.Configuration;
 import org.jboss.pnc.common.util.ObjectWrapper;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -37,9 +37,12 @@ public class PullingMonitorTest {
 
     static PullingMonitor pullingMonitor;
 
+    private static Configuration configuration;
+
     @BeforeClass
     public static void init() {
-        pullingMonitor = new PullingMonitor();
+        configuration = new Configuration();
+        pullingMonitor = new PullingMonitor(configuration);
     }
 
     @AfterClass
@@ -106,7 +109,7 @@ public class PullingMonitorTest {
     }
 
     private void failingMonitor(Supplier<Boolean> condition) throws InterruptedException {
-        PullingMonitor pullingMonitor = new PullingMonitor();
+        PullingMonitor pullingMonitor = new PullingMonitor(configuration);
 
         CountDownLatch latch = new CountDownLatch(1);
 

--- a/openshift-environment-driver/src/test/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriverRemoteTest.java
+++ b/openshift-environment-driver/src/test/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriverRemoteTest.java
@@ -19,7 +19,7 @@ package org.jboss.pnc.environment.openshift;
 
 import com.openshift.internal.restclient.DefaultClient;
 import org.jboss.pnc.common.Configuration;
-import org.jboss.pnc.common.monitor.PullingMonitor;
+import org.jboss.pnc.environment.monitor.PullingMonitor;
 import org.jboss.pnc.common.util.ObjectWrapper;
 import org.jboss.pnc.model.ArtifactRepo;
 import org.jboss.pnc.model.SystemImageType;
@@ -72,7 +72,7 @@ public class OpenshiftEnvironmentDriverRemoteTest {
 
         configurationService = new Configuration();
 
-        environmentDriver = new OpenshiftEnvironmentDriver(configurationService, new PullingMonitor());
+        environmentDriver = new OpenshiftEnvironmentDriver(configurationService, new PullingMonitor(configurationService));
     }
 
     @Test

--- a/openshift-environment-driver/src/test/resources/pnc-config.json
+++ b/openshift-environment-driver/src/test/resources/pnc-config.json
@@ -13,7 +13,9 @@
               "containerPort":"${env.PNC_CONTAINER_PORT}",
               "imageId":"${env.PNC_BUILDER_IMAGE_ID}",
               "workingDirectory":"/tmp",
-              "disabled":"false"
+              "disabled":"false",
+              "buildStartTimeoutSeconds": "30",
+              "buildStartCheckIntervalSeconds": "1"
           }
         ]
 }


### PR DESCRIPTION
@matejonnet hi, this change causes a problem when parsing configuration, I could not figure out why. Can you take a look? Reproduce: mvn clean test