### PR TITLE
[NCL-3326] Set release status to in-progress

### DIFF
--- a/process-managers/src/main/java/org/jboss/pnc/managers/ProductMilestoneReleaseManager.java
+++ b/process-managers/src/main/java/org/jboss/pnc/managers/ProductMilestoneReleaseManager.java
@@ -112,6 +112,7 @@ public class ProductMilestoneReleaseManager {
             Integer id = milestone.getId();
             releaseTask.<MilestoneReleaseResultRest>addListener(BpmEventType.BREW_IMPORT_SUCCESS, r -> onSuccessfulPush(id, r));
             releaseTask.<BpmStringMapNotificationRest>addListener(BpmEventType.BREW_IMPORT_ERROR, r -> onFailedPush(milestone.getId(), r));
+            release.setStatus(MilestoneReleaseStatus.IN_PROGRESS);
             bpmManager.startTask(releaseTask);
             release.setLog("Brew push task started\n");
 


### PR DESCRIPTION
When the milestone release process is started, its status is not set to
IN_PROGRESS. As such, the status is set to null while the release
process is being performed.

This commit puts the status to IN_PROGRESS just before the BPM process
is triggered to rectify this.