### PR TITLE
[NCL-2539] Configuration loaded multiple times

### DIFF
--- a/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
+++ b/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
@@ -65,6 +65,9 @@ class BuildExecutionBase {
     @Inject
     BuildDriverFactory buildDriverFactory;
 
+    @Inject
+    Configuration configuration;
+
     BuildExecutionStatus[] baseBuildStatuses = {
             BuildExecutionStatus.NEW,
             BuildExecutionStatus.BUILD_ENV_SETTING_UP,
@@ -114,7 +117,7 @@ class BuildExecutionBase {
                 repositoryManagerFactory,
                 buildDriverFactory,
                 environmentDriverFactory,
-                new Configuration() //TODO inject instance
+                configuration
         );
 
         runBuild(buildConfiguration, statusChangedEvents, buildExecutionResultWrapper, (e) -> {}, executor);

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/Configurations.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/Configurations.java
@@ -26,6 +26,7 @@ import org.jboss.pnc.common.util.IoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 
@@ -45,16 +46,13 @@ public enum Configurations {
 
     private final String filePath;
 
-    private Configuration configuration;
-
     Configurations(String fileName) {
         this.filePath = CONFIGURATIONS_FOLDER + fileName;
-        this.configuration = new Configuration(); //TODO Inject managed instance
     }
 
-    public String getContentAsString() {
+    public String getContentAsString(Configuration configuration) {
 
-        String content = getContentFromConfigFile();
+        String content = getContentFromConfigFile(configuration);
 
         // if no configuration in pnc-config
         if (content == null) {
@@ -68,7 +66,7 @@ public enum Configurations {
         return content;
     }
 
-    private String getContentFromConfigFile() {
+    private String getContentFromConfigFile(Configuration configuration) {
 
         OpenshiftBuildAgentConfig config = null;
 

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/Configurations.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/Configurations.java
@@ -26,7 +26,6 @@ import org.jboss.pnc.common.util.IoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriver.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriver.java
@@ -55,6 +55,7 @@ public class OpenshiftEnvironmentDriver implements EnvironmentDriver {
     private ExecutorService executor = Executors.newFixedThreadPool(4, new NamedThreadFactory("openshift-environment-driver"));
 
     private OpenshiftEnvironmentDriverModuleConfig config;
+    private Configuration configuration;
     private PullingMonitor pullingMonitor;
 
     @Deprecated //CDI workaround
@@ -65,7 +66,7 @@ public class OpenshiftEnvironmentDriver implements EnvironmentDriver {
     public OpenshiftEnvironmentDriver(Configuration configuration, PullingMonitor pullingMonitor) throws ConfigurationParseException {
         this.pullingMonitor = pullingMonitor;
         config = configuration.getModuleConfig(new PncConfigProvider<>(OpenshiftEnvironmentDriverModuleConfig.class));
-
+        this.configuration = configuration;
         logger.info("Is OpenShift environment driver disabled: {}", config.isDisabled());
     }
 
@@ -82,7 +83,7 @@ public class OpenshiftEnvironmentDriver implements EnvironmentDriver {
             throw new UnsupportedOperationException("OpenshiftEnvironmentDriver currently provides support only for the following system image types:" + compatibleImageTypes);
 
         //TODO: Need to pass the systemImageId and repoUrl to the new environment instead of using system wide environment config
-        return new OpenshiftStartedEnvironment(executor, config, pullingMonitor, repositorySession, systemImageId, debugData, accessToken);
+        return new OpenshiftStartedEnvironment(executor, config, configuration, pullingMonitor, repositorySession, systemImageId, debugData, accessToken);
     }
 
     @Override

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -41,7 +41,6 @@ import org.jboss.util.StringPropertyReplacer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -87,7 +86,6 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
     private Route route;
     private Service sshService;
 
-    @Inject
     private Configuration configuration;
 
     private final String buildAgentContextPath;
@@ -104,6 +102,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
     public OpenshiftStartedEnvironment(
             ExecutorService executor,
             OpenshiftEnvironmentDriverModuleConfig environmentConfiguration,
+            Configuration configuration,
             PullingMonitor pullingMonitor,
             RepositorySession repositorySession,
             String systemImageId,
@@ -113,6 +112,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         logger.info("Creating new build environment using image id: " + environmentConfiguration.getImageId());
 
         this.environmentConfiguration = environmentConfiguration;
+        this.configuration = configuration;
         this.pullingMonitor = pullingMonitor;
         this.repositorySession = repositorySession;
         this.imageId = systemImageId == null ? environmentConfiguration.getImageId() : systemImageId;


### PR DESCRIPTION
We instead use the Application Scope PNC to inject the already loaded configuration.

This is an updated PR to #1297 . I have removed the `@Inject` in the enum, and instead provide the configuration to the method requiring `configuration` via the method parameter.