### PR TITLE
[NCL-2913] Make PNC work with OSE 3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -592,7 +592,7 @@
       <dependency>
         <groupId>com.openshift</groupId>
         <artifactId>openshift-restclient-java</artifactId>
-        <version>4.0.5.Final</version>
+        <version>5.5.0.Final</version>
         <exclusions>
           <exclusion>
             <groupId>log4j</groupId>


### PR DESCRIPTION
This is done by bumping the openshift-restclient-java library to
v5.5.0.Final. The older one (v4.0.5.Final) is not compatible with OSE
3.4 it seems in regards to obtaining the cluster IP of a service.

The way to create a new `IClient` object had to be modified since the
old one is now removed in v5.5.0.Final. The `getUser()` method is no
more, so I decided to use an alternate one.