### PR TITLE
[NCL-2909] Use latest builder image on Openshift

### DIFF
--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriver.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriver.java
@@ -94,8 +94,7 @@ public class OpenshiftEnvironmentDriver implements EnvironmentDriver {
 
         if (!canRunImageType(systemImageType))
             throw new UnsupportedOperationException("OpenshiftEnvironmentDriver currently provides support only for the following system image types:" + compatibleImageTypes);
-        String buildImageId = StringUtils.addEndingSlash(systemImageRepositoryUrl) + systemImageId;
-        return new OpenshiftStartedEnvironment(executor, configuration, config, pullingMonitor, repositorySession, buildImageId, debugData, accessToken);
+        return new OpenshiftStartedEnvironment(executor, configuration, config, pullingMonitor, repositorySession, systemImageRepositoryUrl, systemImageId, debugData, accessToken);
     }
 
     @Override

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.environment.openshift;
 
+import com.openshift.internal.restclient.model.ImageStream;
 import com.openshift.internal.restclient.model.Pod;
 import com.openshift.internal.restclient.model.Route;
 import com.openshift.internal.restclient.model.Service;
@@ -77,7 +78,8 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
     private final Configuration configuration;
     private final OpenshiftEnvironmentDriverModuleConfig environmentConfiguration;
     private final PullingMonitor pullingMonitor;
-    private final String imageId;
+    private final String systemImageRepositoryUrl;
+    private final String systemImageId;
     private final DebugData debugData;
     private final Set<Selector> initialized = new HashSet<>();
     private final Map<String, String> runtimeProperties;
@@ -104,18 +106,21 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
             OpenshiftEnvironmentDriverModuleConfig environmentConfiguration,
             PullingMonitor pullingMonitor,
             RepositorySession repositorySession,
+            String systemImageRepositoryUrl,
             String systemImageId,
             DebugData debugData,
             String accessToken) {
 
-        logger.info("Creating new build environment using image id: " + environmentConfiguration.getImageId());
 
         this.configuration = configuration;
         this.environmentConfiguration = environmentConfiguration;
         this.pullingMonitor = pullingMonitor;
         this.repositorySession = repositorySession;
-        this.imageId = systemImageId == null ? environmentConfiguration.getImageId() : systemImageId;
+        this.systemImageRepositoryUrl = systemImageRepositoryUrl;
+        this.systemImageId = systemImageId;
         this.debugData = debugData;
+
+        logger.info("Creating new build environment using image id: " + getBuildImageId());
 
         createRoute = environmentConfiguration.getExposeBuildAgentOnPublicUrl();
 
@@ -376,7 +381,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
                 && !StringUtils.isEmpty(environmentConfiguration.getProxyPort());
 
         Properties properties = new Properties();
-        properties.put("image", imageId);
+        properties.put("image", getBuildImageWithSha());
         properties.put("containerPort", environmentConfiguration.getContainerPort());
         properties.put("firewallAllowedDestinations", environmentConfiguration.getFirewallAllowedDestinations());
         properties.put("isHttpActive", proxyActive.toString().toLowerCase());
@@ -445,5 +450,36 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
 
         logger.debug("Got {} from {}.", responseCode, url);
         return responseCode == 200;
+    }
+
+    private String getBuildImageId() {
+        return StringUtils.addEndingSlash(systemImageRepositoryUrl) + systemImageId;
+    }
+
+    /**
+     * Generate build image link from systemImageId and systemImageRepositoryUrl and use the image sha instead
+     *
+     * Instead of using <url>/<image>:<tag>, it'll return <url>/<image>@<sha of image of latest tag>
+     *
+     * This will help Openshift slave nodes to always use the latest image for a particular tag
+     *
+     * See NCL-2909 for more information
+     *
+     * @return url link of build image
+     */
+    private String getBuildImageWithSha() {
+        // systemImageId is usually in the format '<image>:<tag>'
+        String[] imageNameAndTag = systemImageId.split(":");
+
+        String imageName = imageNameAndTag[0];
+        // if tag not specified, assume it is 'latest'
+        String imageTag = imageNameAndTag.length > 1 ? imageNameAndTag[1] : "latest";
+
+        ImageStream is = client.get(ResourceKind.IMAGE_STREAM, imageName, environmentConfiguration.getPncNamespace());
+        String shaOfLatestImageTag = is.getImageId(imageTag);
+
+        // new build image is now: '<image>@<sha>'
+        String reconstructedImageSha = imageName + "@" + shaOfLatestImageTag;
+        return StringUtils.addEndingSlash(systemImageRepositoryUrl) + reconstructedImageSha;
     }
 }


### PR DESCRIPTION
Issue
-----

PNC creates new pods used to run builds. Those pods use as image, builder
images with a tag associated with it (<builder image>:<tag, e.g latest>). I'll
use the tag 'latest' as example from now on.

When Openshift starts the pod in one of its Openshift slaves, there are some
cases when the Openshift slave chosen already has the builder image with tag
'latest' in its local docker storage.

There is an issue that arises whenever we rebuild a new builder image with tag
latest on Openshift, and try to start a new pod with image <builder>:latest on
that Openshift slave.

The Openshift slave doesn't attempt to check with docker registry if there is a
newer builder image with tag 'latest', but instead reuses the one in its local
docker storage. This causes us lots of issues because we can never be sure
which builder image we are actually using.

Fix
---
Once PNC wants to start a new build with image <builder>:latest, we ask the
Openshift instance for the latest image id of <builder>:latest instead.

Now having the latest image id, instead of creating the pod with image
<builder>:latest, I'll instead create the pod with image <builder>@<imageid>
(from: https://docs.openshift.com/container-platform/3.3/dev_guide/managing_images.html#referencing-images-in-image-streams)

This should in theory force the Openshift slave to fetch that particular
imageid from docker registry, which means that it'll force the Openshift slave
to always get the latest image for <builder>:latest and we won't suffer from
using the older builder image cached in the local docker storage anymore.

Notice
------
This commit will remove the use of the default build image id specified in
the pnc-config.