### PR TITLE
[NCL-3112][NCL-2999] Close milestone process

### DIFF
--- a/process-managers/src/test/java/org/jboss/pnc/managers/ProductMilestoneReleaseManagerTest.java
+++ b/process-managers/src/test/java/org/jboss/pnc/managers/ProductMilestoneReleaseManagerTest.java
@@ -24,15 +24,18 @@ import org.jboss.pnc.mock.repository.ArtifactRepositoryMock;
 import org.jboss.pnc.mock.repository.BuildRecordRepositoryMock;
 import org.jboss.pnc.mock.repository.ProductMilestoneReleaseRepositoryMock;
 import org.jboss.pnc.mock.repository.ProductMilestoneRepositoryMock;
+import org.jboss.pnc.mock.repository.ProductVersionRepositoryMock;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.ProductMilestone;
 import org.jboss.pnc.model.ProductMilestoneRelease;
+import org.jboss.pnc.model.ProductVersion;
 import org.jboss.pnc.rest.restmodel.causeway.BuildImportResultRest;
 import org.jboss.pnc.rest.restmodel.causeway.BuildImportStatus;
 import org.jboss.pnc.rest.restmodel.causeway.MilestoneReleaseResultRest;
 import org.jboss.pnc.rest.restmodel.causeway.ReleaseStatus;
 import org.jboss.pnc.spi.datastore.repositories.ProductMilestoneReleaseRepository;
 import org.jboss.pnc.spi.datastore.repositories.ProductMilestoneRepository;
