### PR TITLE
Track REST endpoint metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,12 @@ You only need to define the key for which you want to modify its definition. The
 
 ## Metrics support
 
-PNC tracks metrics of JVM and its internals via Dropwizard Metrics. The metrics can currently be reported to a Graphite server by specifying as system property or environment variables those three properties:
-- metrics\_graphite\_server
-- metrics\_graphite\_port
-- metrics\_graphite\_prefix
+PNC tracks metrics of JVM and its internals via Dropwizard Metrics. The metrics can currently be reported to a Graphite server by specifying as system property or environment variables those properties:
+- metrics\_graphite\_server (mandatory)
+- metrics\_graphite\_port (mandatory)
+- metrics\_graphite\_prefix (mandatory)
+- metrics\_graphite\_interval (optional)
+
+If the `metrics_graphite_interval` variable (interval specified in seconds) is not specified, we'll use the default value of 60 seconds to report data to Graphite.
+
+The graphite reporter is configured to report rates per second and durations in terms of milliseconds.

--- a/integration-test/src/test/resources/application.xml
+++ b/integration-test/src/test/resources/application.xml
@@ -73,6 +73,9 @@
     <java>causeway-client.jar</java>
   </module>
   <module>
+    <java>metrics.jar</java>
+  </module>
+  <module>
     <web>
       <web-uri>rest.war</web-uri>
       <context-root>/pnc-rest</context-root>

