### PR TITLE
[NCL-2539] Configuration loaded multiple times

### DIFF
--- a/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
+++ b/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
@@ -65,6 +65,9 @@ class BuildExecutionBase {
     @Inject
     BuildDriverFactory buildDriverFactory;
 
+    @Inject
+    Configuration configuration;
+
     BuildExecutionStatus[] baseBuildStatuses = {
             BuildExecutionStatus.NEW,
             BuildExecutionStatus.BUILD_ENV_SETTING_UP,
@@ -114,7 +117,7 @@ class BuildExecutionBase {
                 repositoryManagerFactory,
                 buildDriverFactory,
                 environmentDriverFactory,
-                new Configuration() //TODO inject instance
+                configuration
         );
 
         runBuild(buildConfiguration, statusChangedEvents, buildExecutionResultWrapper, (e) -> {}, executor);

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/Configurations.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/Configurations.java
@@ -45,16 +45,13 @@ public enum Configurations {
 
     private final String filePath;
 
-    private Configuration configuration;
-
     Configurations(String fileName) {
         this.filePath = CONFIGURATIONS_FOLDER + fileName;
-        this.configuration = new Configuration(); //TODO Inject managed instance
     }
 
-    public String getContentAsString() {
+    public String getContentAsString(Configuration configuration) {
 
-        String content = getContentFromConfigFile();
+        String content = getContentFromConfigFile(configuration);
 
         // if no configuration in pnc-config
         if (content == null) {
@@ -68,7 +65,7 @@ public enum Configurations {
         return content;
     }
 
-    private String getContentFromConfigFile() {
+    private String getContentFromConfigFile(Configuration configuration) {
 
         OpenshiftBuildAgentConfig config = null;
 

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriver.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriver.java
@@ -57,6 +57,7 @@ public class OpenshiftEnvironmentDriver implements EnvironmentDriver {
     private ExecutorService executor;
 
     private OpenshiftEnvironmentDriverModuleConfig config;
+    private Configuration configuration;
     private PullingMonitor pullingMonitor;
 
     @Deprecated //CDI workaround
@@ -70,7 +71,7 @@ public class OpenshiftEnvironmentDriver implements EnvironmentDriver {
         this.pullingMonitor = pullingMonitor;
 
         config = configuration.getModuleConfig(new PncConfigProvider<>(OpenshiftEnvironmentDriverModuleConfig.class));
-
+        this.configuration = configuration;
         String executorThreadPoolSizeStr = config.getExecutorThreadPoolSize();
 
         if (executorThreadPoolSizeStr != null) {
@@ -94,7 +95,7 @@ public class OpenshiftEnvironmentDriver implements EnvironmentDriver {
         if (!canRunImageType(systemImageType))
             throw new UnsupportedOperationException("OpenshiftEnvironmentDriver currently provides support only for the following system image types:" + compatibleImageTypes);
         String buildImageId = StringUtils.addEndingSlash(systemImageRepositoryUrl) + systemImageId;
-        return new OpenshiftStartedEnvironment(executor, config, pullingMonitor, repositorySession, buildImageId, debugData, accessToken);
+        return new OpenshiftStartedEnvironment(executor, configuration, config, pullingMonitor, repositorySession, buildImageId, debugData, accessToken);
     }
 
     @Override


### PR DESCRIPTION
We instead use the Application Scope PNC to inject the already loaded
configuration.

This is an updated PR to #1297 . I have removed the `@Inject` in the
enum, and instead provide the configuration to the method requiring
`configuration` via the method parameter.

This is also an updated PR to #1309, resolving merge conflicts