### PR TITLE
[1.3] NCL-3509 Support usage of Indy 1.2.x and earlier

### DIFF
--- a/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
+++ b/maven-repository-manager/src/main/java/org/jboss/pnc/mavenrepositorymanager/MavenRepositorySession.java
@@ -521,6 +521,17 @@ public class MavenRepositorySession implements RepositorySession {
                         throw new RepositoryManagerException("Failed to set readonly flag on repo: %s. Reason given was: %s",
                                 ex, hostedKey, ex.getMessage());
                     }
+                } else {
+                    // support usage of Indy 1.2.x and earlier, which sets readonly flag as part of the promotion
+                    HostedRepository hosted = indy.stores().load(hostedKey, HostedRepository.class);
+                    if (hosted.isReadonly()) {
+                        hosted.setReadonly(false);
+                        try {
+                            indy.stores().update(hosted, "Reset readonly flag for temporary build after promotion.");
+                        } catch (IndyClientException ex) {
+                            logger.error("Failed to reset readonly flag on repo: %s. Reason given was: %s.", ex, hostedKey, ex.getMessage());
+                        }
+                    }
                 }
             } else {
                 String reason = result.getError();


### PR DESCRIPTION
It sets readonly flag as part of the promotion, which we don't want to
do for temporary builds. So we have to reset it after the promotion.

This is worth probably only for PNC 1.3, because 1.4 and on will use
Indy 1.3.x for sure.