### PR TITLE
[NCL-3028] Provide origin repository to BEC

### DIFF
--- a/bpm/src/main/java/org/jboss/pnc/bpm/task/BpmBuildTask.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/task/BpmBuildTask.java
@@ -80,6 +80,7 @@ public class BpmBuildTask extends BpmTask {
                 //TODO update to use also other parts or Repository Configuration
                 buildConfiguration.getRepositoryConfiguration().getInternalUrl(),
                 buildConfiguration.getScmRevision(),
+                buildConfiguration.getRepositoryConfiguration().getExternalUrl(),
                 buildConfiguration.getRepositoryConfiguration().isPreBuildSyncEnabled(),
                 buildConfiguration.getBuildEnvironment().getSystemImageId(),
                 buildConfiguration.getBuildEnvironment().getSystemImageRepositoryUrl(),

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/local/LocalBuildScheduler.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/local/LocalBuildScheduler.java
@@ -83,6 +83,7 @@ public class LocalBuildScheduler implements BuildScheduler {
                 configuration.getName(),
                 configuration.getRepositoryConfiguration().getInternalUrl(),
                 configuration.getScmRevision(),
+                configuration.getRepositoryConfiguration().getExternalUrl(),
                 configuration.getRepositoryConfiguration().isPreBuildSyncEnabled(),
                 configuration.getBuildEnvironment().getSystemImageId(),
                 configuration.getBuildEnvironment().getSystemImageRepositoryUrl(),

--- a/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionConfiguration.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionConfiguration.java
@@ -35,6 +35,7 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
     private final String name;
     private final String scmRepoURL;
     private final String scmRevision;
+    private final String originRepoURL;
     private final boolean preBuildSyncEnabled;
     private final String systemImageId;
     private final String systemImageRepositoryUrl;
@@ -50,6 +51,7 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
             String name,
             String scmRepoURL,
             String scmRevision,
+            String originRepoURL,
             boolean preBuildSyncEnabled,
             String systemImageId,
             String systemImageRepositoryUrl,
@@ -64,6 +66,7 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
         this.name = name;
         this.scmRepoURL = scmRepoURL;
         this.scmRevision = scmRevision;
+        this.originRepoURL = originRepoURL;
         this.preBuildSyncEnabled = preBuildSyncEnabled;
         this.systemImageId = systemImageId;
         this.systemImageRepositoryUrl = systemImageRepositoryUrl;
@@ -105,6 +108,11 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
     @Override
     public String getScmRevision() {
         return scmRevision;
+    }
+
+    @Override
+    public String getOriginRepoURL() {
+        return originRepoURL;
     }
 
     @Override

--- a/build-executor/src/test/java/org/jboss/pnc/executor/BuildEnvironmentTest.java
+++ b/build-executor/src/test/java/org/jboss/pnc/executor/BuildEnvironmentTest.java
@@ -147,6 +147,7 @@ public class BuildEnvironmentTest {
                 buildConfiguration.getName(),
                 buildConfiguration.getRepositoryConfiguration().getInternalUrl(),
                 buildConfiguration.getScmRevision(),
+                buildConfiguration.getRepositoryConfiguration().getExternalUrl(),
                 buildConfiguration.getRepositoryConfiguration().isPreBuildSyncEnabled(),
                 buildConfiguration.getBuildEnvironment().getSystemImageId(),
                 buildConfiguration.getBuildEnvironment().getSystemImageRepositoryUrl(),

--- a/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
+++ b/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
@@ -150,6 +150,7 @@ class BuildExecutionBase {
                 buildConfiguration.getName(),
                 buildConfiguration.getRepositoryConfiguration().getInternalUrl(),
                 buildConfiguration.getScmRevision(),
+                buildConfiguration.getRepositoryConfiguration().getExternalUrl(),
                 buildConfiguration.getRepositoryConfiguration().isPreBuildSyncEnabled(),
                 buildConfiguration.getBuildEnvironment().getSystemImageId(),
                 buildConfiguration.getBuildEnvironment().getSystemImageRepositoryUrl(),

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildTasksRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildTasksRestTest.java
@@ -89,7 +89,7 @@ public class BuildTasksRestTest extends AbstractTest{
 
         BuildExecutionConfiguration buildExecutionConfig = BuildExecutionConfiguration.build(
                 1, "test-content-id", 1, "mvn clean install", "jboss-modules", "scm-url", "master",
-                false, "dummy-docker-image-id", "dummy.repo.url/repo", SystemImageType.DOCKER_IMAGE, false, new HashMap<>());
+                "origin-scm-url", false, "dummy-docker-image-id", "dummy.repo.url/repo", SystemImageType.DOCKER_IMAGE, false, new HashMap<>());
 
         BuildExecutionConfigurationRest buildExecutionConfigurationRest = new BuildExecutionConfigurationRest(buildExecutionConfig);
 

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionConfigurationMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionConfigurationMock.java
@@ -36,6 +36,7 @@ public class BuildExecutionConfigurationMock implements BuildExecutionConfigurat
     private String name;
     private String scmRepoURL;
     private String scmRevision;
+    private String originRepoURL;
     private boolean preBuildSyncEnabled;
     private String systemImageId;
     private String systemImageRepositoryUrl;
@@ -107,6 +108,14 @@ public class BuildExecutionConfigurationMock implements BuildExecutionConfigurat
 
     public String getScmRevision() {
         return scmRevision;
+    }
+
+    public String getOriginRepoURL() {
+        return originRepoURL;
+    }
+
+    public void setOriginRepoURL(String originRepoURL) {
+        this.originRepoURL = originRepoURL;
     }
 
     public void setScmRevision(String scmRevision) {

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/spi/BuildExecutionConfigurationMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/spi/BuildExecutionConfigurationMock.java
@@ -38,6 +38,7 @@ public class BuildExecutionConfigurationMock {
                 "configuration name",
                 "https://pathToRepo.git",
                 "1111111",
+                "https://pathToOriginRepo.git",
                 false,
                 DEFAULT_SYSTEM_IMAGE_ID,
                 "image.repo.url/repo",

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
@@ -44,6 +44,7 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
 
     private String scmRepoURL;
     private String scmRevision;
+    private String originRepoURL;
     private boolean preBuildSyncEnabled;
 
     private String systemImageId;
@@ -73,6 +74,7 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
         name = buildExecutionConfiguration.getName();
         scmRepoURL = buildExecutionConfiguration.getScmRepoURL();
         scmRevision = buildExecutionConfiguration.getScmRevision();
+        originRepoURL = buildExecutionConfiguration.getOriginRepoURL();
         preBuildSyncEnabled = buildExecutionConfiguration.isPreBuildSyncEnabled();
         systemImageId = buildExecutionConfiguration.getSystemImageId();
         systemImageRepositoryUrl = buildExecutionConfiguration.getSystemImageRepositoryUrl();
@@ -91,6 +93,7 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
                 name,
                 scmRepoURL,
                 scmRevision,
+                originRepoURL,
                 preBuildSyncEnabled,
                 systemImageId,
                 systemImageRepositoryUrl,
@@ -139,6 +142,10 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
         this.scmRevision = scmRevision;
     }
 
+    public void setOriginRepoURL(String originRepoURL) {
+        this.originRepoURL = originRepoURL;
+    }
+
     public void setPreBuildSyncEnabled(boolean preBuildSyncEnabled) {
         this.preBuildSyncEnabled = preBuildSyncEnabled;
     }
@@ -171,6 +178,10 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
 
     public String getScmRevision() {
         return scmRevision;
+    }
+
+    public String getOriginRepoURL() {
+        return originRepoURL;
     }
 
     public boolean isPreBuildSyncEnabled() {

--- a/rest-model/src/test/java/org/jboss/pnc/restmodel/serialization/BuildExecutionConfigurationTest.java
+++ b/rest-model/src/test/java/org/jboss/pnc/restmodel/serialization/BuildExecutionConfigurationTest.java
@@ -47,6 +47,7 @@ public class BuildExecutionConfigurationTest {
                 "configuration name",
                 "https://pathToRepo.git",
                 "1111111",
+                "https://pathToOriginRepo.git",
                 false,
                 "abcd1234",
                 "image.repo.url/repo",
@@ -68,6 +69,7 @@ public class BuildExecutionConfigurationTest {
         Assert.assertEquals(message, buildExecutionConfiguration.getName(), buildExecutionConfigurationFromJson.getName());
         Assert.assertEquals(message, buildExecutionConfiguration.getScmRepoURL(), buildExecutionConfigurationFromJson.getScmRepoURL());
         Assert.assertEquals(message, buildExecutionConfiguration.getScmRevision(), buildExecutionConfigurationFromJson.getScmRevision());
+        Assert.assertEquals(message, buildExecutionConfiguration.getOriginRepoURL(), buildExecutionConfigurationFromJson.getOriginRepoURL());
         Assert.assertEquals(message, buildExecutionConfiguration.isPreBuildSyncEnabled(), buildExecutionConfigurationFromJson.isPreBuildSyncEnabled());
         Assert.assertEquals(message, buildExecutionConfiguration.getUserId(), buildExecutionConfigurationFromJson.getUserId());
     }

--- a/rest/src/test/java/org/jboss/pnc/rest/endpoint/BuildRecordEndpointTest.java
+++ b/rest/src/test/java/org/jboss/pnc/rest/endpoint/BuildRecordEndpointTest.java
@@ -141,6 +141,7 @@ public class BuildRecordEndpointTest {
                 "build-1",
                 "",
                 "",
+                "",
                 false,
                 "",
                 "",

--- a/rest/src/test/java/org/jboss/pnc/rest/serialization/BuildExecutionConfigurationTest.java
+++ b/rest/src/test/java/org/jboss/pnc/rest/serialization/BuildExecutionConfigurationTest.java
@@ -58,6 +58,7 @@ public class BuildExecutionConfigurationTest {
         Assert.assertEquals(message, buildExecutionConfiguration.getName(), buildExecutionConfigurationFromJson.getName());
         Assert.assertEquals(message, buildExecutionConfiguration.getScmRepoURL(), buildExecutionConfigurationFromJson.getScmRepoURL());
         Assert.assertEquals(message, buildExecutionConfiguration.getScmRevision(), buildExecutionConfigurationFromJson.getScmRevision());
+        Assert.assertEquals(message, buildExecutionConfiguration.getOriginRepoURL(), buildExecutionConfigurationFromJson.getOriginRepoURL());
         Assert.assertEquals(message, buildExecutionConfiguration.isPreBuildSyncEnabled(), buildExecutionConfigurationFromJson.isPreBuildSyncEnabled());
         Assert.assertEquals(message, buildExecutionConfiguration.getSystemImageId(), buildExecutionConfigurationFromJson.getSystemImageId());
         Assert.assertEquals(message, buildExecutionConfiguration.getSystemImageRepositoryUrl(), buildExecutionConfigurationFromJson.getSystemImageRepositoryUrl());
@@ -78,6 +79,7 @@ public class BuildExecutionConfigurationTest {
                     "configuration name",
                     "https://pathToRepo.git",
                     "1111111",
+                    "https://pathToOriginRepo.git",
                     false,
                     "abcd1234",
                     "image.repo.url/repo",

--- a/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionConfiguration.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionConfiguration.java
@@ -40,6 +40,8 @@ public interface BuildExecutionConfiguration extends BuildExecution {
 
     String getScmRevision();
 
+    String getOriginRepoURL();
+
     boolean isPreBuildSyncEnabled();
 
     String getSystemImageId();
@@ -60,6 +62,7 @@ public interface BuildExecutionConfiguration extends BuildExecution {
             String name,
             String scmRepoURL,
             String scmRevision,
+            String originRepoURL,
             boolean preBuildSyncEnabled,
             String systemImageId,
             String systemImageRepositoryUrl,
@@ -102,6 +105,11 @@ public interface BuildExecutionConfiguration extends BuildExecution {
             @Override
             public String getScmRevision() {
                 return scmRevision;
+            }
+
+            @Override
+            public String getOriginRepoURL() {
+                return originRepoURL;
             }
 
             @Override


### PR DESCRIPTION
Provide origin repository URL to the BuildExecutionConfiguration so that
the Maitai process then passes the URL to repour for auto-sync feature