### PR TITLE
[v1.3] NCL-3810 Fixes: When BC wizard is re-opened after an error the SCM UR…

### DIFF
--- a/ui/app/build-configs/directives/pnc-select-repository/pncSelectRepository.js
+++ b/ui/app/build-configs/directives/pnc-select-repository/pncSelectRepository.js
@@ -52,7 +52,7 @@
         }
 
         if (angular.isDefined($ctrl.userData.scmUrl)) {
-          $ctrl.checkForRepo($ctrl.userData.scmUrl)
+          $ctrl.checkForRepo($ctrl.userData.scmUrl);
         }
       };
     };

--- a/ui/app/build-configs/directives/pnc-select-repository/pncSelectRepository.js
+++ b/ui/app/build-configs/directives/pnc-select-repository/pncSelectRepository.js
@@ -33,7 +33,7 @@
 
 
     // -- Controller API --
-    
+
     $ctrl.userData = {};
     $ctrl.checkForRepo = checkForRepo;
     $ctrl.isLoading = isLoading;
@@ -49,6 +49,10 @@
         // set default only if there is no initial value coming from ngModel
         if (typeof $ctrl.userData.preBuildSyncEnabled === 'undefined') {
           $ctrl.userData.preBuildSyncEnabled = true;
+        }
+
+        if (angular.isDefined($ctrl.userData.scmUrl)) {
+          $ctrl.checkForRepo($ctrl.userData.scmUrl)
         }
       };
     };


### PR DESCRIPTION
…L is not checked to see if an RC already exists causing a 409 on submit

(cherry picked from commit 6cad99cf1459aabdecbca805edde2a27dfa6ad20)
Signed-off-by: Alex Creasy <acreasy@redhat.com>