### PR TITLE
Fix nested JSON statement for allowedHttpOutgoingDestinations

### DIFF
--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.environment.openshift;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openshift.internal.restclient.model.Pod;
 import com.openshift.internal.restclient.model.Route;
@@ -381,7 +382,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         properties.put("containerPort", environmentConfiguration.getContainerPort());
         properties.put("firewallAllowedDestinations", environmentConfiguration.getFirewallAllowedDestinations());
         // This property sent as Json
-        properties.put("allowedHttpOutgoingDestinations", toJson(environmentConfiguration.getAllowedHttpOutgoingDestinations()));
+        properties.put("allowedHttpOutgoingDestinations", toEscapedJsonString(environmentConfiguration.getAllowedHttpOutgoingDestinations()));
         properties.put("isHttpActive", proxyActive.toString().toLowerCase());
         properties.put("proxyServer", environmentConfiguration.getProxyServer());
         properties.put("proxyPort", environmentConfiguration.getProxyPort());
@@ -451,10 +452,18 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
     }
 
 
-    private String toJson(Object object) {
+    /**
+     * Return an escaped string of the JSON representation of the object
+     *
+     * By 'escaped', it means that strings like '"' are escaped to '\"'
+     * @param object object to marshall
+     * @return Escaped Json String
+     */
+    private String toEscapedJsonString(Object object) {
         ObjectMapper mapper = new ObjectMapper();
+        JsonStringEncoder jsonStringEncoder = JsonStringEncoder.getInstance();
         try {
-            return mapper.writeValueAsString(object);
+            return new String(jsonStringEncoder.quoteAsString(mapper.writeValueAsString(object)));
         } catch(JsonProcessingException e) {
             logger.error("Could not parse object: " + object, e);
             throw new RuntimeException(e);


### PR DESCRIPTION
So we were putting a JSON string inside another JSON structure. However,
we forgot to properly escape the JSON string.

The situation we were getting into is:

```
{
    "name": "allowedHttpOutgoingDestinations",
    "value": "[{"url":"http://haha.com","allowedMethods":"PUT"}]"
},
```

This is obviously wrong JSON. The value of the key 'value' should have
its string escaped to produce valid JSON.

```
{
    "name": "allowedHttpOutgoingDestinations",
    "value": "[{\"url\":\"http://haha.com\",\"allowedMethods\":\"PUT\"}]"
},

```

This commit fixes that bug.