### PR TITLE
[NCL-3504] Add build options for temp build

### DIFF
--- a/bpm/src/main/java/org/jboss/pnc/bpm/task/BpmBuildTask.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/task/BpmBuildTask.java
@@ -77,7 +77,6 @@ public class BpmBuildTask extends BpmTask {
                 buildTask.getUser().getId(),
                 buildConfiguration.getBuildScript(),
                 buildConfiguration.getName(),
-                //TODO update to use also other parts or Repository Configuration
                 buildConfiguration.getRepositoryConfiguration().getInternalUrl(),
                 buildConfiguration.getScmRevision(),
                 buildConfiguration.getRepositoryConfiguration().getExternalUrl(),
@@ -86,7 +85,9 @@ public class BpmBuildTask extends BpmTask {
                 buildConfiguration.getBuildEnvironment().getSystemImageRepositoryUrl(),
                 buildConfiguration.getBuildEnvironment().getSystemImageType(),
                 buildTask.isPodKeptAfterFailure(),
-                buildConfiguration.getGenericParameters());
+                buildConfiguration.getGenericParameters(),
+                buildConfiguration.getTempBuild(),
+                buildConfiguration.getTempBuildTimestamp());
 
         return new BuildExecutionConfigurationRest(buildExecutionConfiguration);
     }

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/local/LocalBuildScheduler.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/local/LocalBuildScheduler.java
@@ -89,7 +89,9 @@ public class LocalBuildScheduler implements BuildScheduler {
                 configuration.getBuildEnvironment().getSystemImageRepositoryUrl(),
                 configuration.getBuildEnvironment().getSystemImageType(),
                 buildTask.isPodKeptAfterFailure(),
-                configuration.getGenericParameters());
+                configuration.getGenericParameters(),
+                configuration.getTempBuild(),
+                configuration.getTempBuildTimestamp());
 
         try {
             buildExecutor.startBuilding(

--- a/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionConfiguration.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionConfiguration.java
@@ -45,6 +45,8 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
     private final boolean podKeptAfterFailure;
     private final List<ArtifactRepository> artifactRepositories;
     private final Map<String, String> genericParameters;
+    private final boolean tempBuild;
+    private final String tempBuildTimestamp;
 
     public DefaultBuildExecutionConfiguration(
             int id,
@@ -61,7 +63,9 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
             SystemImageType systemImageType,
             boolean podKeptAfterFailure,
             List<ArtifactRepository> artifactRepositories,
-            Map<String, String> genericParameters) {
+            Map<String, String> genericParameters,
+            boolean tempBuild,
+            String tempBuildTimestamp) {
 
         this.id = id;
         this.buildContentId = buildContentId;
@@ -78,6 +82,8 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
         this.podKeptAfterFailure = podKeptAfterFailure;
         this.artifactRepositories = artifactRepositories;
         this.genericParameters = genericParameters;
+        this.tempBuild = tempBuild;
+        this.tempBuildTimestamp = tempBuildTimestamp;
     }
 
     @Override
@@ -153,5 +159,15 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
     @Override
     public Map<String, String> getGenericParameters() {
         return genericParameters;
+    }
+
+    @Override
+    public boolean isTempBuild() {
+        return tempBuild;
+    }
+
+    @Override
+    public String getTempBuildTimestamp() {
+        return tempBuildTimestamp;
     }
 }

--- a/build-executor/src/test/java/org/jboss/pnc/executor/BuildEnvironmentTest.java
+++ b/build-executor/src/test/java/org/jboss/pnc/executor/BuildEnvironmentTest.java
@@ -154,7 +154,9 @@ public class BuildEnvironmentTest {
                 buildConfiguration.getBuildEnvironment().getSystemImageType(),
                 keepAliveOnFailure,
                 null,
-                buildConfiguration.getGenericParameters());
+                buildConfiguration.getGenericParameters(),
+                buildConfiguration.getTempBuild(),
+                buildConfiguration.getTempBuildTimestamp());
 
         executor.startBuilding(buildExecutionConfiguration, onBuildExecutionStatusChangedEvent, "");
     }

