### PR TITLE
[NCL-2373] Make all threadpool configurable

### DIFF
--- a/build-coordinator/pom.xml
+++ b/build-coordinator/pom.xml
@@ -59,6 +59,16 @@
       <groupId>org.jboss.pnc</groupId>
       <artifactId>bpm</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jboss</groupId>
+      <artifactId>jboss-common-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.logging</groupId>
+          <artifactId>jboss-logging-spi</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
     <!-- Remote dependencies -->
     <dependency>
@@ -179,17 +189,6 @@
     <dependency>
       <groupId>org.jacoco</groupId>
       <artifactId>org.jacoco.core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss</groupId>
-      <artifactId>jboss-common-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.logging</groupId>
-          <artifactId>jboss-logging-spi</artifactId>
-        </exclusion>
-      </exclusions>
       <scope>test</scope>
     </dependency>
 

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
@@ -21,10 +21,10 @@ import org.jboss.pnc.common.Configuration;
 import org.jboss.pnc.common.json.ConfigurationParseException;
 import org.jboss.pnc.common.json.moduleconfig.SystemConfig;
 import org.jboss.pnc.common.json.moduleprovider.PncConfigProvider;
-import org.jboss.pnc.common.monitor.PullingMonitor;
 import org.jboss.pnc.common.util.NamedThreadFactory;
 import org.jboss.pnc.coordinator.BuildCoordinationException;
 import org.jboss.pnc.coordinator.builder.datastore.DatastoreAdapter;
+import org.jboss.pnc.coordinator.monitor.PullingMonitor;
 import org.jboss.pnc.model.BuildConfigSetRecord;
 import org.jboss.pnc.model.BuildConfiguration;
 import org.jboss.pnc.model.BuildConfigurationAudited;
@@ -84,6 +84,8 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
 
     private BuildTasksInitializer buildTasksInitializer;
 
+    private PullingMonitor monitor;
+
 
     @Deprecated
     public DefaultBuildCoordinator(){} //workaround for CDI constructor parameter injection
