### PR TITLE
[NCL-2954] Add opt to only allow some http methods

### DIFF
--- a/build-coordinator/src/test/resources/pnc-config-one-parallel-only.json
+++ b/build-coordinator/src/test/resources/pnc-config-one-parallel-only.json
@@ -45,6 +45,7 @@
                     "proxyServer": "${env.PNC_DOCKER_PROXY_SERVER}",
                     "proxyPort": "${env.PNC_DOCKER_PROXY_PORT}",
                     "firewallAllowedDestinations": "${env.PNC_FIREWALL_ALLOWED_DESTINATIONS}",
+                    "allowedHttpOutgoingDestinations": [],
                     "restEndpointUrl": "${env.PNC_REST_ENDPOINT_URL}",
                     "restAuthToken": "${env.PNC_REST_AUTH_TOKEN}",
                     "buildAgentHost": "${env.PNC_BUILD_AGENT_HOST}",

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/EnvironmentDriverModuleConfigBase.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/EnvironmentDriverModuleConfigBase.java
@@ -19,6 +19,9 @@
 package org.jboss.pnc.common.json.moduleconfig;
 
 import org.jboss.pnc.common.json.AbstractModuleConfig;
+import org.jboss.pnc.common.json.moduleconfig.helper.HttpDestinationConfig;
+
+import java.util.List;
 
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
@@ -37,6 +40,17 @@ public class EnvironmentDriverModuleConfigBase extends AbstractModuleConfig {
      * all network traffic will be dropped
      */
     protected String firewallAllowedDestinations;
+
+    /**
+     * List of Http destinations; The Http Destination needs to specify the url, port (optional), and the
+     * allowed Http method to allow.
+     *
+     * If you want to specify all the Http methods, specify the destination in the 'firewallAllowedDestinations'
+     * section instead.
+     *
+     * Format: [{"url": "\<url\>", "allowedMethods": "PUT,POST"}, ...]
+     */
+    protected List<HttpDestinationConfig> allowedHttpOutgoingDestinations;
 
     /**
      * Persistent http proxy hostname
@@ -62,6 +76,7 @@ public class EnvironmentDriverModuleConfigBase extends AbstractModuleConfig {
     public EnvironmentDriverModuleConfigBase(
             String imageId,
             String firewallAllowedDestinations,
+            List<HttpDestinationConfig> allowedHttpOutgoingDestinations,
             String proxyServer,
             String proxyPort,
             String nonProxyHosts,
@@ -70,6 +85,7 @@ public class EnvironmentDriverModuleConfigBase extends AbstractModuleConfig {
 
         this.imageId = imageId;
         this.firewallAllowedDestinations = firewallAllowedDestinations;
+        this.allowedHttpOutgoingDestinations = allowedHttpOutgoingDestinations;
         this.proxyServer = proxyServer;
         this.proxyPort = proxyPort;
         this.nonProxyHosts = nonProxyHosts;
@@ -94,6 +110,10 @@ public class EnvironmentDriverModuleConfigBase extends AbstractModuleConfig {
     }
     public String getFirewallAllowedDestinations() {
         return firewallAllowedDestinations;
+    }
+
+    public List<HttpDestinationConfig> getAllowedHttpOutgoingDestinations() {
+        return allowedHttpOutgoingDestinations;
     }
 
     public String getWorkingDirectory() {

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftEnvironmentDriverModuleConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftEnvironmentDriverModuleConfig.java
@@ -18,8 +18,11 @@
 package org.jboss.pnc.common.json.moduleconfig;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jboss.pnc.common.json.moduleconfig.helper.HttpDestinationConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
  * Configuration for DockerEnvironmentDriver
@@ -48,6 +51,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
                                                   @JsonProperty("buildAgentHost") String buildAgentHost,
                                                   @JsonProperty("imageId") String imageId,
                                                   @JsonProperty("firewallAllowedDestinations") String firewallAllowedDestinations,
+                                                  @JsonProperty("allowedHttpOutgoingDestinations") List<HttpDestinationConfig> allowedHttpOutgoingDestinations,
                                                   @JsonProperty("proxyServer") String proxyServer,
                                                   @JsonProperty("proxyPort") String proxyPort,
                                                   @JsonProperty("nonProxyHosts") String nonProxyHosts,
@@ -60,7 +64,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
                                                   @JsonProperty("disabled") Boolean disabled,
                                                   @JsonProperty("keepBuildAgentInstance") Boolean keepBuildAgentInstance,
                                                   @JsonProperty("exposeBuildAgentOnPublicUrl") Boolean exposeBuildAgentOnPublicUrl) {
-        super(imageId, firewallAllowedDestinations, proxyServer, proxyPort, nonProxyHosts,workingDirectory, disabled);
+        super(imageId, firewallAllowedDestinations, allowedHttpOutgoingDestinations, proxyServer, proxyPort, nonProxyHosts,workingDirectory, disabled);
 
         this.restEndpointUrl = restEndpointUrl;
         this.buildAgentHost = buildAgentHost;
@@ -117,6 +121,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
                 "restEndpointUrl='" + restEndpointUrl + '\'' +
                 ", imageId='" + imageId + '\'' +
                 ", firewallAllowedDestinations='" + firewallAllowedDestinations + '\'' +
+                ", allowedHttpOutgoingDestinations='" + allowedHttpOutgoingDestinations + '\'' +
                 ", proxyServer='" + proxyServer + '\'' +
                 ", proxyPort='" + proxyPort + '\'' +
                 ", nonProxyHosts='" + nonProxyHosts + '\'' +

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/helper/HttpDestinationConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/helper/HttpDestinationConfig.java
@@ -1,0 +1,46 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.common.json.moduleconfig.helper;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class HttpDestinationConfig {
+    private String url;
+    private String allowedMethods;
+
+    public HttpDestinationConfig(@JsonProperty("url") String url, @JsonProperty("allowedMethods") String allowedMethods) {
+        this.url = url;
+        this.allowedMethods = allowedMethods;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getAllowedMethods() {
+        return allowedMethods;
+    }
+
+    @Override
+    public String toString() {
+        return "HttpDestinationConfig{" +
+                "url='" + url + '\'' +
+                ", allowedMethods='" + allowedMethods + '\'' +
+                '}';
+    }
+}

--- a/moduleconfig/src/main/resources/pnc-config.json
+++ b/moduleconfig/src/main/resources/pnc-config.json
@@ -45,6 +45,7 @@
                     "proxyServer": "${env.PNC_DOCKER_PROXY_SERVER}",
                     "proxyPort": "${env.PNC_DOCKER_PROXY_PORT}",
                     "firewallAllowedDestinations": "${env.PNC_FIREWALL_ALLOWED_DESTINATIONS}",
+                    "allowedHttpOutgoingDestinations": [],
                     "restEndpointUrl": "${env.PNC_REST_ENDPOINT_URL}",
                     "restAuthToken": "${env.PNC_REST_AUTH_TOKEN}",
                     "buildAgentHost": "${env.PNC_BUILD_AGENT_HOST}",

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -17,6 +17,8 @@
  */
 package org.jboss.pnc.environment.openshift;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openshift.internal.restclient.model.Pod;
 import com.openshift.internal.restclient.model.Route;
 import com.openshift.internal.restclient.model.Service;
@@ -378,6 +380,8 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         properties.put("image", imageId);
         properties.put("containerPort", environmentConfiguration.getContainerPort());
         properties.put("firewallAllowedDestinations", environmentConfiguration.getFirewallAllowedDestinations());
+        // This property sent as Json
+        properties.put("allowedHttpOutgoingDestinations", toJson(environmentConfiguration.getAllowedHttpOutgoingDestinations()));
         properties.put("isHttpActive", proxyActive.toString().toLowerCase());
         properties.put("proxyServer", environmentConfiguration.getProxyServer());
         properties.put("proxyPort", environmentConfiguration.getProxyPort());
@@ -444,5 +448,16 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
 
         logger.debug("Got {} from {}.", responseCode, url);
         return responseCode == 200;
+    }
+
+
+    private String toJson(Object object) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.writeValueAsString(object);
+        } catch(JsonProcessingException e) {
+            logger.error("Could not parse object: " + object, e);
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/openshift-environment-driver/src/main/resources/openshift.configurations/pnc-builder-pod.json
+++ b/openshift-environment-driver/src/main/resources/openshift.configurations/pnc-builder-pod.json
@@ -35,6 +35,10 @@
                         "value": "${firewallAllowedDestinations}"
                     },
                     {
+                        "name": "allowedHttpOutgoingDestinations",
+                        "value": "${allowedHttpOutgoingDestinations}"
+                    },
+                    {
                         "name": "isHttpActive",
                         "value": "${isHttpActive}"
                     },