+import org.jboss.pnc.spi.datastore.repositories.ProductVersionRepository;
 import org.jboss.pnc.spi.exception.CoreException;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,6 +64,7 @@ public class ProductMilestoneReleaseManagerTest {
 
     private ProductMilestoneRepository milestoneRepository;
     private ProductMilestoneReleaseRepository releaseRepository;
+    private ProductVersionRepository productVersionRepository;
     private BuildRecordRepositoryMock buildRecordRepository;
 
     private ProductMilestoneReleaseManager releaseManager;
@@ -73,11 +77,12 @@ public class ProductMilestoneReleaseManagerTest {
     public void setUp() throws CoreException {
         milestoneRepository = new ProductMilestoneRepositoryMock();
         releaseRepository = new ProductMilestoneReleaseRepositoryMock();
+        productVersionRepository = new ProductVersionRepositoryMock();
         buildRecordRepository = new BuildRecordRepositoryMock();
 
         MockitoAnnotations.initMocks(this);
         when(bpmManager.startTask(any())).then(answer);
-        releaseManager = new ProductMilestoneReleaseManager(releaseRepository, bpmManager, new ArtifactRepositoryMock(), buildRecordRepository, milestoneRepository);
+        releaseManager = new ProductMilestoneReleaseManager(releaseRepository, bpmManager, new ArtifactRepositoryMock(), productVersionRepository, buildRecordRepository, milestoneRepository);
     }
 
     @Test
@@ -146,6 +151,7 @@ public class ProductMilestoneReleaseManagerTest {
     private ProductMilestone createMilestone() {
         ProductMilestone milestone = new ProductMilestone();
         milestone.setId(milestoneIdSequence++);
+        milestone.setProductVersion(new ProductVersion());
         milestoneRepository.save(milestone);
 
         return milestone;

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductMilestoneEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/ProductMilestoneEndpoint.java
@@ -203,6 +203,30 @@ public class ProductMilestoneEndpoint extends AbstractEndpoint<ProductMilestone,
         return Response.ok().build();
     }
 
+    @ApiOperation(value = "Close/Release a Product Milestone")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION),
+            @ApiResponse(code = INVALID_CODE, message = INVALID_DESCRIPTION, response = ErrorResponseRest.class),
+            @ApiResponse(code = CONFLICTED_CODE, message = CONFLICTED_DESCRIPTION, response = ErrorResponseRest.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = ErrorResponseRest.class)
+    })
+    @PUT
+    @Path("/{id}/close-milestone")
+    public Response closeMilestone(
+            @ApiParam(value = "Product Milestone id", required = true) @PathParam("id") Integer id,
+            ProductMilestoneRest productMilestoneRest,
+            @Context HttpServletRequest httpServletRequest) throws ValidationException {
+
+        if (httpServletRequest != null) {
+            LoggedInUser loginInUser = authenticationProvider.getLoggedInUser(httpServletRequest);
+            productMilestoneProvider.closeMilestone(id, productMilestoneRest, loginInUser.getTokenString());
+        } else {
+            productMilestoneProvider.closeMilestone(id, productMilestoneRest);
+        }
+
+        return Response.ok().build();
+    }
+
     @ApiOperation(value = "Get the artifacts distributed in this milestone")
     @ApiResponses(value = {
             @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION, response = ArtifactPage.class),

--- a/rest/src/test/java/org/jboss/pnc/rest/provider/AbstractMilestoneReleaseTest.java
+++ b/rest/src/test/java/org/jboss/pnc/rest/provider/AbstractMilestoneReleaseTest.java
@@ -98,10 +98,9 @@ public class AbstractMilestoneReleaseTest {
     public void setUp() throws CoreException, ConfigurationParseException {
         bpmMock = new BpmMock();
         MockitoAnnotations.initMocks(this);
-        releaseManager = new ProductMilestoneReleaseManager(releaseRepository, bpmMock, artifactRepository, buildRecordRepository, productMilestoneRepository);
+        releaseManager = new ProductMilestoneReleaseManager(releaseRepository, bpmMock, artifactRepository, productVersionRepository, buildRecordRepository, productMilestoneRepository);
         ProductMilestoneProvider milestoneProvider = new ProductMilestoneProvider(productMilestoneRepository,
                 artifactRepository,
-                productVersionRepository,
                 releaseManager,
                 rsqlPredicateProducer,
                 sortInfoProducer,

--- a/rest/src/test/java/org/jboss/pnc/rest/provider/MilestoneReleaseTest.java
+++ b/rest/src/test/java/org/jboss/pnc/rest/provider/MilestoneReleaseTest.java
@@ -208,8 +208,7 @@ public class MilestoneReleaseTest extends AbstractMilestoneReleaseTest {
 
     private void triggerMilestoneRelease(ProductMilestone milestone) throws ValidationException {
         ProductMilestoneRest restEntity = new ProductMilestoneRest(milestone);
-        restEntity.setEndDate(new Date());
-        milestoneEndpoint.update(milestone.getId(), restEntity);
+        milestoneEndpoint.closeMilestone(milestone.getId(), restEntity, null);
     }
 
 }

--- a/ui/app/common/restclient/services/ProductMilestoneDAO.js
+++ b/ui/app/common/restclient/services/ProductMilestoneDAO.js
@@ -61,6 +61,10 @@
         getLatestRelease: {
           method: 'GET',
           url: ENDPOINT + '/releases/latest'
+        },
+        closeMilestone: {
+          method: 'PUT',
+          url: REST_BASE_URL + '/product-milestones/:milestoneId/close-milestone'
         }
       });
 

--- a/ui/app/milestone/milestone-controllers.js
+++ b/ui/app/milestone/milestone-controllers.js
@@ -179,9 +179,8 @@
     'productDetail',
     'versionDetail',
     'milestoneDetail',
-    'dateUtilConverter',
     function($scope, $state, $stateParams, productDetail,
-      versionDetail, milestoneDetail, dateUtilConverter) {
+      versionDetail, milestoneDetail) {
 
       var that = this;
 
@@ -190,21 +189,8 @@
 
       that.data = milestoneDetail;
 
-      // date component <- timestamp
-
-      // if endDate is not set yet, use the plannedEndDate instead
-      if (that.data.endDate === null) {
-        that.endDate = new Date(that.data.plannedEndDate);
-      } else {
-        that.endDate = new Date(that.data.endDate);
-      }
-
       that.submit = function() {
-
-        // timestamp <- date component
-        that.data.endDate = dateUtilConverter.convertToTimestampNoon(that.endDate);
-
-        that.data.$update().then(
+        that.data.$closeMilestone().then(
           function() {
             $state.go('product.detail.version', {
               productId: productDetail.id,
@@ -215,8 +201,6 @@
           }
         );
       };
-
-      dateUtilConverter.initDatePicker($scope);
     }
   ]);
 

--- a/ui/app/milestone/views/milestone.close.html
+++ b/ui/app/milestone/views/milestone.close.html
@@ -41,24 +41,6 @@
               </div>
             </div>
 
-            <div class="form-group" ng-class="{ 'has-error' : milestoneForm.endDate.$invalid && !milestoneForm.endDate.$pristine }">
-              <label for="input-end-date" class="col-sm-2 control-label">
-                * Release date&nbsp;<a uib-popover="Release date, e.g. '2035/01/15', time is set to noon UTC."
-                           popover-placement="right" popover-class="popover-info-tip" popover-append-to-body="true"
-
-                           href><span class="fa fa-info-circle"></span></a>
-              </label>
-              <div class="col-sm-10">
-                <div class="input-group">
-                  <input type="text" class="form-control" uib-datepicker-popup="yyyy/MM/dd" ng-model="milestoneCloseCtrl.endDate" is-open="milestoneCloseCtrl.endDateOpen" ng-required="true">
-                  <span class="input-group-btn">
-                    <button type="button" class="btn btn-default" ng-click="milestoneCloseCtrl.endDateOpen = !milestoneCloseCtrl.endDateOpen"><i class="glyphicon glyphicon-calendar"></i></button>
-                  </span>
-                </div>
-                <span class="help-block" ng-show="milestoneForm.endDate.$error.required && !milestoneForm.endDate.$pristine">Required field.</span>
-              </div>
-            </div>
-
             <div class="form-group" ng-class="{ 'has-error' : milestoneForm.downloadurl.$invalid && !milestoneForm.downloadurl.$pristine }">
               <label for="input-downloadurl" class="col-sm-2 control-label">
                 Download URL&nbsp;<a uib-popover="Internal or public location to download the product distribution artifacts"
@@ -71,21 +53,6 @@
                   <input type="url" name="downloadurl" id="input-downloadurl" class="form-control" name="downloadUrl" ng-model="milestoneCloseCtrl.data.downloadUrl">
                 </div>
                 <span class="help-block" ng-show="milestoneForm.downloadurl.$invalid && !milestoneForm.downloadurl.$pristine">Required field.</span>
-              </div>
-            </div>
-
-            <div class="form-group" ng-class="{ 'has-error' : milestoneForm.issuetrackerurl.$invalid && !milestoneForm.issuetrackerurl.$pristine }">
-              <label for="input-issuetrackerurl" class="col-sm-2 control-label">
-                * Issue Tracker URL&nbsp;<a uib-popover="Link to issues fixed in this milestone release"
-                           popover-placement="right" popover-class="popover-info-tip" popover-append-to-body="true"
-
-                           href><span class="fa fa-info-circle"></span></a>
-              </label>
-              <div class="col-sm-10">
-                <div class="input-group">
-                  <input required name="issuetrackerurl" id="input-issuetrackerurl" class="form-control" name="issueTrackerUrl" ng-model="milestoneCloseCtrl.data.issueTrackerUrl">
-                </div>
-                <span class="help-block" ng-show="milestoneForm.issuetrackerurl.$invalid && !milestoneForm.issuetrackerurl.$pristine">Required field.</span>
               </div>
             </div>
 

--- a/ui/app/product/directives/pncProductVersionMilestones/pnc-product-version-milestones.html
+++ b/ui/app/product/directives/pncProductVersionMilestones/pnc-product-version-milestones.html
@@ -50,20 +50,16 @@
       </a>
     </td>
     <td class="text-center">
-      <a ng-show="productmilestone.releaseDate == undefined"
+      <a ng-disabled="productmilestone.endDate != undefined"
          pnc-confirm-click="markCurrentMilestone(productmilestone)"
          pnc-confirm-message="{{ 'Mark Milestone ' + productmilestone.version + ' as current ?'}}"
          title="Mark Milestone as current" class="btn btn-default" pnc-requires-auth><i class="fa fa-clock-o"></i></a>
-      <a ng-show="productmilestone.releaseDate == undefined"
+      <a ng-disabled="productmilestone.endDate != undefined"
          ui-sref="product.detail.version.milestoneUpdate({ milestoneId: productmilestone.id })" title="Update Milestone"
          class="btn btn-default"><i class="pficon pficon-edit"></i></a>
-      <a ng-show="productmilestone.releaseDate == undefined"
+      <a ng-disabled="productmilestone.endDate != undefined"
          ui-sref="product.detail.version.milestoneClose({ milestoneId: productmilestone.id })" title="Close Milestone"
          class="btn btn-default"><i class="fa fa-lock"></i></a>
-      <a ng-show="productmilestone.releaseDate != undefined"
-         pnc-confirm-click="unreleaseMilestone(productmilestone)"
-         pnc-confirm-message="{{ 'Are you sure you want to re-open milestone: ' + productmilestone.version + ' ?'}}"
-         title="Re-open Milestone" class="btn btn-default"><i class="fa fa-unlock-alt"></i></a>
     </td>
   </tr>
   </tbody>

--- a/ui/app/product/directives/pncProductVersionMilestones/pncProductVersionMilestones.js
+++ b/ui/app/product/directives/pncProductVersionMilestones/pncProductVersionMilestones.js
@@ -41,26 +41,6 @@
           var versionDetail = scope.version;
           var productDetail = scope.product;
 
-          scope.unreleaseMilestone = function (milestone) {
-            $log.debug('Unreleasing milestone: %O', milestone);
-
-            milestone.releaseDate = null;
-            milestone.downloadUrl = null;
-
-            milestone.$update({
-              versionId: versionDetail.id
-            }).then(
-              function () {
-                $state.go('product.detail.version', {
-                  productId: productDetail.id,
-                  versionId: versionDetail.id
-                }, {
-                  reload: true
-                });
-              }
-            );
-          };
-
           // Mark Milestone as current in Product Version
           scope.markCurrentMilestone = function (milestone) {
             $log.debug('Mark milestone as current: %O', milestone);


### PR DESCRIPTION
This commit applies changes to the close milestone process related to
NCL-3112 and NCL-2999.

A milestone is considered closed when the release process is successful
and the end date for this milestone is set.

We can initiate the close milestone process by hitting the
`/close-milestone` endpoint. Optionally, we can specify the
`downloadUrl` in that endpoint.

When the `/close-milestone` endpoint is hit, it will start the release
process. If the release process for the milestone is successful, the
following happens:

- the `endDate` of the milestone is set to the date the process release
  succeeded
- if the milestone is set as 'current' in the product version, it is
  then unset as 'current'

On the Web UI, if the end date of a milestone is set, then the options
to:

- set as current
- edit milestone
- close milestone

are disabled.