### PR TITLE
[NCL-2539] Configuration loaded multiple times

### DIFF
--- a/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
+++ b/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
@@ -65,6 +65,9 @@ class BuildExecutionBase {
     @Inject
     BuildDriverFactory buildDriverFactory;
 
+    @Inject
+    Configuration configuration;
+
     BuildExecutionStatus[] baseBuildStatuses = {
             BuildExecutionStatus.NEW,
             BuildExecutionStatus.BUILD_ENV_SETTING_UP,
@@ -114,7 +117,7 @@ class BuildExecutionBase {
                 repositoryManagerFactory,
                 buildDriverFactory,
                 environmentDriverFactory,
-                new Configuration() //TODO inject instance
+                configuration
         );
 
         runBuild(buildConfiguration, statusChangedEvents, buildExecutionResultWrapper, (e) -> {}, executor);

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/Configurations.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/Configurations.java
@@ -26,6 +26,7 @@ import org.jboss.pnc.common.util.IoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 
@@ -45,11 +46,11 @@ public enum Configurations {
 
     private final String filePath;
 
+    @Inject
     private Configuration configuration;
 
     Configurations(String fileName) {
         this.filePath = CONFIGURATIONS_FOLDER + fileName;
-        this.configuration = new Configuration(); //TODO Inject managed instance
     }
 
     public String getContentAsString() {


### PR DESCRIPTION
We instead use the Application Scope PNC to inject the already loaded configuration.