### PR TITLE
Start targetrepo seq with last value = 6 for migration

### DIFF
--- a/model/src/main/resources/db-update/00001-from-1.2.0-to-1.3.0.sql
+++ b/model/src/main/resources/db-update/00001-from-1.2.0-to-1.3.0.sql
@@ -33,6 +33,12 @@ insert into TargetRepository (id, identifier, repositoryPath, repositoryType) va
 
 alter table Artifact add targetRepository_id integer;
 
+-- Start the sequence id for target repository from last value = 6
+-- We need to set last_value to 6 and not to 5 because the sequence has column
+-- 'is_called' set to false
+-- https://www.postgresql.org/docs/8.1/static/functions-sequence.html
+alter sequence target_repository_repo_id_seq restart with 6;
+
 -- migrate data
 -- old repotype 0 -> maven (1)
 -- old repotype 3 -> generic proxy (5)


### PR DESCRIPTION
Otherwise when we insert a new row into the target repository table,
we will try to add a new row with id 1 instead of id = 6

Note that we are not setting last_value to 5 because the target
repository sequence has column 'is_called' set to false.

https://www.postgresql.org/docs/8.1/static/functions-sequence.html

According to the document above, if 'is_called' is false, it will use
the value of 'last_value' as the next id. If 'is_called' is true, it
will use the value of 'last_value' + 1 as the next id.

Since we've only inserted 5 items, and 'is_called' is false, the
'last_value' column should be set to 6.