### PR TITLE
[NCL-2775] Weird date when closing a milestone

### DIFF
--- a/ui/app/milestone/milestone-controllers.js
+++ b/ui/app/milestone/milestone-controllers.js
@@ -204,7 +204,13 @@
       that.data = milestoneDetail;
 
       // date component <- timestamp
-      that.endDate = new Date(that.data.endDate);
+
+      // if endDate is not set yet, use the plannedEndDate instead
+      if (that.data.endDate === null) {
+        that.endDate = new Date(that.data.plannedEndDate);
+      } else {
+        that.endDate = new Date(that.data.endDate);
+      }
 
       that.submit = function() {
 


### PR DESCRIPTION
The issue was caused because `that.data.endDate` is null but
`that.data.plannedEndDate` is generally not.

The fix is to check if `that.data.endDate` is null; if it is then use
the `that.data.plannedEndDate` as value, else use `that.data.endDate`.

Before:
![bad](https://cloud.githubusercontent.com/assets/630746/22265277/65d3fc60-e249-11e6-8e87-17a5ebd9dbad.png)

The JS object:
![planned_end_date](https://cloud.githubusercontent.com/assets/630746/22265294/78c9c3fe-e249-11e6-9c6a-540b73ce6ec5.png)

With the fix:
![solved](https://cloud.githubusercontent.com/assets/630746/22265307/88d543ae-e249-11e6-9fdc-3e0caaa5e60f.png)

