### PR TITLE
Set temporarybuild = false for existing data

### DIFF
--- a/model/src/main/resources/db-update/00001-from-1.2.0-to-1.3.0.sql
+++ b/model/src/main/resources/db-update/00001-from-1.2.0-to-1.3.0.sql
@@ -49,10 +49,10 @@ alter table Artifact drop column repotype;
 
 -- temporary build flags
 alter table buildrecord add temporarybuild boolean;
-update buildrecord set temporarybuild = true;
+update buildrecord set temporarybuild = false;
 alter table buildrecord alter column temporarybuild set not null;
 
 alter table buildconfigsetrecord add temporarybuild boolean;
-update buildconfigsetrecord set temporarybuild = true;
+update buildconfigsetrecord set temporarybuild = false;
 alter table buildconfigsetrecord alter column temporarybuild set not null;
 


### PR DESCRIPTION
The migration script sets the temporarybuild to 'true' for existing
data. I believe that this is wrong and it should be set to 'false' for
*existing* data.