### PR TITLE
NCL-2496: Enable authentication in Indy

### DIFF
--- a/maven-repository-manager/pom.xml
+++ b/maven-repository-manager/pom.xml
@@ -145,6 +145,11 @@
       </exclusions>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   
   <dependencyManagement>

--- a/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver.java
+++ b/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/RepositoryManagerDriver.java
@@ -59,7 +59,7 @@ import static org.jboss.pnc.mavenrepositorymanager.MavenRepositoryConstants.SHAR
 import static org.jboss.pnc.mavenrepositorymanager.MavenRepositoryConstants.UNTESTED_BUILDS_GROUP;
 
 /**
- * Implementation of {@link RepositoryManager} that manages an <a href="https://github.com/jdcasey/indy">AProx</a> instance to
+ * Implementation of {@link RepositoryManager} that manages an <a href="https://github.com/jdcasey/indy">Indy</a> instance to
  * support repositories for Maven-ish builds.
  * <p>
  * Created by <a href="mailto:matejonnet@gmail.com">Matej Lazar</a> on 2014-11-25.

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AbstractImportTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AbstractImportTest.java
@@ -53,7 +53,7 @@ public class AbstractImportTest extends AbstractRepositoryManagerDriverTest {
     @Before
     public void before() throws Exception
     {
-        indy = driver.getIndy();
+        indy = driver.getIndy(accessToken);
 
         // create a remote repo pointing at our server fixture's 'repo/test' directory.
         indy.stores().create(new RemoteRepository(STORE, server.formatUrl(STORE)), "Creating test remote repo",

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AbstractRepositoryManagerDriverTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AbstractRepositoryManagerDriverTest.java
@@ -52,6 +52,7 @@ public class AbstractRepositoryManagerDriverTest {
     public TemporaryFolder temp = new TemporaryFolder();
 
     protected RepositoryManagerDriver driver;
+    protected String accessToken;
     protected CoreServerFixture fixture;
     protected String url;
 

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AllSessionUrlsForBuildAreAlikeTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/AllSessionUrlsForBuildAreAlikeTest.java
@@ -39,7 +39,7 @@ public class AllSessionUrlsForBuildAreAlikeTest
         // create a dummy non-chained build execution and a repo session based on it
         BuildExecution execution = new TestBuildExecution();
 
-        RepositorySession repositoryConfiguration = driver.createBuildRepository(execution);
+        RepositorySession repositoryConfiguration = driver.createBuildRepository(execution, accessToken);
         assertThat(repositoryConfiguration, notNullValue());
 
         RepositoryConnectionInfo connectionInfo = repositoryConfiguration.getConnectionInfo();

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/BuildGroupIncludesConfSetGroupTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/BuildGroupIncludesConfSetGroupTest.java
@@ -39,9 +39,9 @@ public class BuildGroupIncludesConfSetGroupTest extends AbstractRepositoryManage
     public void verifyGroupComposition_ProductVersion_WithConfSet() throws Exception {
         // create a dummy composed (chained) build execution and a repo session based on it
         BuildExecution execution = new TestBuildExecution("build_myproject_67890");
-        Indy indy = driver.getIndy();
+        Indy indy = driver.getIndy(accessToken);
 
-        RepositorySession repositoryConfiguration = driver.createBuildRepository(execution);
+        RepositorySession repositoryConfiguration = driver.createBuildRepository(execution, accessToken);
         String repoId = repositoryConfiguration.getBuildRepositoryId();
 
         assertThat(repoId, equalTo(execution.getBuildContentId()));

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/BuildGroupIncludesProductVersionGroupTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/BuildGroupIncludesProductVersionGroupTest.java
@@ -39,9 +39,9 @@ public class BuildGroupIncludesProductVersionGroupTest extends AbstractRepositor
     public void verifyGroupComposition_ProductVersion_NoConfSet() throws Exception {
         // create a dummy non-chained build execution and repo session based on it
         BuildExecution execution = new TestBuildExecution("build_myproject_12345");
-        Indy indy = driver.getIndy();
+        Indy indy = driver.getIndy(accessToken);
 
-        RepositorySession repositoryConfiguration = driver.createBuildRepository(execution);
+        RepositorySession repositoryConfiguration = driver.createBuildRepository(execution, accessToken);
         String repoId = repositoryConfiguration.getBuildRepositoryId();
 
         assertThat(repoId, equalTo(execution.getBuildContentId()));

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/DependencyUrlIncludesTrackingIdAndGeneratedBuildGroupNameTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/DependencyUrlIncludesTrackingIdAndGeneratedBuildGroupNameTest.java
@@ -39,7 +39,7 @@ public class DependencyUrlIncludesTrackingIdAndGeneratedBuildGroupNameTest
         // create a dummy non-chained build execution and repo session based on it
         BuildExecution execution = new TestBuildExecution();
 
-        RepositorySession repositoryConfiguration = driver.createBuildRepository(execution);
+        RepositorySession repositoryConfiguration = driver.createBuildRepository(execution, accessToken);
 
         assertThat(repositoryConfiguration, notNullValue());
 

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/DownloadTwoThenVerifyExtractedArtifactsContainThemTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/DownloadTwoThenVerifyExtractedArtifactsContainThemTest.java
@@ -63,7 +63,7 @@ public class DownloadTwoThenVerifyExtractedArtifactsContainThemTest
         // create a dummy non-chained build execution and repo session based on it
         BuildExecution execution = new TestBuildExecution();
 
-        RepositorySession rc = driver.createBuildRepository(execution);
+        RepositorySession rc = driver.createBuildRepository(execution, accessToken);
         assertThat(rc, notNullValue());
 
         String baseUrl = rc.getConnectionInfo().getDependencyUrl();
@@ -94,7 +94,7 @@ public class DownloadTwoThenVerifyExtractedArtifactsContainThemTest
                     equalTo(true));
         }
 
-        Indy indy = driver.getIndy();
+        Indy indy = driver.getIndy(accessToken);
 
         // check that the new imports are available from shared-imports
         assertAvailableInSharedImports(indy, pomContent, pomPath);

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/DownloadTwoThenVerifyExtractedArtifactsContainThemTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/DownloadTwoThenVerifyExtractedArtifactsContainThemTest.java
@@ -42,6 +42,7 @@ import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.jboss.pnc.mavenrepositorymanager.MavenRepositoryConstants.SHARED_IMPORTS_ID;
 import static org.junit.Assert.assertThat;
 
 @Category(ContainerTest.class)
@@ -102,7 +103,7 @@ public class DownloadTwoThenVerifyExtractedArtifactsContainThemTest
     }
 
     private void assertAvailableInSharedImports(Indy indy, String content, String path) throws IndyClientException, IOException {
-        InputStream stream = indy.content().get(StoreType.hosted, SHARED_IMPORTS, path);
+        InputStream stream = indy.content().get(StoreType.hosted, SHARED_IMPORTS_ID, path);
         String downloaded = IOUtils.toString(stream);
         assertThat(downloaded, equalTo(content));
     }

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/ExcludeInternalRepoByNameTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/ExcludeInternalRepoByNameTest.java
@@ -24,9 +24,6 @@ import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
-import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
-import org.commonjava.maven.atlas.ident.ref.SimpleArtifactRef;
-import org.commonjava.maven.atlas.ident.ref.SimpleProjectVersionRef;
 import org.jboss.pnc.mavenrepositorymanager.fixture.TestBuildExecution;
 import org.jboss.pnc.model.Artifact;
 import org.jboss.pnc.spi.repositorymanager.BuildExecution;
@@ -37,11 +34,15 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.InputStream;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.jboss.pnc.mavenrepositorymanager.MavenRepositoryConstants.PUBLIC_GROUP_ID;
+import static org.jboss.pnc.mavenrepositorymanager.MavenRepositoryConstants.SHARED_IMPORTS_ID;
 import static org.junit.Assert.assertThat;
 
 @Category(ContainerTest.class)
@@ -66,9 +67,9 @@ public class ExcludeInternalRepoByNameTest
         indy.stores().create(new RemoteRepository(EXTERNAL, server.formatUrl(EXTERNAL)), "Creating external test remote repo",
                 RemoteRepository.class);
 
-        Group publicGroup = indy.stores().load(StoreType.group, PUBLIC, Group.class);
+        Group publicGroup = indy.stores().load(StoreType.group, PUBLIC_GROUP_ID, Group.class);
         if (publicGroup == null) {
-            publicGroup = new Group(PUBLIC, new StoreKey(StoreType.remote, INTERNAL), new StoreKey(StoreType.remote, EXTERNAL));
+            publicGroup = new Group(PUBLIC_GROUP_ID, new StoreKey(StoreType.remote, INTERNAL), new StoreKey(StoreType.remote, EXTERNAL));
             indy.stores().create(publicGroup, "creating public group", Group.class);
         } else {
             publicGroup.setConstituents(Arrays.asList(new StoreKey(StoreType.remote, INTERNAL), new StoreKey(StoreType.remote, EXTERNAL)));
@@ -110,13 +111,13 @@ public class ExcludeInternalRepoByNameTest
         Indy indy = driver.getIndy(accessToken);
 
         // check that the imports from external locations are available from shared-imports
-        InputStream stream = indy.content().get(StoreType.hosted, SHARED_IMPORTS, externalPath);
+        InputStream stream = indy.content().get(StoreType.hosted, SHARED_IMPORTS_ID, externalPath);
         String downloaded = IOUtils.toString(stream);
         assertThat(downloaded, equalTo(content));
         stream.close();
 
         // check that the imports from internal/trusted locations are NOT available from shared-imports
-        stream = indy.content().get(StoreType.hosted, SHARED_IMPORTS, internalPath);
+        stream = indy.content().get(StoreType.hosted, SHARED_IMPORTS_ID, internalPath);
         assertThat(stream, nullValue());
 
     }

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/ExcludeInternalRepoByNameTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/ExcludeInternalRepoByNameTest.java
@@ -87,7 +87,7 @@ public class ExcludeInternalRepoByNameTest
         // create a dummy non-chained build execution and repo session based on it
         BuildExecution execution = new TestBuildExecution();
 
-        RepositorySession rc = driver.createBuildRepository(execution);
+        RepositorySession rc = driver.createBuildRepository(execution, accessToken);
         assertThat(rc, notNullValue());
 
         String baseUrl = rc.getConnectionInfo().getDependencyUrl();
@@ -107,7 +107,7 @@ public class ExcludeInternalRepoByNameTest
         assertThat(deps, notNullValue());
         assertThat(deps.size(), equalTo(2));
 
-        Indy indy = driver.getIndy();
+        Indy indy = driver.getIndy(accessToken);
 
         // check that the imports from external locations are available from shared-imports
         InputStream stream = indy.content().get(StoreType.hosted, SHARED_IMPORTS, externalPath);

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/ExcludeInternalRepoByRegexTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/ExcludeInternalRepoByRegexTest.java
@@ -38,7 +38,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.jboss.pnc.mavenrepositorymanager.MavenRepositoryConstants.PUBLIC_GROUP_ID;
+import static org.jboss.pnc.mavenrepositorymanager.MavenRepositoryConstants.SHARED_IMPORTS_ID;
 import static org.junit.Assert.assertThat;
 
 @Category(ContainerTest.class)
@@ -63,9 +67,9 @@ public class ExcludeInternalRepoByRegexTest
         indy.stores().create(new RemoteRepository(EXTERNAL, server.formatUrl(EXTERNAL)), "Creating external test remote repo",
                 RemoteRepository.class);
 
-        Group publicGroup = indy.stores().load(StoreType.group, PUBLIC, Group.class);
+        Group publicGroup = indy.stores().load(StoreType.group, PUBLIC_GROUP_ID, Group.class);
         if (publicGroup == null) {
-            publicGroup = new Group(PUBLIC, new StoreKey(StoreType.remote, INTERNAL), new StoreKey(StoreType.remote, EXTERNAL));
+            publicGroup = new Group(PUBLIC_GROUP_ID, new StoreKey(StoreType.remote, INTERNAL), new StoreKey(StoreType.remote, EXTERNAL));
             indy.stores().create(publicGroup, "creating public group", Group.class);
         } else {
             publicGroup.setConstituents(Arrays.asList(new StoreKey(StoreType.remote, INTERNAL), new StoreKey(StoreType.remote, EXTERNAL)));
@@ -107,13 +111,13 @@ public class ExcludeInternalRepoByRegexTest
         Indy indy = driver.getIndy(accessToken);
 
         // check that the imports from external locations are available from shared-imports
-        InputStream stream = indy.content().get(StoreType.hosted, SHARED_IMPORTS, externalPath);
+        InputStream stream = indy.content().get(StoreType.hosted, SHARED_IMPORTS_ID, externalPath);
         String downloaded = IOUtils.toString(stream);
         assertThat(downloaded, equalTo(content));
         stream.close();
 
         // check that the imports from internal/trusted locations are NOT available from shared-imports
-        stream = indy.content().get(StoreType.hosted, SHARED_IMPORTS, internalPath);
+        stream = indy.content().get(StoreType.hosted, SHARED_IMPORTS_ID, internalPath);
         assertThat(stream, nullValue());
 
     }

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/ExcludeInternalRepoByRegexTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/ExcludeInternalRepoByRegexTest.java
@@ -84,7 +84,7 @@ public class ExcludeInternalRepoByRegexTest
         // create a dummy non-chained build execution and repo session based on it
         BuildExecution execution = new TestBuildExecution();
 
-        RepositorySession rc = driver.createBuildRepository(execution);
+        RepositorySession rc = driver.createBuildRepository(execution, accessToken);
         assertThat(rc, notNullValue());
 
         String baseUrl = rc.getConnectionInfo().getDependencyUrl();
@@ -104,7 +104,7 @@ public class ExcludeInternalRepoByRegexTest
         assertThat(deps, notNullValue());
         assertThat(deps.size(), equalTo(2));
 
-        Indy indy = driver.getIndy();
+        Indy indy = driver.getIndy(accessToken);
 
         // check that the imports from external locations are available from shared-imports
         InputStream stream = indy.content().get(StoreType.hosted, SHARED_IMPORTS, externalPath);

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/ImportDepVerifyPromotionToSharedImportsTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/ImportDepVerifyPromotionToSharedImportsTest.java
@@ -47,7 +47,7 @@ public class ImportDepVerifyPromotionToSharedImportsTest extends AbstractImportT
 
         // create a dummy non-chained build execution and repo session based on it
         BuildExecution execution = new TestBuildExecution();
-        RepositorySession session = driver.createBuildRepository(execution);
+        RepositorySession session = driver.createBuildRepository(execution, accessToken);
 
         // simulate a build resolving an artifact via the AProx remote repository.
         assertThat(download(UrlUtils.buildUrl(session.getConnectionInfo().getDependencyUrl(), path)), equalTo(content));

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/ImportDepVerifyPromotionToSharedImportsTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/ImportDepVerifyPromotionToSharedImportsTest.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.jboss.pnc.mavenrepositorymanager.MavenRepositoryConstants.SHARED_IMPORTS_ID;
 import static org.junit.Assert.assertThat;
 
 @Category(ContainerTest.class)
@@ -63,7 +64,7 @@ public class ImportDepVerifyPromotionToSharedImportsTest extends AbstractImportT
         assertThat(a.getFilename(), equalTo(new File(path).getName()));
 
         // end result: you should be able to download this artifact from shared-imports now.
-        assertThat(download(indy.content().contentUrl(StoreType.hosted, SHARED_IMPORTS, path)), equalTo(content));
+        assertThat(download(indy.content().contentUrl(StoreType.hosted, SHARED_IMPORTS_ID, path)), equalTo(content));
     }
 
 }

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/IndyPromotionValidationTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/IndyPromotionValidationTest.java
@@ -69,7 +69,7 @@ public class IndyPromotionValidationTest {
 
         RepositoryManager driver = new RepositoryManagerDriver(new TestConfiguration(baseUrl));
         try {
-            RepositorySession repositorySession = driver.createBuildRepository(new TestBuildExecution("test"));
+            RepositorySession repositorySession = driver.createBuildRepository(new TestBuildExecution("test"), null);
             CloseableHttpClient client = HttpClientBuilder.create().build();
             String deployUrl = repositorySession.getConnectionInfo().getDeployUrl();
 

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/UploadOneThenDownloadAndVerifyArtifactHasOriginUrlTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/UploadOneThenDownloadAndVerifyArtifactHasOriginUrlTest.java
@@ -51,7 +51,7 @@ public class UploadOneThenDownloadAndVerifyArtifactHasOriginUrlTest
     public void extractBuildArtifacts_ContainsTwoUploads() throws Exception {
         // create a dummy non-chained build execution and repo session based on it
         BuildExecution execution = new TestBuildExecution();
-        RepositorySession rc = driver.createBuildRepository(execution);
+        RepositorySession rc = driver.createBuildRepository(execution, accessToken);
 
         assertThat(rc, notNullValue());
 

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/UploadTwoThenVerifyExtractedArtifactsContainThemTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/UploadTwoThenVerifyExtractedArtifactsContainThemTest.java
@@ -54,7 +54,7 @@ public class UploadTwoThenVerifyExtractedArtifactsContainThemTest
     public void extractBuildArtifacts_ContainsTwoUploads() throws Exception {
         // create a dummy non-chained build execution and repo session based on it
         BuildExecution execution = new TestBuildExecution();
-        RepositorySession rc = driver.createBuildRepository(execution);
+        RepositorySession rc = driver.createBuildRepository(execution, accessToken);
 
         assertThat(rc, notNullValue());
 
@@ -94,7 +94,7 @@ public class UploadTwoThenVerifyExtractedArtifactsContainThemTest
                     equalTo(true));
         }
 
-        Indy indy = driver.getIndy();
+        Indy indy = driver.getIndy(accessToken);
 
         // check that we can download the two files from the build repository
         for (String path : new String[] { pomPath, jarPath }) {

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyBuildGroupRemovedAfterArtifactExtractionTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyBuildGroupRemovedAfterArtifactExtractionTest.java
@@ -47,10 +47,10 @@ public class VerifyBuildGroupRemovedAfterArtifactExtractionTest extends Abstract
 
         // create a dummy composed (chained) build execution, and a repo session based on it
         BuildExecution execution = new TestBuildExecution(buildId);
-        RepositorySession session = driver.createBuildRepository(execution);
+        RepositorySession session = driver.createBuildRepository(execution, accessToken);
 
         // simulate a build deploying a file.
-        driver.getIndy().module(IndyFoloContentClientModule.class)
+        driver.getIndy(accessToken).module(IndyFoloContentClientModule.class)
                 .store(buildId, StoreType.hosted, buildId, path, new ByteArrayInputStream(content.getBytes()));
 
         // now, extract the build artifacts. This will trigger promotion of the build hosted repo to the chain group.
@@ -64,7 +64,7 @@ public class VerifyBuildGroupRemovedAfterArtifactExtractionTest extends Abstract
         assertThat(a.getFilename(), equalTo(new File(path).getName()));
 
         // end result: the build aggregation group should have been garbage collected
-        boolean buildGroupExists = driver.getIndy().stores().exists(StoreType.group, buildId);
+        boolean buildGroupExists = driver.getIndy(accessToken).stores().exists(StoreType.group, buildId);
         assertThat(buildGroupExists, equalTo(false));
     }
 

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyBuildRepoPromotionToUntestedBuildsGroupTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyBuildRepoPromotionToUntestedBuildsGroupTest.java
@@ -34,11 +34,12 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.util.List;
 
+import static org.jboss.pnc.mavenrepositorymanager.MavenRepositoryConstants.UNTESTED_BUILDS_GROUP;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 @Category(ContainerTest.class)
-public class VerifyBuildRepoPromotionToUntestedBuildsGroupTest extends AbstractRepositoryManagerDriverTest {
+public class VerifyBuildRepoPromotionToUntestedBuildsGroupTest extends AbstractImportTest {
 
     @Test
     public void extractBuildArtifactsTriggersBuildRepoPromotionToChainGroup() throws Exception {
@@ -66,7 +67,7 @@ public class VerifyBuildRepoPromotionToUntestedBuildsGroupTest extends AbstractR
         assertThat(a.getFilename(), equalTo(new File(path).getName()));
 
         // end result: the untested-builds group should contain the build hosted repo.
-        Group untestedBuildsGroup = driver.getIndy(accessToken).stores().load(StoreType.group, MavenRepositoryConstants.UNTESTED_BUILDS_GROUP, Group.class);
+        Group untestedBuildsGroup = driver.getIndy(accessToken).stores().load(StoreType.group, UNTESTED_BUILDS_GROUP, Group.class);
         assertThat(untestedBuildsGroup.getConstituents().contains(new StoreKey(StoreType.hosted, buildId)), equalTo(true));
     }
 

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyBuildRepoPromotionToUntestedBuildsGroupTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyBuildRepoPromotionToUntestedBuildsGroupTest.java
@@ -49,10 +49,10 @@ public class VerifyBuildRepoPromotionToUntestedBuildsGroupTest extends AbstractR
 
         // create a dummy build execution, and a repo session based on it
         BuildExecution execution = new TestBuildExecution(buildId);
-        RepositorySession session = driver.createBuildRepository(execution);
+        RepositorySession session = driver.createBuildRepository(execution, accessToken);
 
         // simulate a build deploying a file.
-        driver.getIndy().module(IndyFoloContentClientModule.class)
+        driver.getIndy(accessToken).module(IndyFoloContentClientModule.class)
                 .store(buildId, StoreType.hosted, buildId, path, new ByteArrayInputStream(content.getBytes()));
 
         // now, extract the build artifacts. This will trigger promotion of the build hosted repo to the untested-builds group.
@@ -66,7 +66,7 @@ public class VerifyBuildRepoPromotionToUntestedBuildsGroupTest extends AbstractR
         assertThat(a.getFilename(), equalTo(new File(path).getName()));
 
         // end result: the untested-builds group should contain the build hosted repo.
-        Group untestedBuildsGroup = driver.getIndy().stores().load(StoreType.group, MavenRepositoryConstants.UNTESTED_BUILDS_GROUP, Group.class);
+        Group untestedBuildsGroup = driver.getIndy(accessToken).stores().load(StoreType.group, MavenRepositoryConstants.UNTESTED_BUILDS_GROUP, Group.class);
         assertThat(untestedBuildsGroup.getConstituents().contains(new StoreKey(StoreType.hosted, buildId)), equalTo(true));
     }
 

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyManualDeletionOfBuildRepoTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyManualDeletionOfBuildRepoTest.java
@@ -50,10 +50,10 @@ public class VerifyManualDeletionOfBuildRepoTest extends AbstractRepositoryManag
 
         // create a dummy non-chained build execution and a repo session based on it
         BuildExecution execution = new TestBuildExecution(buildId);
-        RepositorySession session = driver.createBuildRepository(execution);
+        RepositorySession session = driver.createBuildRepository(execution, accessToken);
 
         // simulate a build deploying a file.
-        driver.getIndy().module(IndyFoloContentClientModule.class)
+        driver.getIndy(accessToken).module(IndyFoloContentClientModule.class)
                 .store(buildId, StoreType.hosted, buildId, path, new ByteArrayInputStream(content.getBytes()));
 
         // now, extract the build artifacts. This will trigger promotion of the build hosted repo to the chain group.
@@ -71,7 +71,7 @@ public class VerifyManualDeletionOfBuildRepoTest extends AbstractRepositoryManag
         record.setBuildContentId(buildId);
 
         // manually delete the build to the public group (since it's convenient)
-        RunningRepositoryDeletion deletion = driver.deleteBuild(record);
+        RunningRepositoryDeletion deletion = driver.deleteBuild(record, accessToken);
         deletion.monitor(completed -> {
             assertThat("Manual deletion failed.", completed.isSuccessful(), equalTo(true));
         }, error -> {
@@ -80,7 +80,7 @@ public class VerifyManualDeletionOfBuildRepoTest extends AbstractRepositoryManag
         });
 
         // end result: the build hosted repo should no longer exist.
-        assertThat(driver.getIndy().stores().exists(StoreType.hosted, buildId), equalTo(false));
+        assertThat(driver.getIndy(accessToken).stores().exists(StoreType.hosted, buildId), equalTo(false));
     }
 
 }

--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyManualPromotionOfBuildRepoTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyManualPromotionOfBuildRepoTest.java
@@ -55,10 +55,10 @@ public class VerifyManualPromotionOfBuildRepoTest extends AbstractRepositoryMana
 
         // create a dummy non-chained build execution and a repo session based on it
         BuildExecution execution = new TestBuildExecution(buildId);
-        RepositorySession session = driver.createBuildRepository(execution);
+        RepositorySession session = driver.createBuildRepository(execution, accessToken);
 
         // simulate a build deploying a file.
-        driver.getIndy().module(IndyFoloContentClientModule.class)
+        driver.getIndy(accessToken).module(IndyFoloContentClientModule.class)
                 .store(buildId, StoreType.hosted, buildId, path, new ByteArrayInputStream(content.getBytes()));
 
         // now, extract the build artifacts. This will trigger promotion of the build hosted repo to the chain group.
@@ -76,7 +76,7 @@ public class VerifyManualPromotionOfBuildRepoTest extends AbstractRepositoryMana
         record.setBuildContentId(buildId);
 
         // manually promote the build to the public group (since it's convenient)
-        RunningRepositoryPromotion promotion = driver.promoteBuild(record, PUBLIC);
+        RunningRepositoryPromotion promotion = driver.promoteBuild(record, PUBLIC, accessToken);
         promotion.monitor(completed -> {
             assertThat("Manual promotion failed.", completed.isSuccessful(), equalTo(true));
         }, error -> {
@@ -85,7 +85,7 @@ public class VerifyManualPromotionOfBuildRepoTest extends AbstractRepositoryMana
         });
 
         // end result: the chain group should contain the build hosted repo.
-        Group publicGroup = driver.getIndy().stores().load(StoreType.group, PUBLIC, Group.class);
+        Group publicGroup = driver.getIndy(accessToken).stores().load(StoreType.group, PUBLIC, Group.class);
         System.out.println("public group constituents: " + publicGroup.getConstituents());
         assertThat(publicGroup.getConstituents().contains(new StoreKey(StoreType.hosted, buildId)), equalTo(true));
     }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/repositorymanager/RepositoryManagerMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/repositorymanager/RepositoryManagerMock.java
@@ -64,7 +64,8 @@ public class RepositoryManagerMock implements RepositoryManager {
     }
 
     @Override
-    public RepositorySession createBuildRepository(BuildExecution buildExecution) throws RepositoryManagerException {
+    public RepositorySession createBuildRepository(BuildExecution buildExecution, String accessToken)
+    		throws RepositoryManagerException {
 
         RepositorySession repositoryConfiguration = new RepositorySessionMock();
         return repositoryConfiguration;
@@ -76,15 +77,21 @@ public class RepositoryManagerMock implements RepositoryManager {
     }
 
     @Override
-    public RunningRepositoryPromotion promoteBuild(BuildRecord buildRecord, String toGroup)
+    public RunningRepositoryPromotion promoteBuild(BuildRecord buildRecord, String toGroup, String accessToken)
             throws RepositoryManagerException {
         return new RunningRepositoryPromotionMock(promotionSuccess, promotionError);
     }
 
     @Override
-    public RunningRepositoryDeletion deleteBuild(BuildRecord buildRecord) throws RepositoryManagerException {
+    public RunningRepositoryDeletion deleteBuild(BuildRecord buildRecord, String accessToken)
+    		throws RepositoryManagerException {
         return new RunningRepositoryDeletionMock(deletionSuccess, deletionError);
     }
+
+	@Override
+	public void close(String accessToken) {
+		// do nothing
+	}
 
     public static final class RunningRepositoryPromotionMock implements RunningRepositoryPromotion {
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <jdk.min.version>1.8</jdk.min.version>
     <maven.min.version>3.2</maven.min.version>
     <atlasVersion>0.16.0</atlasVersion>
-    <indyVersion>1.0.0</indyVersion>
+    <indyVersion>1.1.0-SNAPSHOT</indyVersion>
     <version.jboss.maven.plugin>7.5.Final</version.jboss.maven.plugin>
     <version.jboss.bom>1.0.7.Final</version.jboss.bom>
     <version.junit>4.11</version.junit>

--- a/spi/src/main/java/org/jboss/pnc/spi/repositorymanager/RepositoryManager.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/repositorymanager/RepositoryManager.java
@@ -33,10 +33,11 @@ public interface RepositoryManager {
      * repository session.
      *
      * @param buildExecution The build execution currently running
+     * @param accessToken The access token to use
      * @return The new repository session
      * @throws RepositoryManagerException If there is a problem creating the repository
      */
