### PR TITLE
[Not merge] Fix indy-weft injection problem during IT

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -43,6 +43,12 @@
       <artifactId>ear-package</artifactId>
       <scope>test</scope>
       <type>ear</type>
+      <exclusions>
+        <exclusion>
+          <groupId>org.commonjava.cdi.util</groupId>
+          <artifactId>weft</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>
@@ -54,6 +60,10 @@
         <exclusion>
           <groupId>org.jboss.pnc</groupId>
           <artifactId>datastore</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.commonjava.cdi.util</groupId>
+          <artifactId>weft</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Seems when weft wrapped in the ear, this problem will happen. Not sure why jboss CDI environment can not find weft config @Default bean. But after remove it, I can run the it smoothly on my local env.
@pkocandr you can have this fix in and try on you local (Please clear all cached dependency and built target then try it)