### PR TITLE
Make timestamp generation prettier

### DIFF
--- a/common/src/main/java/org/jboss/pnc/common/util/TimeUtils.java
+++ b/common/src/main/java/org/jboss/pnc/common/util/TimeUtils.java
@@ -109,7 +109,7 @@ public class TimeUtils {
                 .build();
 
 
-        return String.format("t%d%d%d-%d%d%d-%d", instant.get(Calendar.YEAR), instant.get(Calendar.MONTH) + 1,
+        return String.format("t%d%02d%02d-%02d%02d%02d-%03d", instant.get(Calendar.YEAR), instant.get(Calendar.MONTH) + 1,
                 instant.get(Calendar.DAY_OF_MONTH), instant.get(Calendar.HOUR_OF_DAY), instant.get(Calendar.MINUTE),
                 instant.get(Calendar.SECOND), instant.get(Calendar.MILLISECOND));
     }

--- a/common/src/test/java/org/jboss/pnc/common/test/util/TimeUtilsTest.java
+++ b/common/src/test/java/org/jboss/pnc/common/test/util/TimeUtilsTest.java
@@ -38,12 +38,27 @@ public class TimeUtilsTest {
     @Test
     public void generateTimestampValidTest() {
         // given
-        Date date = new Date(1512050025464L); //Nov 30, 2017 2:53:45 PM (2017-11-30-14:53:45)
+        Date date = new Date(1512050025464L); //Nov 30, 2017 1:53:45 PM (2017-11-30-13:53:45) UTC (464 milliseconds)
 
         //when
         String timestamp = TimeUtils.generateTimestamp(true, date);
 
         //then
         assertEquals("t20171130-135345-464", timestamp);
+    }
+
+
+    @Test
+    public void generateCorrectTimeStampFormatForSingleDigitDates() {
+        // given
+        // test that TimeUtils appends an extra '0' when month, day, or time is a single digit
+        Date date = new Date(1501722185009L); //Aug 03, 2017 1:03:05 AM (2017-08-03-01:03:05) UTC (9 milliseconds)
+
+        // when
+        String timestamp = TimeUtils.generateTimestamp(true, date);
+
+        // then
+        assertEquals("t20170803-010305-009", timestamp);
+
     }
 }


### PR DESCRIPTION
Currently, if the month, day, or time is a single digit, the timestamp
generated will be:

```
t<yyyy>-<m>-<d>-<h>-<M>-<s>-<f>
```

This commit changes this so that we add extra '0' where necessary. The
timestamp then looks like this:

```
t<yyyy>-0<m>-0<d>-0<h>-0<M>-0<s>-00<f>
```

E.g 't20170803-010305-009'