### PR TITLE
[v1.3] Fix monitor bug and builder image not starting

### DIFF
--- a/common/src/main/java/org/jboss/pnc/common/monitor/PullingMonitor.java
+++ b/common/src/main/java/org/jboss/pnc/common/monitor/PullingMonitor.java
@@ -97,14 +97,21 @@ public class PullingMonitor {
      * @param timeUnit Unit used for checkInterval and timeout
      */
     public void monitor(Runnable onMonitorComplete, Consumer<Exception> onMonitorError, Supplier<Boolean> condition, int checkInterval, int timeout, TimeUnit timeUnit) {
-        AtomicInteger timeWaiting = new AtomicInteger(0);
 
         ObjectWrapper<RunningTask> runningTaskReference = new ObjectWrapper<>();
         Runnable monitor = () -> {
             RunningTask runningTask = runningTaskReference.get();
-            try {
-                int waiting = timeWaiting.addAndGet(checkInterval);
 
+            if (runningTask == null) {
+                /* There might be a situation where this runnable is called before runningTaskReference is set with the
+                 * running task since this runnable is scheduled to run before runningTaskReference is set. In that
+                 * case, we just skip this runnable and re-run on the next scheduled interval with the assumption that
+                 * runningTaskReference will be set before the next re-run
+                 */
+                log.debug("runningTask not set yet inside the 'monitor' runnable! Skipping!");
+                return;
+            }
+            try {
                 // Check if given condition is satisfied
                 if (condition.get()) {
                     runningTasks.remove(runningTask);
@@ -112,6 +119,7 @@ public class PullingMonitor {
                     onMonitorComplete.run();
                 }
             } catch (Exception e) {
+                log.error("Exception in monitor runnable", e);
                 runningTasks.remove(runningTask);
                 runningTask.cancel();
                 onMonitorError.accept(e);


### PR DESCRIPTION
Monitor bug
-----------
The 'monitor' bug inside `PullingMonitor` class happens in situations
where the `monitor` runnable is run before `runningTaskReference` is set
with the running task since the runnable is scheduled to run before
`runningTaskReference` is set.

In those cases, we just skip this runnable run and re-run it on the next
scheduled interval with the assumption that `runningTaskReference` will
be set before the next re-run.

Without the fix, if the condition is true, we'll try to remove from the
'runningTasks' ConcurrentSet object a null object
('runningTaskReference' contains a null object, that null object is
assigned to variable 'runningTask' inside the runnable). This causes the
'remove' method to throw a NullPointerException.

Ironically, the NullPointerException is caught by the 'catch' part,
which again tries to call the `remove` method with 'null' as parameter!
A new stacktrace is thrown. Unfortunately the latter gets
lost inside the 'catch' part and nothing is shown in the logs.

This exception causes the next scheduled runs of the runnable to be
cancelled.

Some additional logs are added to try to discover these issues.

Builder Image not starting
--------------------------
When the Openshift object definitions are sent to the Openshift cluster
to start a new builder image, we run checks to make sure that the
builder agent's pod, service, and route are created and running.

Those checks use the 'monitor' method to periodically ask the Openshift
cluster if those 3 objects are created, and if the pod is replying to
'http pings'.

If the check succeeds immediately (and the 'condition' returns true
really fast), there's a risk we experience the 'monitor' bug and that
causes Orch to think that the entire environment is not yet ready,
even though it's actually ready on Openshift.

The 'waiting' and 'timeWaiting' variables are removed since they are not used.