--- a/openshift-environment-driver/src/test/resources/pnc-config.json
+++ b/openshift-environment-driver/src/test/resources/pnc-config.json
@@ -6,6 +6,7 @@
               "proxyServer":"${env.PNC_DOCKER_PROXY_SERVER}",
               "proxyPort":"${env.PNC_DOCKER_PROXY_PORT}",
               "firewallAllowedDestinations":"${env.PNC_FIREWALL_ALLOWED_DESTINATIONS}",
+              "allowedHttpOutgoingDestinations": [],
               "restEndpointUrl":"${env.PNC_REST_ENDPOINT_URL}",
               "restAuthToken":"${env.PNC_REST_AUTH_TOKEN}",
               "buildAgentBindPath":"${env.PNC_BUILD_AGENT_BIND_PATH}",


### PR DESCRIPTION
Add option to only allow some HTTP methods for a url. You can also
specify the port of the url.

The option is specified in pnc-config.json as such:

```
...
"firewallAllowedDestinations": "...",
"allowedHttpOutgoingDestinations": [
    {"url": "<url>", allowedMethods: "PUT,POST"},
    ...
]
```

If the same URL is specified in both `firewallAllowedDestinations` and
`allowedHttpOutgoingDestinations`, the one in the latter has higher
priority than the former. This is enforced in the startup script running
in the builder pods.