@@ -92,7 +94,8 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
     public DefaultBuildCoordinator(DatastoreAdapter datastoreAdapter, Event<BuildCoordinationStatusChangedEvent> buildStatusChangedEventNotifier,
                                    Event<BuildSetStatusChangedEvent> buildSetStatusChangedEventNotifier, BuildSchedulerFactory buildSchedulerFactory,
                                    BuildQueue buildQueue,
-                                   Configuration configuration) {
+                                   Configuration configuration,
+                                   PullingMonitor monitor) {
         this.datastoreAdapter = datastoreAdapter;
         this.buildStatusChangedEventNotifier = buildStatusChangedEventNotifier;
         this.buildSetStatusChangedEventNotifier = buildSetStatusChangedEventNotifier;
@@ -100,6 +103,7 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
         this.configuration = configuration;
         this.buildQueue = buildQueue;
         this.buildTasksInitializer = new BuildTasksInitializer(datastoreAdapter);
+        this.monitor = monitor;
     }
 
     /**
@@ -206,7 +210,6 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
 
     private void monitorCancellation(BuildTask buildTask) {
         int cancellationTimeout = 30;
-        PullingMonitor monitor = new PullingMonitor();
 
         Runnable invokeCancelInternal = () -> {
             if (!getSubmittedBuildTasks().contains(buildTask)) {

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/monitor/MonitorException.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/monitor/MonitorException.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.jboss.pnc.common.monitor;
+package org.jboss.pnc.coordinator.monitor;
 
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/monitor/RunningTask.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/monitor/RunningTask.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.jboss.pnc.common.monitor;
+package org.jboss.pnc.coordinator.monitor;
 
 import java.time.Duration;
 import java.time.Instant;

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinatorTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinatorTest.java
@@ -20,6 +20,7 @@ package org.jboss.pnc.coordinator.builder;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jboss.pnc.common.Configuration;
 import org.jboss.pnc.coordinator.builder.datastore.DatastoreAdapter;
+import org.jboss.pnc.coordinator.monitor.PullingMonitor;
 import org.jboss.pnc.model.BuildConfigurationAudited;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.BuildStatus;
@@ -74,6 +75,9 @@ public class DefaultBuildCoordinatorTest {
     @Mock
     private Event<BuildCoordinationStatusChangedEvent> buildStatusChangedEventNotifier;
 
+    @Mock
+    private PullingMonitor monitor;
+
     @InjectMocks
     private DatastoreAdapter datastoreAdapter = new DatastoreAdapter();
 
@@ -89,7 +93,8 @@ public class DefaultBuildCoordinatorTest {
                 buildSetStatusChangedEventNotifier,
                 buildSchedulerFactory,
                 buildQueue,
-                configuration);
+                configuration,
+                monitor);
     }
 
     @Test

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/AbstractDependentBuildTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/AbstractDependentBuildTest.java
@@ -27,6 +27,7 @@ import org.jboss.pnc.coordinator.builder.BuildScheduler;
 import org.jboss.pnc.coordinator.builder.BuildSchedulerFactory;
 import org.jboss.pnc.coordinator.builder.DefaultBuildCoordinator;
 import org.jboss.pnc.coordinator.builder.datastore.DatastoreAdapter;
+import org.jboss.pnc.coordinator.monitor.PullingMonitor;
 import org.jboss.pnc.datastore.DefaultDatastore;
 import org.jboss.pnc.mock.repository.ArtifactRepositoryMock;
 import org.jboss.pnc.mock.repository.BuildConfigSetRecordRepositoryMock;
@@ -106,6 +107,7 @@ public abstract class AbstractDependentBuildTest {
         when(systemConfig.getCoordinatorThreadPoolSize()).thenReturn(1);
         when(systemConfig.getCoordinatorMaxConcurrentBuilds()).thenReturn(1);
         when(config.getModuleConfig(any())).thenReturn(systemConfig);
+        PullingMonitor monitor = new PullingMonitor();
 
         buildQueue = new BuildQueue(config);
 
@@ -126,7 +128,8 @@ public abstract class AbstractDependentBuildTest {
         coordinator = new DefaultBuildCoordinator(datastoreAdapter, mock(Event.class), mock(Event.class),
                 new MockBuildSchedulerFactory(),
                 buildQueue,
-                config);
+                config,
+                monitor);
         buildQueue.initSemaphore();
         coordinator.start();
     }

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/BuildCoordinatorDeployments.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/BuildCoordinatorDeployments.java
@@ -22,6 +22,7 @@ import org.jboss.pnc.bpm.BpmManager;
 import org.jboss.pnc.common.Configuration;
 import org.jboss.pnc.coordinator.builder.DefaultBuildCoordinator;
 import org.jboss.pnc.coordinator.builder.datastore.DatastoreAdapter;
+import org.jboss.pnc.coordinator.monitor.PullingMonitor;
 import org.jboss.pnc.model.utils.ContentIdentityManager;
 import org.jboss.pnc.coordinator.notifications.buildSetTask.BuildSetCallBack;
 import org.jboss.pnc.coordinator.notifications.buildSetTask.BuildSetStatusNotifications;
@@ -93,7 +94,9 @@ public class BuildCoordinatorDeployments {
                 .addClass(BuildEnvironment.Builder.class)
                 .addClass(TestEntitiesFactory.class)
                 .addClass(BuildCoordinatorFactory.class)
+                .addClass(PullingMonitor.class)
                 .addPackages(true,
+                        PullingMonitor.class.getPackage(),
                         BuildCoordinator.class.getPackage(),
                         DefaultBuildCoordinator.class.getPackage(),
                         BuildSetStatusNotifications.class.getPackage(),

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/BuildCoordinatorFactory.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/BuildCoordinatorFactory.java
@@ -26,6 +26,7 @@ import org.jboss.pnc.coordinator.builder.BuildQueue;
 import org.jboss.pnc.coordinator.builder.BuildSchedulerFactory;
 import org.jboss.pnc.coordinator.builder.DefaultBuildCoordinator;
 import org.jboss.pnc.coordinator.builder.datastore.DatastoreAdapter;
+import org.jboss.pnc.coordinator.monitor.PullingMonitor;
 import org.jboss.pnc.mock.datastore.DatastoreMock;
 import org.jboss.pnc.spi.coordinator.BuildCoordinator;
 import org.jboss.pnc.spi.events.BuildCoordinationStatusChangedEvent;
@@ -57,8 +58,9 @@ public class BuildCoordinatorFactory {
 
         Configuration configuration = createConfiguration();
         BuildQueue queue = new BuildQueue(configuration);
+        PullingMonitor monitor = new PullingMonitor();
         BuildCoordinator coordinator = new DefaultBuildCoordinator(datastoreAdapter, buildStatusChangedEventNotifier, buildSetStatusChangedEventNotifier,
-                buildSchedulerFactory, queue, configuration);
+                buildSchedulerFactory, queue, configuration, monitor);
         coordinator.start();
         queue.initSemaphore();
         return new BuildCoordinatorBeans(queue, coordinator);
@@ -67,7 +69,7 @@ public class BuildCoordinatorFactory {
     private Configuration createConfiguration() {
         try {
             Configuration configuration = mock(Configuration.class);
-            doReturn(new SystemConfig("ProperDriver", "local-build-scheduler", "NO_AUTH", "10", "10", "10", "10")).when(configuration)
+            doReturn(new SystemConfig("ProperDriver", "local-build-scheduler", "NO_AUTH", "10", "10", "10", "10", "10")).when(configuration)
                     .getModuleConfig(any(PncConfigProvider.class));
             return configuration;
         } catch (ConfigurationParseException e) {

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/monitor/PullingMonitorTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/monitor/PullingMonitorTest.java
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-package org.jboss.pnc.common.test.monitor;
+package org.jboss.pnc.coordinator.test.monitor;
 
-import org.jboss.pnc.common.monitor.PullingMonitor;
+import org.jboss.pnc.coordinator.monitor.PullingMonitor;
 import org.jboss.pnc.common.util.ObjectWrapper;
 import org.junit.AfterClass;
 import org.junit.Assert;

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftEnvironmentDriverModuleConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftEnvironmentDriverModuleConfig.java
@@ -36,6 +36,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
     private String restEndpointUrl;
     private String buildAgentHost;
     private String buildAgentBindPath;
+    private String executorThreadPoolSize;
 
     private String podNamespace;
     private String restAuthToken;
@@ -52,6 +53,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
                                                   @JsonProperty("nonProxyHosts") String nonProxyHosts,
                                                   @JsonProperty("podNamespace") String podNamespace,
                                                   @JsonProperty("buildAgentBindPath") String buildAgentBindPath,
+                                                  @JsonProperty("executorThreadPoolSize") String executorThreadPoolSize,
                                                   @JsonProperty("restAuthToken") String restAuthToken,
                                                   @JsonProperty("containerPort") String containerPort,
                                                   @JsonProperty("workingDirectory") String workingDirectory,
@@ -63,6 +65,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
         this.restEndpointUrl = restEndpointUrl;
         this.buildAgentHost = buildAgentHost;
         this.buildAgentBindPath = buildAgentBindPath;
+        this.executorThreadPoolSize = executorThreadPoolSize;
         this.podNamespace = podNamespace;
         this.restAuthToken = restAuthToken;
         this.containerPort = containerPort;
@@ -96,6 +99,10 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
         return buildAgentBindPath;
     }
 
+    public String getExecutorThreadPoolSize() {
+        return executorThreadPoolSize;
+    }
+
     public boolean getKeepBuildAgentInstance() {
         return keepBuildAgentInstance;
     }
@@ -116,6 +123,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
                 ", podNamespace='" + podNamespace + '\'' +
                 ", buildAgentHost='" + buildAgentHost + '\'' +
                 ", buildAgentBindPath='" + buildAgentBindPath + '\'' +
+                ", executorThreadPoolSize='" + executorThreadPoolSize + '\'' +
                 ", restAuthToken= HIDDEN " +
                 ", containerPort='" + containerPort + '\'' +
                 ", disabled='" + disabled + '\'' +

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/SystemConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/SystemConfig.java
@@ -55,6 +55,8 @@ public class SystemConfig extends AbstractModuleConfig {
      */
     private int coordinatorMaxConcurrentBuilds;
 
