### PR TITLE
[NCL-3816] Fix predicates for buildconfigset

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationSetEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationSetEndpoint.java
@@ -283,7 +283,7 @@ public class BuildConfigurationSetEndpoint extends AbstractEndpoint<BuildConfigu
             @ApiParam(value = PAGE_SIZE_DESCRIPTION) @QueryParam(PAGE_SIZE_QUERY_PARAM) @DefaultValue(PAGE_SIZE_DEFAULT_VALUE) int pageSize,
             @ApiParam(value = SORTING_DESCRIPTION) @QueryParam(SORTING_QUERY_PARAM) String sort,
             @ApiParam(value = QUERY_DESCRIPTION, required = false) @QueryParam(QUERY_QUERY_PARAM) String q) {
-        return fromCollection(buildRecordProvider.getAllForBuildConfigSetRecord(pageIndex, pageSize, sort, q, id));
+        return fromCollection(buildRecordProvider.getAllForBuildConfigSet(pageIndex, pageSize, sort, q, id));
     }
 
     @ApiOperation(value = "Builds the Configurations for the Specified Set")

--- a/rest/src/main/java/org/jboss/pnc/rest/provider/BuildRecordProvider.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/provider/BuildRecordProvider.java
@@ -82,6 +82,7 @@ import static org.jboss.pnc.rest.utils.StreamHelper.nullableStreamOf;
 import static org.jboss.pnc.spi.datastore.predicates.BuildRecordPredicates.withArtifactDistributedInMilestone;
 import static org.jboss.pnc.spi.datastore.predicates.BuildRecordPredicates.withAttribute;
 import static org.jboss.pnc.spi.datastore.predicates.BuildRecordPredicates.withBuildConfigSetId;
+import static org.jboss.pnc.spi.datastore.predicates.BuildRecordPredicates.withBuildConfigSetRecordId;
 import static org.jboss.pnc.spi.datastore.predicates.BuildRecordPredicates.withBuildConfigurationId;
 import static org.jboss.pnc.spi.datastore.predicates.BuildRecordPredicates.withBuildConfigurationIdRev;
 import static org.jboss.pnc.spi.datastore.predicates.BuildRecordPredicates.withUserId;
@@ -295,6 +296,11 @@ public class BuildRecordProvider extends AbstractProvider<BuildRecord, BuildReco
     }
 
     public CollectionInfo<BuildRecordRest> getAllForBuildConfigSetRecord(int pageIndex, int pageSize, String sortingRsql,
+            String rsql, Integer buildConfigurationSetRecordId) {
+        return queryForCollection(pageIndex, pageSize, sortingRsql, rsql, withBuildConfigSetRecordId(buildConfigurationSetRecordId));
+    }
+
+    public CollectionInfo<BuildRecordRest> getAllForBuildConfigSet(int pageIndex, int pageSize, String sortingRsql,
             String rsql, Integer buildConfigurationSetId) {
         return queryForCollection(pageIndex, pageSize, sortingRsql, rsql, withBuildConfigSetId(buildConfigurationSetId));
     }

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuildRecordPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuildRecordPredicates.java
@@ -21,6 +21,8 @@ import org.jboss.pnc.model.Artifact;
 import org.jboss.pnc.model.Artifact_;
 import org.jboss.pnc.model.BuildConfigSetRecord;
 import org.jboss.pnc.model.BuildConfigSetRecord_;
+import org.jboss.pnc.model.BuildConfigurationSet;
+import org.jboss.pnc.model.BuildConfigurationSet_;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.BuildRecord_;
 import org.jboss.pnc.model.BuildStatus;
@@ -73,8 +75,12 @@ public class BuildRecordPredicates {
 
     public static Predicate<BuildRecord> withBuildConfigSetId(Integer buildConfigSetId) {
         return (root, query, cb) -> {
-            Join<BuildRecord, BuildConfigSetRecord> joinedConfiguSet = root.join(BuildRecord_.buildConfigSetRecord);
-            return cb.equal(joinedConfiguSet.get(org.jboss.pnc.model.BuildConfigSetRecord_.id), buildConfigSetId);
+
+            Join<BuildRecord, BuildConfigSetRecord> builtConfigSetRecord = root.join(BuildRecord_.buildConfigSetRecord);
+
+            Join<BuildConfigSetRecord, BuildConfigurationSet> buildConfigSet = builtConfigSetRecord.join(BuildConfigSetRecord_.buildConfigurationSet);
+
+            return cb.equal(buildConfigSet.get(BuildConfigurationSet_.id), buildConfigSetId);
         };
     }
 


### PR DESCRIPTION
The predicate fix is for getting a list of BuildRecord from a build
config set id.