### PR TITLE
[NCL-3514] Don't show deprecated environments

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/BuildEnvironment.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildEnvironment.java
@@ -81,6 +81,8 @@ public class BuildEnvironment implements GenericEntity<Integer> {
     @Column(name="value")
     private Map<String, String> attributes = new HashMap<String, String>();
 
+    private Boolean deprecated = false;
+
     public BuildEnvironment() {
     }
 
@@ -146,6 +148,14 @@ public class BuildEnvironment implements GenericEntity<Integer> {
         this.systemImageType = systemImageType;
     }
 
+    public boolean isDeprecated() {
+        return deprecated != null && deprecated != Boolean.FALSE;
+    }
+
+    public void setDeprecated(boolean deprecated) {
+        this.deprecated = deprecated;
+    }
+
     @Override
     public String toString() {
         return "Build Environment [name: " + name + ", image id: " + this.systemImageId + "]";
@@ -167,6 +177,8 @@ public class BuildEnvironment implements GenericEntity<Integer> {
 
         private SystemImageType systemImageType;
 
+        private Boolean deprecated = false;
+
         private Builder() {
             
         }
@@ -184,6 +196,7 @@ public class BuildEnvironment implements GenericEntity<Integer> {
             buildEnvironment.systemImageId = systemImageId;
             buildEnvironment.setAttributes(attributes);
             buildEnvironment.setSystemImageType(systemImageType);
+            buildEnvironment.deprecated = deprecated;
             return buildEnvironment;
         }
 
@@ -224,6 +237,11 @@ public class BuildEnvironment implements GenericEntity<Integer> {
 
         public Builder systemImageType(SystemImageType systemImageType) {
             this.systemImageType = systemImageType;
+            return this;
+        }
+
+        public Builder deprecated(boolean isDeprecated) {
+            this.deprecated = isDeprecated;
             return this;
         }
 

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildEnvironmentRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildEnvironmentRest.java
@@ -55,6 +55,9 @@ public class BuildEnvironmentRest implements GenericRestEntity<Integer> {
     @NotNull(groups = {WhenCreatingNew.class, WhenUpdating.class})
     private SystemImageType systemImageType;
 
+    @ApiModelProperty(dataType = "boolean")
+    private boolean deprecated;
+
     public BuildEnvironmentRest() {
     }
 
@@ -66,6 +69,7 @@ public class BuildEnvironmentRest implements GenericRestEntity<Integer> {
         this.systemImageId = buildEnvironment.getSystemImageId();
         this.attributes = buildEnvironment.getAttributes();
         this.systemImageType = buildEnvironment.getSystemImageType();
+        this.deprecated = buildEnvironment.isDeprecated();
     }
 
     @Override
@@ -137,6 +141,14 @@ public class BuildEnvironmentRest implements GenericRestEntity<Integer> {
         this.attributes = attributes;
     }
 
+    public boolean isDeprecated() {
+        return deprecated;
+    }
+
+    public void setDeprecated(boolean deprecated) {
+        this.deprecated = deprecated;
+    }
+
     public BuildEnvironment.Builder toDBEntityBuilder() {
         return BuildEnvironment.Builder.newBuilder()
                 .id(this.getId())
@@ -145,6 +157,7 @@ public class BuildEnvironmentRest implements GenericRestEntity<Integer> {
                 .systemImageRepositoryUrl(this.getSystemImageRepositoryUrl())
                 .systemImageId(this.getSystemImageId())
                 .attributes(this.getAttributes())
-                .systemImageType(this.getSystemImageType());
+                .systemImageType(this.getSystemImageType())
+                .deprecated(this.isDeprecated());
     }
 }


### PR DESCRIPTION
This commit adds the field 'deprecated' to the 'BuildEnvironment' model
to indicate which build environments are deprecated and shouldn't be
used in current/future build environments.

Note that this commit doesn't add a restriction on the backend on
assigning a deprecated build environment to a build configuration. This
is done so that you can still modify an existing build configuration
using deprecated build environment.