### PR TITLE
[NCL-2373] Make all threadpool configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ Or you can configure the app using the environment variables listred in the file
 
 For the configuration descriptions see api doc of classes in `moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig`
 
+### PullingMonitor ThreadPool size configuration
+
+If you want to specify the ThreadPool size for `PullingMonitor`, you can do so by using the system property `pulling_monitor_threadpool`.
+
+For example, you can specify via `-Dpulling-monitor-threadpool=10` parameter
+
+You can also specify the environment variable `pulling_monitor_threadpool`.
+Note that the system property has precedence over the environment variable if both are defined.
+
 
 ## Database set-up
 

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftEnvironmentDriverModuleConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftEnvironmentDriverModuleConfig.java
@@ -36,6 +36,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
     private String restEndpointUrl;
     private String buildAgentHost;
     private String buildAgentBindPath;
+    private String executorThreadPoolSize;
 
     private String podNamespace;
     private String restAuthToken;
@@ -52,6 +53,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
                                                   @JsonProperty("nonProxyHosts") String nonProxyHosts,
                                                   @JsonProperty("podNamespace") String podNamespace,
                                                   @JsonProperty("buildAgentBindPath") String buildAgentBindPath,
+                                                  @JsonProperty("executorThreadPoolSize") String executorThreadPoolSize,
                                                   @JsonProperty("restAuthToken") String restAuthToken,
                                                   @JsonProperty("containerPort") String containerPort,
                                                   @JsonProperty("workingDirectory") String workingDirectory,
@@ -63,6 +65,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
         this.restEndpointUrl = restEndpointUrl;
         this.buildAgentHost = buildAgentHost;
         this.buildAgentBindPath = buildAgentBindPath;
+        this.executorThreadPoolSize = executorThreadPoolSize;
         this.podNamespace = podNamespace;
         this.restAuthToken = restAuthToken;
         this.containerPort = containerPort;
@@ -96,6 +99,10 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
         return buildAgentBindPath;
     }
 
+    public String getExecutorThreadPoolSize() {
+        return executorThreadPoolSize;
+    }
+
     public boolean getKeepBuildAgentInstance() {
         return keepBuildAgentInstance;
     }
@@ -116,6 +123,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
                 ", podNamespace='" + podNamespace + '\'' +
                 ", buildAgentHost='" + buildAgentHost + '\'' +
                 ", buildAgentBindPath='" + buildAgentBindPath + '\'' +
+                ", executorThreadPoolSize='" + executorThreadPoolSize + '\'' +
                 ", restAuthToken= HIDDEN " +
                 ", containerPort='" + containerPort + '\'' +
                 ", disabled='" + disabled + '\'' +


### PR DESCRIPTION
ThreadPool now configurable in class:

- OpenshiftEnvironmentDriver
- PullingMonitor

ThreadPool not made configurable in class:

- JenkinsBuildMonitor (module not built)
- BuildExecutorMock (Used for testing only)

The `OpenshiftEnvironmentDriver` is configured via the
`openshift-environment-driver` config section, with key
`executorThreadPoolSize`.

The `PullingMonitor` is configured via system properties, with key
`pulling-monitor-threadpool`. For example, you can pass:

```
-Dpulling-monitor-threadpool=15
```

parameter.