--- a/metrics/src/main/java/org/jboss/pnc/metrics/MetricsConfiguration.java
+++ b/metrics/src/main/java/org/jboss/pnc/metrics/MetricsConfiguration.java
@@ -52,6 +52,10 @@ public class MetricsConfiguration {
     private static final String  GRAPHITE_PORT_KEY = "metrics_graphite_port";
     private static final String  GRAPHITE_PREFIX_KEY = "metrics_graphite_prefix";
 
+    // The interval is in seconds
+    private static final String  GRAPHITE_INTERVAL_KEY = "metrics_graphite_interval";
+    private static final int DEFAULT_GRAPHITE_INTERVAL = 60;
+
     @Getter
     private MetricRegistry metricRegistry;
 
@@ -118,13 +122,30 @@ public class MetricsConfiguration {
      *
      */
     private void setupGraphiteReporter() {
+
+        int graphiteInterval = DEFAULT_GRAPHITE_INTERVAL;
+
+        try {
+
+            graphiteInterval = Integer.parseInt(
+                    getValueFromProperty(GRAPHITE_INTERVAL_KEY, "Graphite Interval reporting"));
+
+        } catch (NumberFormatException e) {
+
+            // thrown because we couldn't parse the interval as a number
+            logger.warn("Could not parse Graphite interval! Using default value of {} seconds instead", DEFAULT_GRAPHITE_INTERVAL);
+
+        } catch(NoPropertyException e) {
+            // If we're here that property is not specified. Just continue using the default
+        }
+
         try {
 
             String graphiteServer = getValueFromProperty(GRAPHITE_SERVER_KEY, "Graphite Server URL");
             int graphitePort = Integer.parseInt(getValueFromProperty(GRAPHITE_PORT_KEY, "Graphite Port"));
             String graphitePrefix = getValueFromProperty(GRAPHITE_PREFIX_KEY, "Graphite Prefix");
 
-            startGraphiteReporter(graphiteServer, graphitePort, graphitePrefix);
+            startGraphiteReporter(graphiteServer, graphitePort, graphitePrefix, graphiteInterval);
 
         } catch (NumberFormatException e) {
 
@@ -144,8 +165,9 @@ public class MetricsConfiguration {
      * @param host   Graphite server
      * @param port   Graphite port (usually 2003)
      * @param prefix Prefix to use as a namespace for our logs
+     * @param interval interval at which to report metrics to Graphite in seconds
      */
-    private void startGraphiteReporter(String host, int port, String prefix) {
+    private void startGraphiteReporter(String host, int port, String prefix, int interval) {
 
         logger.info("Setting up Graphite reporter");
 
@@ -158,6 +180,6 @@ public class MetricsConfiguration {
                 .filter(MetricFilter.ALL)
                 .build(graphite);
 
-        reporter.start(1, TimeUnit.MINUTES);
+        reporter.start(interval, TimeUnit.SECONDS);
     }
 }

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -90,6 +90,11 @@
       <artifactId>messaging</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>metrics</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Remote dependencies -->
     <dependency>

--- a/rest/src/main/java/org/jboss/pnc/rest/configuration/JaxRsActivator.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/configuration/JaxRsActivator.java
@@ -18,6 +18,9 @@
 package org.jboss.pnc.rest.configuration;
 
 import io.swagger.jaxrs.config.BeanConfig;
+import org.jboss.pnc.rest.configuration.metrics.GeneralRestMetricsFilter;
+import org.jboss.pnc.rest.configuration.metrics.TimedMetric;
+import org.jboss.pnc.rest.configuration.metrics.TimedMetricFilter;
 import org.jboss.pnc.rest.debug.TestEndpoint;
 import org.jboss.pnc.rest.endpoint.BpmEndpoint;
 import org.jboss.pnc.rest.endpoint.BuildConfigSetRecordEndpoint;
@@ -69,6 +72,7 @@ public class JaxRsActivator extends Application {
         Set<Class<?>> resources = new HashSet<>();
         addSwaggerResources(resources);
         addProjectResources(resources);
+        addMetricsResources(resources);
         return resources;
     }
 
@@ -126,6 +130,12 @@ public class JaxRsActivator extends Application {
     private void addSwaggerResources(Set<Class<?>> resources) {
         resources.add(io.swagger.jaxrs.listing.ApiListingResource.class);
         resources.add(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+    }
+
+    private void addMetricsResources(Set<Class<?>> resources) {
+        resources.add(GeneralRestMetricsFilter.class);
+        resources.add(TimedMetric.class);
+        resources.add(TimedMetricFilter.class);
     }
 
     private String getRestBasePath() throws IOException {

--- a/rest/src/main/java/org/jboss/pnc/rest/configuration/metrics/GeneralRestMetricsFilter.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/configuration/metrics/GeneralRestMetricsFilter.java
@@ -1,0 +1,70 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.configuration.metrics;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.jboss.pnc.metrics.MetricsConfiguration;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+@Provider
+public class GeneralRestMetricsFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private static final String METRICS_RATE_KEY = "pnc.rest.all.rate";
+    private static final String METRICS_TIMER_KEY = "pnc.rest.all.timer";
+
+    @Inject
+    private MetricsConfiguration metricsConfiguration;
+
+    @Inject
+    private HttpServletRequest servletRequest;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+
+        MetricRegistry registry = metricsConfiguration.getMetricRegistry();
+
+        Timer timer = registry.timer(METRICS_TIMER_KEY);
+        Meter meter = registry.meter(METRICS_RATE_KEY);
+
+        Timer.Context counter = timer.time();
+        meter.mark();
+
+        servletRequest.setAttribute("timer.context", counter);
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+
+        Timer.Context tc = (Timer.Context) servletRequest.getAttribute("timer.context");
+
+        if (tc != null) {
+            tc.stop();
+            servletRequest.removeAttribute("timer.context");
+        }
+    }
+}

--- a/rest/src/main/java/org/jboss/pnc/rest/configuration/metrics/TimedMetric.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/configuration/metrics/TimedMetric.java
@@ -1,0 +1,33 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.configuration.metrics;
+
+import javax.ws.rs.NameBinding;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotate this to any REST method to get a timer and request rate of the particular method reported
+ */
+@NameBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface TimedMetric {
+}

--- a/rest/src/main/java/org/jboss/pnc/rest/configuration/metrics/TimedMetricFilter.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/configuration/metrics/TimedMetricFilter.java
@@ -1,0 +1,87 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.configuration.metrics;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.jboss.pnc.metrics.MetricsConfiguration;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+@Provider
+@Priority(Priorities.USER)
+@TimedMetric
+public class TimedMetricFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private static final String METRICS_KEY = "pnc.rest";
+    private static final String METRICS_RATE_KEY = ".rate";
+    private static final String METRICS_TIMER_KEY = ".timer";
+
+    @Context
+    private ResourceInfo resourceInfo;
+
+    @Inject
+    private MetricsConfiguration metricsConfiguration;
+
+    @Inject
+    private HttpServletRequest servletRequest;
+
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+
+        MetricRegistry registry = metricsConfiguration.getMetricRegistry();
+
+        String metricsName = METRICS_KEY +
+                name(resourceInfo.getResourceClass().getSimpleName(), resourceInfo.getResourceMethod().getName());
+
+        Timer timer = registry.timer(metricsName + METRICS_TIMER_KEY);
+        Meter meter = registry.meter(metricsName + METRICS_RATE_KEY);
+
+        Timer.Context counter = timer.time();
+        meter.mark();
+
+        servletRequest.setAttribute("timer.context.method", counter);
+
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+
+        Timer.Context tc = (Timer.Context) servletRequest.getAttribute("timer.context.method");
+
+        if (tc != null) {
+            tc.stop();
+            servletRequest.removeAttribute("timer.context.method");
+        }
+    }
+}

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigSetRecordEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigSetRecordEndpoint.java
@@ -26,6 +26,7 @@ import org.jboss.pnc.coordinator.maintenance.Result;
 import org.jboss.pnc.coordinator.maintenance.TemporaryBuildsCleanerAsyncInvoker;
 import org.jboss.pnc.model.BuildConfigSetRecord;
 import org.jboss.pnc.model.User;
+import org.jboss.pnc.rest.configuration.metrics.TimedMetric;
 import org.jboss.pnc.rest.provider.BuildConfigSetRecordProvider;
 import org.jboss.pnc.rest.provider.BuildRecordProvider;
 import org.jboss.pnc.rest.restmodel.BuildConfigSetRecordRest;
@@ -118,6 +119,7 @@ public class BuildConfigSetRecordEndpoint extends AbstractEndpoint<BuildConfigSe
             @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = ErrorResponseRest.class)
     })
     @GET
+    @TimedMetric
     public Response getAll(
             @ApiParam(value = PAGE_INDEX_DESCRIPTION) @QueryParam(PAGE_INDEX_QUERY_PARAM) @DefaultValue(PAGE_INDEX_DEFAULT_VALUE) int pageIndex,
             @ApiParam(value = PAGE_SIZE_DESCRIPTION) @QueryParam(PAGE_SIZE_QUERY_PARAM) @DefaultValue(PAGE_SIZE_DEFAULT_VALUE) int pageSize,

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildEndpoint.java
@@ -25,6 +25,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.User;
+import org.jboss.pnc.rest.configuration.metrics.TimedMetric;
 import org.jboss.pnc.rest.provider.BuildRecordProvider;
 import org.jboss.pnc.rest.restmodel.BuildRecordRest;
 import org.jboss.pnc.rest.restmodel.response.error.ErrorResponseRest;
@@ -110,6 +111,7 @@ public class BuildEndpoint extends AbstractEndpoint<BuildRecord, BuildRecordRest
             @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = ErrorResponseRest.class)
     })
     @GET
