### PR TITLE
[PR-1275]Add ability to configure pod strt timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,13 +147,17 @@ Or you can configure the app using the environment variables listred in the file
 
 For the configuration descriptions see api doc of classes in `moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig`
 
-### PullingMonitor ThreadPool size configuration
+### PullingMonitor configuration
 
 If you want to specify the ThreadPool size for `PullingMonitor`, you can do so by using the system property `pulling_monitor_threadpool`.
 
 For example, you can specify via `-Dpulling-monitor-threadpool=10` parameter
 
 You can also specify the environment variable `pulling_monitor_threadpool`.
+
+Similarly, to configure the timeout to wait for the builder pod to start, we can specify it either by the system property or environment property `pulling_monitor_timeout`
+Finally, to configure the check interval in seconds for the builder pod to start, we can specify it either by the system property or environment property `pulling_monitor_check_interval`
+
 Note that the system property has precedence over the environment variable if both are defined.
 
 


### PR DESCRIPTION
PR-1275 (https://github.com/project-ncl/pnc/pull/1275) introduced the
ability to configure the timeout and check interval required to wait for
the builder pod to start. Unfortunately due to commits that PR is in an
umergeable state.

This commit attempts to add the same configuration in a different
approach, using system, or environment properties. This approach was
used because we are already using the same concept to configure the default
thread pool size we use for building (See NCL-2373)