### PR TITLE
[NCL-3104]: Enable Indy integration test, which was disabled because …

### DIFF
--- a/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyManualDeletionOfBuildRepoTest.java
+++ b/maven-repository-manager/src/test/java/org/jboss/pnc/mavenrepositorymanager/VerifyManualDeletionOfBuildRepoTest.java
@@ -43,7 +43,6 @@ import static org.junit.Assert.fail;
 public class VerifyManualDeletionOfBuildRepoTest extends AbstractRepositoryManagerDriverTest {
 
     @Test
-    @Ignore //Enable in NCL-3104 once NOS-946 is resolved
     public void manuallyPromoteBuildRepoToChainGroup() throws Exception {
         String path = "/org/myproj/myproj/1.0/myproj-1.0.pom";
         String content = "This is a test " + System.currentTimeMillis();


### PR DESCRIPTION
…of not stable Indy snapshot