--- a/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
+++ b/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
@@ -158,7 +158,9 @@ class BuildExecutionBase {
                 buildConfiguration.getBuildEnvironment().getSystemImageType(),
                 false,
                 null,
-                buildConfiguration.getGenericParameters());
+                buildConfiguration.getGenericParameters(),
+                buildConfiguration.getTempBuild(),
+                buildConfiguration.getTempBuildTimestamp());
 
         executor.startBuilding(buildExecutionConfiguration, onBuildExecutionStatusChangedEvent, "");
     }

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildTasksRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildTasksRestTest.java
@@ -89,7 +89,8 @@ public class BuildTasksRestTest extends AbstractTest{
 
         BuildExecutionConfiguration buildExecutionConfig = BuildExecutionConfiguration.build(
                 1, "test-content-id", 1, "mvn clean install", "jboss-modules", "scm-url", "master",
-                "origin-scm-url", false, "dummy-docker-image-id", "dummy.repo.url/repo", SystemImageType.DOCKER_IMAGE, false, null, new HashMap<>());
+                "origin-scm-url", false, "dummy-docker-image-id", "dummy.repo.url/repo", SystemImageType.DOCKER_IMAGE,
+                false, null, new HashMap<>(), false, null);
 
         BuildExecutionConfigurationRest buildExecutionConfigurationRest = new BuildExecutionConfigurationRest(buildExecutionConfig);
 

--- a/model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
@@ -193,6 +193,14 @@ public class BuildConfiguration implements GenericEntity<Integer>, Cloneable {
     @Column(name = "value", nullable = false, length = 8192)
     private Map<String, String> genericParameters = new HashMap<>();
 
+    @Getter
+    @Setter
+    private Boolean tempBuild = false;
+
+    @Getter
+    @Setter
+    private String tempBuildTimestamp;
+
     /**
      * Instantiates a new project build configuration.
      */

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionConfigurationMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionConfigurationMock.java
@@ -45,6 +45,8 @@ public class BuildExecutionConfigurationMock implements BuildExecutionConfigurat
     private SystemImageType systemImageType;
     private List<ArtifactRepository> artifactRepositories;
     private Map<String, String> genericParameters;
+    private boolean tempBuild;
+    private String tempBuildTimestamp;
 
     public static BuildExecutionConfiguration mockConfig() {
         BuildExecutionConfigurationMock mock = new BuildExecutionConfigurationMock();
@@ -58,6 +60,8 @@ public class BuildExecutionConfigurationMock implements BuildExecutionConfigurat
         mock.setSystemImageType(SystemImageType.DOCKER_IMAGE);
         mock.setArtifactRepositories(null);
         mock.setGenericParameters(new HashMap<>());
+        mock.setTempBuild(false);
+        mock.setTempBuildTimestamp(null);
 
         return mock;
     }
@@ -186,6 +190,24 @@ public class BuildExecutionConfigurationMock implements BuildExecutionConfigurat
 
     public void setGenericParameters(Map<String, String> genericParameters) {
         this.genericParameters = genericParameters;
+    }
+
+    public void setTempBuild(boolean tempBuild) {
+        this.tempBuild = tempBuild;
+    }
+
+    @Override
+    public boolean isTempBuild() {
+        return tempBuild;
+    }
+
+    public void setTempBuildTimestamp(String timestamp) {
+        this.tempBuildTimestamp = timestamp;
+    }
+
+    @Override
+    public String getTempBuildTimestamp() {
+        return tempBuildTimestamp;
     }
 
 }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/spi/BuildExecutionConfigurationMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/spi/BuildExecutionConfigurationMock.java
@@ -45,7 +45,9 @@ public class BuildExecutionConfigurationMock {
                 SystemImageType.DOCKER_IMAGE,
                 false,
                 null,
-                new HashMap<>()
+                new HashMap<>(),
+                false,
+                null
         );
     }
 }

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
@@ -57,6 +57,9 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
     private List<ArtifactRepository> artifactRepositories;
     private Map<String, String> genericParameters;
 
+    private boolean tempBuild = false;
+    private String tempBuildTimestamp;
+
     public BuildExecutionConfigurationRest() {}
 
     public BuildExecutionConfigurationRest(String serialized) throws IOException {
@@ -86,6 +89,8 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
         user = new UserRest(buildExecutionConfiguration.getUserId());
         podKeptOnFailure = buildExecutionConfiguration.isPodKeptOnFailure();
         genericParameters = buildExecutionConfiguration.getGenericParameters();
+        tempBuild = buildExecutionConfiguration.isTempBuild();
+        tempBuildTimestamp = buildExecutionConfiguration.getTempBuildTimestamp();
 
         if (buildExecutionConfiguration.getArtifactRepositories() != null) {
             artifactRepositories = new ArrayList<>(buildExecutionConfiguration.getArtifactRepositories().size());
@@ -111,7 +116,9 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
                 systemImageType,
                 podKeptOnFailure,
                 artifactRepositories,
-                genericParameters
+                genericParameters,
+                tempBuild,
+                tempBuildTimestamp
         );
     }
 
