### PR TITLE
Ignore unknown fields on BuildExecutionConfigurationRest

### DIFF
--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
@@ -19,6 +19,7 @@
 package org.jboss.pnc.rest.restmodel;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.Getter;
@@ -37,6 +38,7 @@ import java.util.Map;
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
  */
 @XmlRootElement(name = "buildExecutionConfiguration")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class BuildExecutionConfigurationRest implements BuildExecutionConfiguration {
 
     private int id;


### PR DESCRIPTION
This was done to help with the Maitai process. While we have different
Maitai processes, they all share the same backend code.

The backend code was updated to suit both the newer process (1.3.4) [Used in PNC 1.2.x]
which is used for the new repository configuration, and the older
process (1.3.2) [Used in PNC 1.1.x] with the older Build Configuration creation process.
Therefore, the backend code will send extra fields (with value null) for
process 1.3.2, which causes Jackson to throw an error that it doesn't
know about those extra fields.

This commit tells Jackson to ignore those extra fields.