+    private String monitorThreadPoolSize;
+
     public SystemConfig(
             @JsonProperty("buildDriverId") String buildDriverId,
             @JsonProperty("buildSchedulerId") String buildSchedulerId,
@@ -62,7 +64,8 @@ public class SystemConfig extends AbstractModuleConfig {
             @JsonProperty("executorThreadPoolSize") String executorThreadPoolSize,
             @JsonProperty("builderThreadPoolSize") String builderThreadPoolSize,
             @JsonProperty("coordinatorThreadPoolSize") String coordinatorThreadPoolSize,
-            @JsonProperty("coordinatorMaxConcurrentBuilds") String coordinatorMaxConcurrentBuilds) {
+            @JsonProperty("coordinatorMaxConcurrentBuilds") String coordinatorMaxConcurrentBuilds,
+            @JsonProperty("monitorThreadPoolSize") String monitorThreadPoolSize) {
         this.buildDriverId = buildDriverId;
         this.buildSchedulerId = buildSchedulerId;
         this.authenticationProviderId = authenticationProviderId;
@@ -70,6 +73,7 @@ public class SystemConfig extends AbstractModuleConfig {
         this.builderThreadPoolSize = builderThreadPoolSize;
         this.coordinatorThreadPoolSize = toIntWithDefault("coordinatorThreadPoolSize", coordinatorThreadPoolSize, 1);
         this.coordinatorMaxConcurrentBuilds = toIntWithDefault("coordinatorMaxConcurrentBuilds", coordinatorMaxConcurrentBuilds, 10);
+        this.monitorThreadPoolSize = monitorThreadPoolSize;
     }
 
     public String getBuildDriverId() {
@@ -98,6 +102,10 @@ public class SystemConfig extends AbstractModuleConfig {
 
     public int getCoordinatorMaxConcurrentBuilds() {
         return coordinatorMaxConcurrentBuilds;
+    }
+
+    public String getMonitorThreadPoolSize() {
+        return monitorThreadPoolSize;
     }
 
     private int toIntWithDefault(String fieldName, String numberAsString, int defaultValue) {

--- a/openshift-environment-driver/pom.xml
+++ b/openshift-environment-driver/pom.xml
@@ -54,6 +54,10 @@
       <groupId>org.jboss.pnc</groupId>
       <artifactId>spi</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>build-coordinator</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.jboss</groupId>

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -29,7 +29,7 @@ import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
 import org.apache.commons.lang.RandomStringUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.pnc.common.json.moduleconfig.OpenshiftEnvironmentDriverModuleConfig;
-import org.jboss.pnc.common.monitor.PullingMonitor;
+import org.jboss.pnc.coordinator.monitor.PullingMonitor;
 import org.jboss.pnc.common.util.RandomUtils;
 import org.jboss.pnc.common.util.StringUtils;
 import org.jboss.pnc.spi.builddriver.DebugData;

--- a/openshift-environment-driver/src/test/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriverRemoteTest.java
+++ b/openshift-environment-driver/src/test/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriverRemoteTest.java
@@ -19,7 +19,7 @@ package org.jboss.pnc.environment.openshift;
 
 import com.openshift.internal.restclient.DefaultClient;
 import org.jboss.pnc.common.Configuration;
-import org.jboss.pnc.common.monitor.PullingMonitor;
+import org.jboss.pnc.coordinator.monitor.PullingMonitor;
 import org.jboss.pnc.common.util.ObjectWrapper;
 import org.jboss.pnc.model.ArtifactRepo;
 import org.jboss.pnc.model.SystemImageType;

--- a/termd-build-driver/src/main/java/org/jboss/pnc/termdbuilddriver/TermdBuildDriver.java
+++ b/termd-build-driver/src/main/java/org/jboss/pnc/termdbuilddriver/TermdBuildDriver.java
@@ -83,7 +83,7 @@ public class TermdBuildDriver implements BuildDriver { //TODO rename class
 
     @Inject
     public TermdBuildDriver(Configuration configuration) {
-        int threadPoolSize = 12; //TODO configurable
+        int threadPoolSize = 12;
         try {
             String executorThreadPoolSizeStr = configuration.getModuleConfig(new PncConfigProvider<>(SystemConfig.class))
                     .getBuilderThreadPoolSize();

--- a/termd-build-driver/src/test/java/org/jboss/pnc/termdbuilddriver/TermdBuildDriverTest.java
+++ b/termd-build-driver/src/test/java/org/jboss/pnc/termdbuilddriver/TermdBuildDriverTest.java
@@ -54,7 +54,7 @@ public class TermdBuildDriverTest extends AbstractLocalBuildAgentTest {
 
     @Before
     public void before() throws ConfigurationParseException {
-        doReturn(new SystemConfig(null, null, null, null, null, null, null)).when(configuration).getModuleConfig(any());
+        doReturn(new SystemConfig(null, null, null, null, null, null, null, null)).when(configuration).getModuleConfig(any());
     }
 
     @Test(timeout = 15_000)


### PR DESCRIPTION
ThreadPool now configurable in class:

- OpenshiftEnvironmentDriver
- PullingMonitor

ThreadPool *not* made configurable in class:

- JenkinsBuildMonitor (module not built)
- BuildExecutorMock (Used for testing only)

The `OpenshiftEnvironmentDriver` is configured via the
`openshift-environment-driver` config section, with key
`executorThreadPoolSize`.

The `PullingMonitor` is configured via the system config section, with
key `monitorThreadPoolSize`.

The `monitor` sub-module is moved from `common` to `coordinator` so as the
`PullingMonitor` class, found in the `monitor` sub-module, can have
access to the configuration. The `common` module cannot have access to
the configuration's module configs because of circular dependency.