-    RepositorySession createBuildRepository(BuildExecution buildExecution)
+    RepositorySession createBuildRepository(BuildExecution buildExecution, String accessToken)
             throws RepositoryManagerException;
 
     /**
@@ -46,12 +47,13 @@ public interface RepositoryManager {
      *
      * @param buildRecord The build output to promote
      * @param toGroup The ID of the repository group where the build output should be promoted
+     * @param accessToken The access token to use
      *
      * @return An object representing the running promotion process, with callbacks for result and error.
      *
      * @throws RepositoryManagerException If there is a problem promoting the build
      */
-    RunningRepositoryPromotion promoteBuild(BuildRecord buildRecord, String toGroup)
+    RunningRepositoryPromotion promoteBuild(BuildRecord buildRecord, String toGroup, String accessToken)
             throws RepositoryManagerException;
 
     /**
@@ -60,12 +62,19 @@ public interface RepositoryManager {
      * Note that the operation won't start until monitoring starts for the returned {@link RunningRepositoryDeletion} instance.
      *
      * @param buildRecord The build whose artifacts/repositories should be removed
+     * @param accessToken The access token to use
      * @return An object representing the running deletion, with callbacks for result and error.
      *
      * @throws RepositoryManagerException If there is a problem deleting the build
      */
-    RunningRepositoryDeletion deleteBuild(BuildRecord buildRecord) throws RepositoryManagerException;
+    RunningRepositoryDeletion deleteBuild(BuildRecord buildRecord, String accessToken) throws RepositoryManagerException;
 
+    /**
+     * Closes connection to the repository driver for the given accessToken.
+     * @param accessToken The access token to use
+     */
+    void close(String accessToken);
+    
     boolean canManage(ArtifactRepo.Type managerType);
 
 }


### PR DESCRIPTION
For all operations it uses now the token of currently logged in user.
Therefore we had to drop the global repos setup at PNC startup, because
there is no user signed in. But it was not used anyway, because the
setup did not contain all the needed repos.

To be able to add the support we needed to use separate Indy client
for each build. That is achieved by calling init() at the beginning of
each RepositoryManager's methods and the in completeExecution there is
the connection close() called. Another option was to close the
connection after the client is not used for a period of time, but this
approach was easier to implement. We'll see if that works well.

Regarding the tests I used null token for now. I think there is the mock
used, so it should be ok. Not sure if there are any integration tests
using a live Indy instance.