### PR TITLE
fixed validation for empty internal repo

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProvider.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProvider.java
@@ -129,7 +129,7 @@ public class BuildConfigurationProvider extends AbstractProvider<BuildConfigurat
     public void validateInternalRepository(String internalRepoUrl) throws InvalidEntityException {
         String internalScmAuthority = moduleConfig.getInternalScmAuthority();
 
-        if (StringUtils.isNotBlank(internalScmAuthority)) {
+        if (StringUtils.isNotBlank(internalRepoUrl) && internalScmAuthority != null) {
             String expectedPrefix = "git+ssh://" + internalScmAuthority;
             if (!internalRepoUrl.startsWith(expectedPrefix)) {
                 throw new InvalidEntityException("Internal repository url has to start with: " + expectedPrefix);


### PR DESCRIPTION
When someone enters internal repo URL, and then erases it, the UI sends an empty string to the backend.

This commit fixes validation so that the empty URL is not checked against the required SCM prefix.