### PR TITLE
Remove secret mount from build agent pod def

### DIFF
--- a/openshift-environment-driver/src/main/resources/openshift.configurations/pnc-builder-pod.json
+++ b/openshift-environment-driver/src/main/resources/openshift.configurations/pnc-builder-pod.json
@@ -10,14 +10,6 @@
         "nodeSelector": {
             "acceptpncbuildagent" : "true"
         },
-        "volumes": [
-            {
-                "name": "volume-tls-certs-pem",
-                "secret": {
-                    "secretName": "tls-certificates-pem"
-                }
-            }
-        ],
         "containers": [
             {
                 "name": "pnc-build-agent-container",
@@ -84,12 +76,6 @@
                     }
                 ],
                 "resources": {},
-                "volumeMounts": [
-                    {
-                        "name": "volume-tls-certs-pem",
-                        "mountPath": "/etc/pki/tls/certs"
-                    }
-                ],
                 "terminationMessagePath": "/dev/termination-log",
                 "imagePullPolicy": "Always",
                 "securityContext": {


### PR DESCRIPTION
We don't need that secret mount anymore. That mount contains TLS certs;
however these certs are already mounted into the builder image pods, so
it's not necessary to have the secret mounted.