### PR TITLE
[NCL-2999] Once a milestone closed, no more mods

### DIFF
--- a/ui/app/product/directives/pncProductVersionMilestones/pnc-product-version-milestones.html
+++ b/ui/app/product/directives/pncProductVersionMilestones/pnc-product-version-milestones.html
@@ -50,20 +50,16 @@
       </a>
     </td>
     <td class="text-center">
-      <a ng-show="productmilestone.releaseDate == undefined"
+      <a ng-disabled="productmilestone.endDate != undefined"
          pnc-confirm-click="markCurrentMilestone(productmilestone)"
          pnc-confirm-message="{{ 'Mark Milestone ' + productmilestone.version + ' as current ?'}}"
          title="Mark Milestone as current" class="btn btn-default" pnc-requires-auth><i class="fa fa-clock-o"></i></a>
-      <a ng-show="productmilestone.releaseDate == undefined"
+      <a ng-disabled="productmilestone.endDate != undefined"
          ui-sref="product.detail.version.milestoneUpdate({ milestoneId: productmilestone.id })" title="Update Milestone"
          class="btn btn-default"><i class="pficon pficon-edit"></i></a>
-      <a ng-show="productmilestone.releaseDate == undefined"
+      <a ng-disabled="productmilestone.endDate != undefined"
          ui-sref="product.detail.version.milestoneClose({ milestoneId: productmilestone.id })" title="Close Milestone"
          class="btn btn-default"><i class="fa fa-lock"></i></a>
-      <a ng-show="productmilestone.releaseDate != undefined"
-         pnc-confirm-click="unreleaseMilestone(productmilestone)"
-         pnc-confirm-message="{{ 'Are you sure you want to re-open milestone: ' + productmilestone.version + ' ?'}}"
-         title="Re-open Milestone" class="btn btn-default"><i class="fa fa-unlock-alt"></i></a>
     </td>
   </tr>
   </tbody>

--- a/ui/app/product/directives/pncProductVersionMilestones/pncProductVersionMilestones.js
+++ b/ui/app/product/directives/pncProductVersionMilestones/pncProductVersionMilestones.js
@@ -41,26 +41,6 @@
           var versionDetail = scope.version;
           var productDetail = scope.product;
 
-          scope.unreleaseMilestone = function (milestone) {
-            $log.debug('Unreleasing milestone: %O', milestone);
-
-            milestone.releaseDate = null;
-            milestone.downloadUrl = null;
-
-            milestone.$update({
-              versionId: versionDetail.id
-            }).then(
-              function () {
-                $state.go('product.detail.version', {
-                  productId: productDetail.id,
-                  versionId: versionDetail.id
-                }, {
-                  reload: true
-                });
-              }
-            );
-          };
-
           // Mark Milestone as current in Product Version
           scope.markCurrentMilestone = function (milestone) {
             $log.debug('Mark milestone as current: %O', milestone);


### PR DESCRIPTION
Once a milestone is closed, we shouldn't allow the user to do any
further modifications to the closed milestone.

This commit adds a check on the backend repository for product
milestone (which the product milestone endpoint uses) to check if the
existing milestone in the database already has an end date set. If so,
that means that the milestone is 'released', and no more modifications
should be allowed.

The web UI is also updated to:
- disable actions if the end date is set for released milestones