### PR TITLE
[NCL-3695]: Don't use toString method to pass parameters to Maitai - 1.3

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/utils/BpmNotifier.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/utils/BpmNotifier.java
@@ -84,7 +84,7 @@ public class BpmNotifier {
         HttpPost request = new HttpPost(uri);
 
         List<NameValuePair> parameters = new ArrayList<>();
-        parameters.add(new BasicNameValuePair("event", buildResultRest != null ? buildResultRest.toString() : "{\"error\", \"" + errMessage + "\"}"));
+        parameters.add(new BasicNameValuePair("event", buildResultRest != null ? buildResultRest.toFullLogString() : "{\"error\", \"" + errMessage + "\"}"));
 
         UrlEncodedFormEntity entity = null;
         try {


### PR DESCRIPTION
… BuildResultRest