### PR TITLE
Use Indy 1.2.0 for now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <!--<version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.0.Final-redhat-1</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>-->
     <version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>1.0.1.Final-redhat-3</version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>
     <atlasVersion>0.16.0</atlasVersion>
-    <indyVersion>1.2.0-SNAPSHOT</indyVersion>
+    <indyVersion>1.2.0</indyVersion>
     <version.jboss.bom>1.0.7.Final</version.jboss.bom>
     <version.assertj-core>3.8.0</version.assertj-core>
     <version.mockito>2.8.47</version.mockito>


### PR DESCRIPTION
Using Indy client 1.3.0.2 is causing tests to fail. To progress now we will temporarily stick to 1.2.0.