+    @TimedMetric
     public Response getAll(
             @ApiParam(value = PAGE_INDEX_DESCRIPTION) @QueryParam(PAGE_INDEX_QUERY_PARAM) @DefaultValue(PAGE_INDEX_DEFAULT_VALUE) int pageIndex,
             @ApiParam(value = PAGE_SIZE_DESCRIPTION) @QueryParam(PAGE_SIZE_QUERY_PARAM) @DefaultValue(PAGE_SIZE_DEFAULT_VALUE) int pageSize,

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildRecordEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildRecordEndpoint.java
@@ -26,6 +26,7 @@ import org.jboss.pnc.coordinator.maintenance.Result;
 import org.jboss.pnc.coordinator.maintenance.TemporaryBuildsCleanerAsyncInvoker;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.User;
+import org.jboss.pnc.rest.configuration.metrics.TimedMetric;
 import org.jboss.pnc.rest.provider.ArtifactProvider;
 import org.jboss.pnc.rest.provider.BuildRecordProvider;
 import org.jboss.pnc.rest.restmodel.BuildRecordRest;
@@ -123,6 +124,7 @@ public class BuildRecordEndpoint extends AbstractEndpoint<BuildRecord, BuildReco
     })
     @GET
     @Override
+    @TimedMetric
     public Response getAll(
             @ApiParam(value = PAGE_INDEX_DESCRIPTION) @QueryParam(PAGE_INDEX_QUERY_PARAM) @DefaultValue(PAGE_INDEX_DEFAULT_VALUE) int pageIndex,
             @ApiParam(value = PAGE_SIZE_DESCRIPTION) @QueryParam(PAGE_SIZE_QUERY_PARAM) @DefaultValue(PAGE_SIZE_DEFAULT_VALUE) int pageSize,


### PR DESCRIPTION
This PR includes:
- Add ability to specify rate of reporting data to Graphite
- Track all REST request metrics
- Track specific REST request metrics

![newrate_rest](https://user-images.githubusercontent.com/630746/39888441-cc4a75dc-5462-11e8-82e9-1afd1022de43.png)