@@ -283,6 +290,25 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
     @Override
     public Map<String, String> getGenericParameters() {
         return genericParameters;
+    }
+
+
+    public void setTempBuild(boolean tempBuild) {
+        this.tempBuild = tempBuild;
+    }
+
+    @Override
+    public boolean isTempBuild() {
+        return tempBuild;
+    }
+
+    public void setTempBuildTimestamp(String timestamp) {
+        this.tempBuildTimestamp = timestamp;
+    }
+
+    @Override
+    public String getTempBuildTimestamp() {
+        return tempBuildTimestamp;
     }
 
     @Override

--- a/rest-model/src/test/java/org/jboss/pnc/restmodel/serialization/BuildExecutionConfigurationTest.java
+++ b/rest-model/src/test/java/org/jboss/pnc/restmodel/serialization/BuildExecutionConfigurationTest.java
@@ -54,7 +54,9 @@ public class BuildExecutionConfigurationTest {
                 SystemImageType.DOCKER_IMAGE,
                 false,
                 null,
-                new HashMap<>()
+                new HashMap<>(),
+                false,
+                null
         );
         BuildExecutionConfigurationRest buildExecutionConfigurationREST = new BuildExecutionConfigurationRest(buildExecutionConfiguration);
 

--- a/rest/src/test/java/org/jboss/pnc/rest/endpoint/BuildRecordEndpointTest.java
+++ b/rest/src/test/java/org/jboss/pnc/rest/endpoint/BuildRecordEndpointTest.java
@@ -148,7 +148,9 @@ public class BuildRecordEndpointTest {
                 SystemImageType.DOCKER_IMAGE,
                 false,
                 null,
-                new HashMap<>());
+                new HashMap<>(),
+                false,
+                null);
 
         BuildExecutionSession buildExecutionSession = new DefaultBuildExecutionSession(buildExecutionConfiguration, null);
         when(buildExecutor.getRunningExecution(buildExecutionTaskId)).thenReturn(buildExecutionSession);

--- a/rest/src/test/java/org/jboss/pnc/rest/serialization/BuildExecutionConfigurationTest.java
+++ b/rest/src/test/java/org/jboss/pnc/rest/serialization/BuildExecutionConfigurationTest.java
@@ -85,7 +85,9 @@ public class BuildExecutionConfigurationTest {
                     SystemImageType.DOCKER_IMAGE,
                     false,
                     null,
-                    genericParameters
+                    genericParameters,
+                    false,
+                    null
             );
     }
 

--- a/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionConfiguration.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionConfiguration.java
@@ -58,6 +58,10 @@ public interface BuildExecutionConfiguration extends BuildExecution {
 
     Map<String, String> getGenericParameters();
 
+    boolean isTempBuild();
+
+    String getTempBuildTimestamp();
+
     static BuildExecutionConfiguration build(
             int id,
             String buildContentId,
@@ -72,9 +76,12 @@ public interface BuildExecutionConfiguration extends BuildExecution {
             String systemImageRepositoryUrl,
             SystemImageType systemImageType,
             boolean podKeptAfterFailure,
-            Map<String, String> genericParameters) {
+            Map<String, String> genericParameters,
+            boolean tempBuild,
+            String tempBuildTimestamp) {
         return build(id, buildContentId, userId, buildScript, name, scmRepoURL, scmRevision, originRepoURL, preBuildSyncEnabled,
-                systemImageId, systemImageRepositoryUrl, systemImageType, podKeptAfterFailure, null, genericParameters);
+                systemImageId, systemImageRepositoryUrl, systemImageType, podKeptAfterFailure, null, genericParameters,
+                tempBuild, tempBuildTimestamp);
     }
 
     static BuildExecutionConfiguration build(
@@ -92,7 +99,9 @@ public interface BuildExecutionConfiguration extends BuildExecution {
             SystemImageType systemImageType,
             boolean podKeptAfterFailure,
             List<ArtifactRepository> artifactRepositories,
-            Map<String, String> genericParameters) {
+            Map<String, String> genericParameters,
+            boolean tempBuild,
+            String tempBuildTimestamp) {
 
         List<ArtifactRepository> builtRepositories;
         if (artifactRepositories == null) {
@@ -180,6 +189,16 @@ public interface BuildExecutionConfiguration extends BuildExecution {
             @Override
             public Map<String, String> getGenericParameters() {
                 return genericParameters;
+            }
+
+            @Override
+            public boolean isTempBuild() {
+                return tempBuild;
+            }
+
+            @Override
+            public String getTempBuildTimestamp() {
+                return tempBuildTimestamp;
             }
         };
     }


### PR DESCRIPTION
The new parameters 'tempBuild' and 'tempBuildTimestamp' are added to
`BuildExecutionConfiguration` and `BuildExecutionConfigurationRest`.

It is assumed that the 2 parameters are ultimately stored inside
`BuildConfiguration`.