### PR TITLE
[NCl-3281] Remove uniqueness constraint on externalurlnormalized

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/RepositoryConfiguration.java
+++ b/model/src/main/java/org/jboss/pnc/model/RepositoryConfiguration.java
@@ -93,7 +93,6 @@ public class RepositoryConfiguration implements GenericEntity<Integer> {
     @Size(max = 255)
     @Getter
     @Setter
-    @Column(unique = true)
     private String externalUrl;
 
     /**


### PR DESCRIPTION
Given that `externalurl` is used to build `externalurlnormalized`, and
that `externalurl` doesn't have any uniqueness constraint,
`externalurlnormalized` should also not have any uniqueness constraint