### PR TITLE
Extract temporary as a separate flag in TargetRepository

### DIFF
--- a/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
+++ b/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
@@ -192,6 +192,7 @@ public class DatastoreTest {
                 .repositoryType(TargetRepository.Type.MAVEN)
                 .repositoryPath("builds-untested")
                 .identifier("indy-maven")
+                .temporaryRepo(false)
                 .build();
         targetRepository = targetRepositoryRepository.save(targetRepository);
         logger.info("Saved targetRepository: {}", targetRepository);
@@ -261,6 +262,7 @@ public class DatastoreTest {
                 .repositoryType(TargetRepository.Type.MAVEN)
                 .repositoryPath("builds-untested")
                 .identifier("indy-maven")
+                .temporaryRepo(false)
                 .build();
 
         String now = Instant.now().toString();
@@ -268,6 +270,7 @@ public class DatastoreTest {
                 .repositoryType(TargetRepository.Type.MAVEN)
                 .repositoryPath("temp-" + now)
                 .identifier("indy-maven")
+                .temporaryRepo(true)
                 .build();
 
         Artifact builtArtifact1 = Artifact.Builder.newBuilder()

--- a/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
+++ b/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
@@ -116,7 +116,7 @@ public class DatastoreTest {
 
     @Inject
     LicenseRepository licenseRepository;
-    
+
     @Inject
     UserRepository userRepository;
 
@@ -129,7 +129,7 @@ public class DatastoreTest {
     }
 
     /**
-     * The data initialization of the build configurations needs to be done in a separate test method so that 
+     * The data initialization of the build configurations needs to be done in a separate test method so that
      * the transaction can complete, and the hibernate envers BuildConfigurationAudit is created.
      */
     @Test
@@ -217,7 +217,7 @@ public class DatastoreTest {
                 .username("pnc").email("pnc@redhat.com").build();
         user = userRepository.save(user);
         Assert.assertNotNull(user.getId());
-        
+
         BuildRecord buildRecord = BuildRecord.Builder.newBuilder().id(datastore.getNextBuildRecordId())
                 .buildConfigurationAudited(buildConfigAud)
                 .submitTime(Date.from(Instant.now()))
@@ -267,7 +267,7 @@ public class DatastoreTest {
         TargetRepository targetRepositoryTmp = TargetRepository.builder()
                 .repositoryType(TargetRepository.Type.MAVEN)
                 .repositoryPath("temp-" + now)
-                .identifier("indy-maven-temp")
+                .identifier("indy-maven")
                 .build();
 
         Artifact builtArtifact1 = Artifact.Builder.newBuilder()
@@ -302,7 +302,7 @@ public class DatastoreTest {
                 .username("pnc2").email("pnc2@redhat.com").build();
         user = userRepository.save(user);
         Assert.assertNotNull(user.getId());
-        
+
         BuildRecord.Builder buildRecordBuilder = BuildRecord.Builder.newBuilder()
                 .id(datastore.getNextBuildRecordId())
                 .buildConfigurationAudited(buildConfigAud)

--- a/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
+++ b/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
@@ -427,6 +427,7 @@ public class DatabaseDataInitializer {
                 .repositoryType(TargetRepository.Type.MAVEN)
                 .repositoryPath("builds-untested")
                 .identifier("indy-maven")
+                .temporaryRepo(false)
                 .build();
 
         targetRepositoryRepository.save(targetRepository);
@@ -479,7 +480,7 @@ public class DatabaseDataInitializer {
         importedArtifact1 = artifactRepository.save(importedArtifact1);
         importedArtifact2 = artifactRepository.save(importedArtifact2);
 
-        Set<BuildRecord> buildRecords = new HashSet<BuildRecord>();
+        Set<BuildRecord> buildRecords = new HashSet<>();
 
         final int INITIAL_REVISION = 1;
         IdRev buildConfig1AuditIdRev = new IdRev(buildConfiguration1.getId(), INITIAL_REVISION);

--- a/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
+++ b/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
@@ -275,7 +275,7 @@ public class MavenRepositorySession implements RepositorySession {
                     originUrl = download.getLocalUrl();
                 }
 
-                TargetRepository.Type repoType = toRepoType(download.getAccessChannel(), false); //no temp downloads (they are all together)
+                TargetRepository.Type repoType = toRepoType(download.getAccessChannel());
                 TargetRepository targetRepository = getDownloadsTargetRepository(repoType);
 
                 Artifact.Builder artifactBuilder = Artifact.Builder.newBuilder()
@@ -305,17 +305,19 @@ public class MavenRepositorySession implements RepositorySession {
 
     private TargetRepository getDownloadsTargetRepository(TargetRepository.Type repoType) throws RepositoryManagerException {
         TargetRepository targetRepository;
-        if (repoType.equals(TargetRepository.Type.MAVEN) || repoType.equals(TargetRepository.Type.MAVEN_TEMPORARY)) {
+        if (repoType.equals(TargetRepository.Type.MAVEN)) {
             targetRepository = TargetRepository.builder()
                     .identifier("indy-maven")
                     .repositoryType(repoType)
                     .repositoryPath("/api/content/maven/hosted/shared-imports/")
+                    .temporaryRepo(false)
                     .build();
         } else if (repoType.equals(TargetRepository.Type.GENERIC_PROXY)) {
             targetRepository = TargetRepository.builder()
                     .identifier("indy-http")
                     .repositoryType(repoType)
                     .repositoryPath("/not-available/") //TODO set the path for http cache
+                    .temporaryRepo(false)
                     .build();
         } else {
             throw new RepositoryManagerException("Repository type " + repoType + " is not yet supported.");
@@ -400,7 +402,7 @@ public class MavenRepositorySession implements RepositorySession {
 
                 logger.info("Recording upload: {}", identifier);
 
-                TargetRepository.Type repoType = toRepoType(upload.getAccessChannel(), isTempBuild);
+                TargetRepository.Type repoType = toRepoType(upload.getAccessChannel());
                 TargetRepository targetRepository = getUploadsTargetRepository(repoType);
 
                 Artifact.Quality artifactQuality = getArtifactQuality(isTempBuild);
@@ -531,14 +533,10 @@ public class MavenRepositorySession implements RepositorySession {
         return false;
     }
 
-    private TargetRepository.Type toRepoType(AccessChannel accessChannel, boolean isTempBuild) {
+    private TargetRepository.Type toRepoType(AccessChannel accessChannel) {
         switch (accessChannel) {
             case MAVEN_REPO:
-                if (isTempBuild) {
-                    return TargetRepository.Type.MAVEN_TEMPORARY;
-                } else {
-                    return TargetRepository.Type.MAVEN;
-                }
+                return TargetRepository.Type.MAVEN;
             case GENERIC_PROXY:
                 return TargetRepository.Type.GENERIC_PROXY;
             default:

--- a/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
+++ b/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
@@ -326,16 +326,17 @@ public class MavenRepositorySession implements RepositorySession {
     private TargetRepository getUploadsTargetRepository(TargetRepository.Type repoType) throws RepositoryManagerException {
         TargetRepository targetRepository;
         if (repoType.equals(TargetRepository.Type.MAVEN)) {
+            String groupName;
+            if (isTempBuild) {
+                groupName = TEMPORARY_BUILDS_GROUP;
+            } else {
+                groupName = UNTESTED_BUILDS_GROUP;
+            }
             targetRepository = TargetRepository.builder()
                     .identifier("indy-maven")
                     .repositoryType(TargetRepository.Type.MAVEN)
-                    .repositoryPath("/api/content/maven/group/" + UNTESTED_BUILDS_GROUP)
-                    .build();
-        } else if (repoType.equals(TargetRepository.Type.MAVEN_TEMPORARY)) {
-            targetRepository = TargetRepository.builder()
-                    .identifier("indy-maven-temp")
-                    .repositoryType(TargetRepository.Type.MAVEN_TEMPORARY)
-                    .repositoryPath("/api/content/maven/group/" + TEMPORARY_BUILDS_GROUP)
+                    .repositoryPath("/api/content/maven/group/" + groupName)
+                    .temporaryRepo(isTempBuild)
                     .build();
         } else {
             throw new RepositoryManagerException("Repository type " + repoType + " is not yet supported.");

--- a/model/src/main/java/org/jboss/pnc/model/TargetRepository.java
+++ b/model/src/main/java/org/jboss/pnc/model/TargetRepository.java
@@ -116,7 +116,6 @@ public class TargetRepository implements GenericEntity<Integer> {
          * Maven artifact repository such as Maven central (http://central.maven.org/maven2/)
          */
         MAVEN,
-        MAVEN_TEMPORARY,
 
         /**
          * Node.js package repository such as https://registry.npmjs.org/

--- a/model/src/main/java/org/jboss/pnc/model/TargetRepository.java
+++ b/model/src/main/java/org/jboss/pnc/model/TargetRepository.java
@@ -60,6 +60,15 @@ public class TargetRepository implements GenericEntity<Integer> {
     private Integer id;
 
     /**
+     * Flag that the repository is temporary.
+     */
+    @Getter
+    @Setter
+    @NotNull
+    @Column(updatable=false)
+    private Boolean temporaryRepo;
+
+    /**
      * Identifier to link repository configurations (eg. hostname)
      */
     @Getter
@@ -143,7 +152,7 @@ public class TargetRepository implements GenericEntity<Integer> {
      * @return true if the artifact url came from a trusted repo, false otherwise
      */
     static boolean isTrusted(String artifactOriginUrl, TargetRepository targetRepository) {
-        if (targetRepository.repositoryType.equals(Type.MAVEN_TEMPORARY)) {
+        if (targetRepository.temporaryRepo) {
             return false;
         }
         if (artifactOriginUrl == null || artifactOriginUrl.isEmpty()) {

--- a/model/src/main/resources/db-update/00001-from-1.2.0-to-1.3.0.sql
+++ b/model/src/main/resources/db-update/00001-from-1.2.0-to-1.3.0.sql
@@ -22,6 +22,7 @@ create sequence target_repository_repo_id_seq;
 -- ## Updates required by new artifact repository relations
 create table TargetRepository (
     id integer not null,
+    temporaryRepo boolean not null,
     identifier varchar(255) not null,
     repositoryPath varchar(255) not null,
     repositoryType varchar(255) not null,
@@ -29,17 +30,16 @@ create table TargetRepository (
     unique (identifier, repositoryPath)
 );
 -- insert default repositories
-insert into TargetRepository (id, identifier, repositoryPath, repositoryType) values (1, 'indy-maven', 'builds-untested', 'MAVEN');
-insert into TargetRepository (id, identifier, repositoryPath, repositoryType) values (2, 'indy-maven', 'builds-untested-temp', 'MAVEN_TEMPORARY');
-insert into TargetRepository (id, identifier, repositoryPath, repositoryType) values (3, 'indy-maven', 'shared-imports', 'MAVEN');
-insert into TargetRepository (id, identifier, repositoryPath, repositoryType) values (4, 'indy-maven', 'shared-imports', 'MAVEN_TEMPORARY');
-insert into TargetRepository (id, identifier, repositoryPath, repositoryType) values (5, 'indy-http', '', 'GENERIC_PROXY');
+insert into TargetRepository (id, temporaryRepo, identifier, repositoryPath, repositoryType) values (1, false, 'indy-maven', '/api/content/maven/group/builds-untested', 'MAVEN');
+insert into TargetRepository (id, temporaryRepo, identifier, repositoryPath, repositoryType) values (2, true, 'indy-maven', '/api/content/maven/group/temporary-builds', 'MAVEN');
+insert into TargetRepository (id, temporaryRepo, identifier, repositoryPath, repositoryType) values (3, false, 'indy-maven', '/api/content/maven/hosted/shared-imports', 'MAVEN');
+insert into TargetRepository (id, temporaryRepo, identifier, repositoryPath, repositoryType) values (4, false, 'indy-http', '', 'GENERIC_PROXY');
 
 -- Start the sequence id for target repository from last value = 6
 -- We need to set last_value to 6 and not to 5 because the sequence has column
 -- 'is_called' set to false
 -- https://www.postgresql.org/docs/8.1/static/functions-sequence.html
-alter sequence target_repository_repo_id_seq restart with 6;
+alter sequence target_repository_repo_id_seq restart with 5;
 
 -- Artifact
 alter table Artifact add targetRepository_id integer;
@@ -53,7 +53,7 @@ alter table Artifact
 -- old repotype 0 -> maven (1)
 -- old repotype 3 -> generic proxy (5)
 update Artifact set targetRepository_id = 1 where repotype = 0;
-update Artifact set targetRepository_id = 5 where repotype = 3;
+update Artifact set targetRepository_id = 4 where repotype = 3;
 
 alter table Artifact alter column targetRepository_id set not null;
 alter table Artifact drop column repotype;

--- a/model/src/test/java/org/jboss/pnc/model/ArtifactTest.java
+++ b/model/src/test/java/org/jboss/pnc/model/ArtifactTest.java
@@ -106,6 +106,7 @@ public class ArtifactTest extends AbstractModelTest {
                 .identifier("Indy")
                 .repositoryPath("/api")
                 .repositoryType(TargetRepository.Type.MAVEN)
+                .temporaryRepo(false)
                 .build();
         em.getTransaction().begin();
         em.persist(targetRepository);

--- a/model/src/test/java/org/jboss/pnc/model/BasicModelTest.java
+++ b/model/src/test/java/org/jboss/pnc/model/BasicModelTest.java
@@ -36,7 +36,7 @@ public class BasicModelTest extends AbstractModelTest {
 
     /** located in src/test/resources */
     final static String DBUNIT_DATASET_FILE = "basic-model-test-data.xml";
-    
+
     private User pncUser;
 
     protected final RepositoryConfiguration basicRepositoryConfiguration = RepositoryConfiguration.Builder
@@ -159,6 +159,7 @@ public class BasicModelTest extends AbstractModelTest {
 
     private TargetRepository getTargetRepository(String path) {
         return TargetRepository.builder()
+                    .temporaryRepo(false)
                     .identifier("indy-maven")
                     .repositoryPath(path)
                     .repositoryType(TargetRepository.Type.MAVEN)
@@ -300,7 +301,7 @@ public class BasicModelTest extends AbstractModelTest {
     public void testProductVersionBrewTagGeneration() {
         EntityManager em = getEmFactory().createEntityManager();
         EntityTransaction tx = em.getTransaction();
-        
+
         final String version = "10.1";
         Product product = Product.Builder.newBuilder().id(1)
                 .build();
@@ -316,7 +317,7 @@ public class BasicModelTest extends AbstractModelTest {
 
         ProductVersion productVersionLoaded = em.find(ProductVersion.class, productVersionOriginal.getId());
         Assert.assertEquals("tp1-" + version + "-pnc", productVersionLoaded.getAttributes().get(ProductVersion.ATTRIBUTE_KEY_BREW_TAG_PREFIX));
-        
-        
+
+
     }
 }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/model/builders/ArtifactBuilder.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/model/builders/ArtifactBuilder.java
@@ -66,6 +66,7 @@ public class ArtifactBuilder {
                 .identifier("indy-maven")
                 .repositoryPath(path)
                 .repositoryType(TargetRepository.Type.MAVEN)
+                .temporaryRepo(false)
                 .build();
     }
 

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/TargetRepositoryRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/TargetRepositoryRest.java
@@ -54,6 +54,13 @@ public class TargetRepositoryRest implements GenericEntity<Integer> {
     @Null(groups = WhenCreatingNew.class)
     private Integer id;
 
+    /**
+     * Flag that the repository is temporary.
+     */
+    @Getter
+    @NotNull(groups = {WhenUpdating.class, WhenCreatingNew.class})
+    private Boolean temporaryRepo;
+
     @Getter
     @NotNull(groups = {WhenUpdating.class, WhenCreatingNew.class})
     private String identifier;
@@ -76,11 +83,13 @@ public class TargetRepositoryRest implements GenericEntity<Integer> {
         identifier = targetRepository.getIdentifier();
         repositoryType = targetRepository.getRepositoryType();
         repositoryPath = targetRepository.getRepositoryPath();
+        temporaryRepo = targetRepository.getTemporaryRepo();
     }
 
     public TargetRepository.TargetRepositoryBuilder toDBEntityBuilder() {
         return TargetRepository.builder()
                 .id(id)
+                .temporaryRepo(temporaryRepo)
                 .identifier(identifier)
                 .repositoryType(repositoryType)
                 .repositoryPath(repositoryPath)

--- a/rest/src/main/java/org/jboss/pnc/rest/provider/ArtifactProvider.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/provider/ArtifactProvider.java
@@ -100,7 +100,7 @@ public class ArtifactProvider extends AbstractProvider<Artifact, ArtifactRest> {
 
     /**
      * Lookups built artifacts for the specified BuildRecord
-     * 
+     *
      * @return Returns requested artifacts or empty collection if BuildRecord with the specified ID doesn't exists
      */
     public CollectionInfo<ArtifactRest> getBuiltArtifactsForBuildRecord(int pageIndex, int pageSize, String sortingRsql, String query,
@@ -126,7 +126,7 @@ public class ArtifactProvider extends AbstractProvider<Artifact, ArtifactRest> {
 
     private String getDeployUrl(Artifact artifact) {
         TargetRepository.Type repositoryType = artifact.getTargetRepository().getRepositoryType();
-        if (repositoryType.equals(TargetRepository.Type.MAVEN) || repositoryType.equals(TargetRepository.Type.MAVEN_TEMPORARY)) {
+        if (repositoryType.equals(TargetRepository.Type.MAVEN)) {
             if (artifact.getDeployPath() == null || artifact.getDeployPath().equals("")) {
                 return "";
             } else {
@@ -146,7 +146,7 @@ public class ArtifactProvider extends AbstractProvider<Artifact, ArtifactRest> {
 
     private String getPublicUrl(Artifact artifact) {
         TargetRepository.Type repositoryType = artifact.getTargetRepository().getRepositoryType();
-        if (repositoryType.equals(TargetRepository.Type.MAVEN) || repositoryType.equals(TargetRepository.Type.MAVEN_TEMPORARY)) {
+        if (repositoryType.equals(TargetRepository.Type.MAVEN)) {
             if (artifact.getDeployPath() == null || artifact.getDeployPath().equals("")) {
                 return "";
             } else {
@@ -178,14 +178,17 @@ public class ArtifactProvider extends AbstractProvider<Artifact, ArtifactRest> {
         return null;
     }
 
+    @Override
     public Integer store(ArtifactRest restEntity) throws RestValidationException {
         throw new UnsupportedOperationException("Direct artifact manipulation is not available.");
     }
 
+    @Override
     public void update(Integer id, ArtifactRest restEntity) throws RestValidationException {
         throw new UnsupportedOperationException("Direct artifact manipulation is not available.");
     }
 
+    @Override
     public void delete(Integer id) throws RestValidationException {
         throw new UnsupportedOperationException("Direct artifact manipulation is not available.");
     }

--- a/ui/app/build-records/views/build-records.detail.artifacts.html
+++ b/ui/app/build-records/views/build-records.detail.artifacts.html
@@ -44,7 +44,7 @@
           <td>{{ artifact.identifier }}</td>
           <td>{{ artifact.artifactQuality }}</td>
           <td>{{ artifact.filename }}</td>
-          <td>{{ artifact.repoType }}</td>
+          <td>{{ artifact.targetRepository.repositoryType }}</td>
           <td>
             <div class="checksum checksum-md5">
               {{ artifact.md5 }}


### PR DESCRIPTION
The flag was merged into repository type, which does not make much sense
and made the code more complicated, since 2 values had to be checked for
a single repository type.