### PR TITLE
[NCL-3533] Update migration script from 1.2.0 to 1.3.0

### DIFF
--- a/model/src/main/resources/db-update/00001-from-1.2.0-to-1.3.0.sql
+++ b/model/src/main/resources/db-update/00001-from-1.2.0-to-1.3.0.sql
@@ -16,13 +16,17 @@
 -- limitations under the License.
 --
 
+-- TargetRepository
+
+create sequence target_repository_repo_id_seq;
 -- ## Updates required by new artifact repository relations
 create table TargetRepository (
     id integer not null,
     identifier varchar(255) not null,
     repositoryPath varchar(255) not null,
     repositoryType varchar(255) not null,
-    primary key (id)
+    primary key (id),
+    unique (identifier, repositoryPath)
 );
 -- insert default repositories
 insert into TargetRepository (id, identifier, repositoryPath, repositoryType) values (1, 'indy-maven', 'builds-untested', 'MAVEN');
@@ -31,19 +35,26 @@ insert into TargetRepository (id, identifier, repositoryPath, repositoryType) va
 insert into TargetRepository (id, identifier, repositoryPath, repositoryType) values (4, 'indy-maven', 'shared-imports', 'MAVEN_TEMPORARY');
 insert into TargetRepository (id, identifier, repositoryPath, repositoryType) values (5, 'indy-http', '', 'GENERIC_PROXY');
 
-alter table Artifact add targetRepository_id integer;
-
 -- Start the sequence id for target repository from last value = 6
 -- We need to set last_value to 6 and not to 5 because the sequence has column
 -- 'is_called' set to false
 -- https://www.postgresql.org/docs/8.1/static/functions-sequence.html
 alter sequence target_repository_repo_id_seq restart with 6;
 
+-- Artifact
+alter table Artifact add targetRepository_id integer;
+
+alter table Artifact
+    add constraint fk_artifact_targetRepository
+    foreign key (targetRepository_id)
+    references TargetRepository;
+
 -- migrate data
 -- old repotype 0 -> maven (1)
 -- old repotype 3 -> generic proxy (5)
 update Artifact set targetRepository_id = 1 where repotype = 0;
 update Artifact set targetRepository_id = 5 where repotype = 3;
+
 alter table Artifact alter column targetRepository_id set not null;
 alter table Artifact drop column repotype;
 
@@ -56,3 +67,46 @@ alter table buildconfigsetrecord add temporarybuild boolean;
 update buildconfigsetrecord set temporarybuild = true;
 alter table buildconfigsetrecord alter column temporarybuild set not null;
 
+
+-- BuildRecordPushResult
+create sequence build_record_push_result_id_seq;
+
+create table BuildRecordPushResult (
+    id int4 not null,
+    brewBuildId int4,
+    brewBuildUrl varchar(255),
+    log text,
+    status varchar(255),
+    buildRecord_id int4,
+    primary key (id)
+);
+
+alter table BuildRecordPushResult
+    add constraint fk_buildrecordpushresult_buildrecord
+    foreign key (buildRecord_id)
+    references BuildRecord;
+
+-- Copy data from build_record_attributes table to empty buildrecordpushresult table
+INSERT INTO
+    buildrecordpushresult (id, buildrecord_id, brewbuildid, brewbuildurl, status)
+SELECT
+    nextval('build_record_push_result_id_seq'), brID.build_record_id, cast(brID.value as int), brURL.value, 'SUCCESS'
+FROM
+    build_record_attributes brID
+left join
+    build_record_attributes brURL on brID.build_record_id = brURL.build_record_id AND brURL.key = 'brewLink'
+WHERE
+    brID.key = 'brewId';
+
+-- build_config_set_record_attributes collection table
+create table build_config_set_record_attributes (
+    build_config_set_record_id int4 not null,
+    value varchar(255),
+    key varchar(255) not null,
+    primary key (build_config_set_record_id, key)
+);
+
+alter table build_config_set_record_attributes
+    add constraint fk_build_config_set_record_attributes_build_config_set_record
+    foreign key (build_config_set_record_id)
+    references BuildConfigSetRecord;


### PR DESCRIPTION
The schema changes were obtained by first running
pnc-schema-generator[1] on PNC 1.2.0 and PNC 1.3.0-SNAPSHOT.

[1] is still a little bit confused on the names of the foreign keys and
seems to use random foreign key names instead of the ones we used in the
code.

We then use apgdiff[2] to get a sort of migration SQL commands to run
when migration from the schema from 1.2.0 to 1.3.0-SNAPSHOT. The
migration SQL commands is not perfect though. For one, it might generate some
weird output (rare), and it might generate unecessary foreign key migrations
due to the problem with [1] mentioned ealier.

However, it is still really useful, and this was used to create the new
updates in that script.

This commit also contain changes for NCL-3533, which is to migrate data
from build_record_attributes to buildrecordpushresults.

[1]: https://github.com/project-ncl/pnc-schema-generator