### PR TITLE
[NCL-3855] Failed to delete temporary build

### DIFF
--- a/auth/src/main/java/org/jboss/pnc/auth/KeycloakClient.java
+++ b/auth/src/main/java/org/jboss/pnc/auth/KeycloakClient.java
@@ -28,6 +28,7 @@ import java.io.UnsupportedEncodingException;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.jboss.pnc.auth.keycloakutil.util.HttpUtil.APPLICATION_FORM_URL_ENCODED;
 import static org.jboss.pnc.auth.keycloakutil.util.HttpUtil.doPost;
+import static org.jboss.pnc.auth.keycloakutil.util.HttpUtil.setSslRequired;
 import static org.jboss.pnc.auth.keycloakutil.util.HttpUtil.urlencode;
 
 /**
@@ -35,11 +36,11 @@ import static org.jboss.pnc.auth.keycloakutil.util.HttpUtil.urlencode;
  */
 class KeycloakClient {
 
-    static AccessTokenResponse getAuthTokensBySecret(String server, String realm, String clientId, String secret) {
-        return getAuthTokensBySecret(server, realm, null, null, clientId, secret);
+    static AccessTokenResponse getAuthTokensBySecret(String server, String realm, String clientId, String secret, boolean sslRequired) {
+        return getAuthTokensBySecret(server, realm, null, null, clientId, secret, sslRequired);
     }
 
-    static AccessTokenResponse getAuthTokensBySecret(String server, String realm, String user, String password, String clientId, String secret) {
+    static AccessTokenResponse getAuthTokensBySecret(String server, String realm, String user, String password, String clientId, String secret, boolean sslRequired) {
         StringBuilder body = new StringBuilder();
         try {
             if (user != null) {
@@ -55,6 +56,7 @@ class KeycloakClient {
                 body.append("grant_type=client_credentials");
             }
 
+            setSslRequired(sslRequired);
             InputStream result = doPost(server + "/realms/" + realm + "/protocol/openid-connect/token",
                     APPLICATION_FORM_URL_ENCODED, APPLICATION_JSON, body.toString(), BasicAuthHelper.createHeader(clientId, secret));
             return JsonSerialization.readValue(result, AccessTokenResponse.class);

--- a/auth/src/main/java/org/jboss/pnc/auth/KeycloakServiceClient.java
+++ b/auth/src/main/java/org/jboss/pnc/auth/KeycloakServiceClient.java
@@ -43,7 +43,8 @@ public class KeycloakServiceClient {
                 keycloakServiceAccountConfig.getAuthServerUrl(),
                 keycloakServiceAccountConfig.getRealm(),
                 keycloakServiceAccountConfig.getResource(),
-                keycloakServiceAccountConfig.getSecret());
+                keycloakServiceAccountConfig.getSecret(),
+                keycloakServiceAccountConfig.getSslRequired());
         return keycloakToken.getToken();
     }
 }

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/KeycloakClientConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/KeycloakClientConfig.java
@@ -33,7 +33,7 @@ public class KeycloakClientConfig {
     private final String realm;
     private final String realmPublicKey;
     private final String authServerUrl;
-    private final String sslRequired;
+    private final Boolean sslRequired;
     private final String resource;
     private final Map<String, String> credentials;
 
@@ -42,7 +42,7 @@ public class KeycloakClientConfig {
             @JsonProperty("realm") String realm,
             @JsonProperty("realm-public-key") String realmPublicKey,
             @JsonProperty("auth-server-url") String authServerUrl,
-            @JsonProperty("ssl-required") @DefaultValue("none") String sslRequired,
+            @JsonProperty("ssl-required") Boolean sslRequired,
             @JsonProperty("resource") String resource,
             @JsonProperty("credentials") @DefaultValue("{}") Map<String, String> credentials) {
         this.realm = realm;


### PR DESCRIPTION
Respect the ssl-required setting in pnc-config to allow talking to
keycloak without SSL client verification. Also changing the expected
value type from string to boolean, because the string value "none" used
before is EAP specific and has no meaning in our context.

The setting of the sslRequired value is done in KeycloakClient before
performing the request. It is not thread-safe but when we use single
value coming from config which cannot be changed during runtime, it
should be ok.