### PR TITLE
NCL-3377 Fixes: Pre-build sync enabled flag is not stored

### DIFF
--- a/ui/app/build-configs/directives/pnc-create-build-config-wizard/pncCreateBuildConfigWizard.js
+++ b/ui/app/build-configs/directives/pnc-create-build-config-wizard/pncCreateBuildConfigWizard.js
@@ -142,7 +142,7 @@
         });
         RepositoryConfiguration.autoCreateRepoConfig({
           url: $ctrl.wizardData.repoConfig.scmUrl,
-          preBuildSyncEnabled: $ctrl.wizardData.repoConfig.preBuildSyncEnabled,
+          preBuildSync: $ctrl.wizardData.repoConfig.preBuildSyncEnabled,
           buildConfiguration: bc
         }).catch(function () {
           $ctrl.wizardDone = true;


### PR DESCRIPTION
(cherry picked from commit 19b173ed84158d05c46d650aa4826cd2be409944)
Signed-off-by: Alex Creasy <acreasy@redhat.com>