### PR TITLE
Fix bower

### DIFF
--- a/ui/.bowerrc
+++ b/ui/.bowerrc
@@ -4,5 +4,6 @@
     "packages": ".build-tmp/bower-cache",
     "registry": ".build-tmp/bower-registry"
   },
-  "tmp": ".build-tmp/bower-tmp"
+  "tmp": ".build-tmp/bower-tmp",
+  "registry": "https://registry.bower.io"
 }


### PR DESCRIPTION
It looks like since Oct 11, the old bower registry got deprecated.
https://twitter.com/bower/status/918073147789889536

This causes the PNC build to fails because the ui/bower component cannot
talk to the mothership.

This PR updates our .bowerrc to specify the new registry to use.