### PR TITLE
[WIP] Prototype for REST refactor design

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,8 @@
   </developers>
 
   <modules>
+    <module>prototype-rest-model</module>
+    <module>prototype-rest-api</module>
     <module>test-common</module>
     <module>common</module>
     <module>causeway-client</module>
@@ -83,6 +85,8 @@
     <module>model</module>
     <module>rest</module>
     <module>rest-model</module>
+    <module>prototype-facade</module>
+    <module>prototype-rest</module>
     <module>spi</module>
     <module>ui</module>
     <module>web</module>
@@ -334,6 +338,18 @@
 
       <dependency>
         <groupId>org.jboss.pnc</groupId>
+        <artifactId>prototype-rest-model</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.pnc</groupId>
+        <artifactId>prototype-facade</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.pnc</groupId>
         <artifactId>bpm</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -344,6 +360,13 @@
         <version>${project.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.jboss.pnc</groupId>
+        <artifactId>prototype-rest-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+
         <!-- Use this dependency to attach WAR itself -->
       <dependency>
         <groupId>org.jboss.pnc</groupId>
@@ -351,6 +374,14 @@
         <version>${project.version}</version>
         <type>war</type>
       </dependency>
+
+      <dependency>
+        <groupId>org.jboss.pnc</groupId>
+        <artifactId>prototype-rest</artifactId>
+        <version>${project.version}</version>
+        <type>war</type>
+      </dependency>
+
 
         <!-- Use this dependency to attach war classes -->
       <dependency>
@@ -491,13 +522,13 @@
       <dependency>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-jaxrs</artifactId>
-        <version>1.5.3</version>
+        <version>1.5.20</version>
       </dependency>
 
       <dependency>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-core</artifactId>
-        <version>1.5.3</version>
+        <version>1.5.20</version>
       </dependency>
 
       <dependency>

--- a/prototype-facade/pom.xml
+++ b/prototype-facade/pom.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source.
+    Copyright 2014 Red Hat, Inc., and individual contributors
+    as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>parent</artifactId>
+    <groupId>org.jboss.pnc</groupId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>prototype-facade</artifactId>
+  <packaging>jar</packaging>
+
+  <description>REST DTO.</description>
+
+  <dependencies>
+    <!-- Project dependencies -->
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>model</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.pnc</groupId>
+        <artifactId>spi</artifactId>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.pnc</groupId>
+        <artifactId>prototype-rest-model</artifactId>
+        <scope>provided</scope>
+    </dependency>
+
+    <!-- Remote dependencies -->
+    <dependency>
+        <groupId>org.jboss.spec.javax.ejb</groupId>
+        <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>javax.enterprise</groupId>
+        <artifactId>cdi-api</artifactId>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+    <!-- TODO only here as lombok is too eager to do everything-->
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-validator</groupId>
+      <artifactId>commons-validator</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>test-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>pnc-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>${project.artifactId}</finalName>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>auth-container-eap</id>
+      <activation>
+        <property>
+          <name>auth.eap.home</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jboss.as.plugins</groupId>
+            <artifactId>jboss-as-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>start-server</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+                <configuration>
+                  <jbossHome>${auth.eap.home}</jbossHome>
+                </configuration>
+              </execution>
+              <execution>
+                <id>shutdown-server</id>
+                <phase>process-test-resources</phase>
+                <goals>
+                  <goal>shutdown</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/facade/mappers/AbstractMapper.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/facade/mappers/AbstractMapper.java
@@ -1,0 +1,65 @@
+package org.jboss.pnc.rest.facade.mappers;
+
+import org.jboss.pnc.rest.facade.mappers.api.EntityMapper;
+import org.jboss.pnc.model.GenericEntity;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ *
+ * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
+ */
+public abstract class AbstractMapper<DB extends GenericEntity<?>, Rest, Ref> implements EntityMapper<DB, Rest, Ref> {
+
+    protected Instant toInstant(final Date time) {
+        if (time != null) {
+            return time.toInstant();
+        }
+        return null;
+    }
+
+    protected Date toDate(final Instant time) {
+        if (time != null) {
+            return Date.from(time);
+        }
+        return null;
+    }
+
+    protected <K, V> Map<K, V> toMap(final Map<K, V> map) {
+        if (map != null) {
+            return Collections.unmodifiableMap(map);
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    protected <V> Set<V> toSet(final Set<V> set) {
+        if (set != null) {
+            return Collections.unmodifiableSet(set);
+        } else {
+            return Collections.emptySet();
+        }
+    }
+
+    protected <I extends Serializable> I toId(GenericEntity<I> entity) {
+        if (entity != null) {
+            return entity.getId();
+        }
+        return null;
+    }
+
+    protected <I extends Serializable> Set<I> toIds(Collection<? extends GenericEntity<I>> entities) {
+        if (entities != null) {
+            return entities.stream().map(GenericEntity::getId).collect(Collectors.toSet());
+        }
+        return Collections.emptySet();
+    }
+
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/facade/mappers/BuildConfigurationMapper.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/facade/mappers/BuildConfigurationMapper.java
@@ -1,0 +1,87 @@
+package org.jboss.pnc.rest.facade.mappers;
+
+import org.jboss.pnc.model.BuildConfiguration;
+import org.jboss.pnc.rest.model.BuildConfigurationRef;
+import org.jboss.pnc.rest.model.BuildConfigurationRest;
+
+import java.time.Instant;
+
+/**
+ *
+ * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
+ */
+public class BuildConfigurationMapper extends AbstractMapper<BuildConfiguration, BuildConfigurationRest, BuildConfigurationRef> {
+
+    private RepositoryConfigurationMapper repositoryConfigurationMapper;
+    private ProjectMapper projectMapper;
+    private EnvironmentMapper environmentMapper;
+    private BuildTypeMapper buildTypeMapper; // won't need if enums are in some common module
+
+    @Override
+    public BuildConfigurationRest toRest(BuildConfiguration buildConfiguration) {
+        if (buildConfiguration == null) {
+            return null;
+        }
+
+        return BuildConfigurationRest.builder()
+                .id(buildConfiguration.getId())
+                .name(buildConfiguration.getName())
+                .description(buildConfiguration.getDescription())
+                .buildScript(buildConfiguration.getBuildScript())
+                .scmRevision(buildConfiguration.getScmRevision())
+                .creationTime(toInstant(buildConfiguration.getCreationTime()))
+                .lastModificationTime(toInstant(buildConfiguration.getLastModificationTime()))
+                .archived(buildConfiguration.isArchived())
+                .genericParameters(toMap(buildConfiguration.getGenericParameters()))
+                .repositoryConfiguration(repositoryConfigurationMapper
+                        .toRef(buildConfiguration.getRepositoryConfiguration()))
+                .project(projectMapper.toRef(buildConfiguration.getProject()))
+                .environment(environmentMapper.toRef(buildConfiguration.getBuildEnvironment()))
+                .dependencyIds(toIds(buildConfiguration.getDependencies()))
+                .productVersionId(toId(buildConfiguration.getProductVersion()))
+                .buildType(buildTypeMapper.map(buildConfiguration.getBuildType()))
+                .build();
+    }
+
+    @Override
+    public BuildConfigurationRef toRef(BuildConfiguration buildConfiguration) {
+        if (buildConfiguration == null) {
+            return null;
+        }
+        Instant i;
+
+
+        return BuildConfigurationRef.builder()
+                .id(buildConfiguration.getId())
+                .name(buildConfiguration.getName())
+                .description(buildConfiguration.getDescription())
+                .buildScript(buildConfiguration.getBuildScript())
+                .scmRevision(buildConfiguration.getScmRevision())
+                .creationTime(toInstant(buildConfiguration.getCreationTime()))
+                .lastModificationTime(toInstant(buildConfiguration.getLastModificationTime()))
+                .archived(buildConfiguration.isArchived())
+                .genericParameters(toMap(buildConfiguration.getGenericParameters()))
+                .productVersionId(toId(buildConfiguration.getProductVersion()))
+                .buildType(buildTypeMapper.map(buildConfiguration.getBuildType()))
+                .build();
+    }
+
+    @Override
+    public BuildConfiguration toEntity(BuildConfigurationRest buildConfiguration) {
+        if (buildConfiguration == null) {
+            return null;
+        }
+
+        BuildConfiguration.Builder builder = BuildConfiguration.Builder.newBuilder()
+                .id(buildConfiguration.getId())
+                .name(buildConfiguration.getName())
+                .description(buildConfiguration.getDescription())
+                .buildScript(buildConfiguration.getBuildScript())
+                .scmRevision(buildConfiguration.getScmRevision())
+                .archived(buildConfiguration.isArchived())
+                .genericParameters(buildConfiguration.getGenericParameters())
+                .buildType(buildTypeMapper.map(buildConfiguration.getBuildType()));
+        // TODO do we want to map also refs to entities?
+        return builder.build();
+    }
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/facade/mappers/BuildTypeMapper.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/facade/mappers/BuildTypeMapper.java
@@ -1,0 +1,19 @@
+package org.jboss.pnc.rest.facade.mappers;
+
+import org.jboss.pnc.rest.model.enums.BuildType;
+
+/**
+ *
+ * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
+ */
+class BuildTypeMapper {
+
+    BuildType map(org.jboss.pnc.model.BuildType buildType) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    org.jboss.pnc.model.BuildType map(BuildType buildType) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/facade/mappers/EnvironmentMapper.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/facade/mappers/EnvironmentMapper.java
@@ -1,0 +1,16 @@
+package org.jboss.pnc.rest.facade.mappers;
+
+import org.jboss.pnc.model.BuildEnvironment;
+import org.jboss.pnc.rest.model.BuildEnvironmentRef;
+
+/**
+ *
+ * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
+ */
+class EnvironmentMapper {
+
+    BuildEnvironmentRef toRef(BuildEnvironment buildEnvironment) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/facade/mappers/ProjectMapper.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/facade/mappers/ProjectMapper.java
@@ -1,0 +1,16 @@
+package org.jboss.pnc.rest.facade.mappers;
+
+import org.jboss.pnc.model.Project;
+import org.jboss.pnc.rest.model.ProjectRef;
+
+/**
+ *
+ * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
+ */
+class ProjectMapper {
+
+    ProjectRef toRef(Project project) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/facade/mappers/RepositoryConfigurationMapper.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/facade/mappers/RepositoryConfigurationMapper.java
@@ -1,0 +1,16 @@
+package org.jboss.pnc.rest.facade.mappers;
+
+import org.jboss.pnc.model.RepositoryConfiguration;
+import org.jboss.pnc.rest.model.RepositoryConfigurationRef;
+
+/**
+ *
+ * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
+ */
+class RepositoryConfigurationMapper {
+
+    RepositoryConfigurationRef toRef(RepositoryConfiguration repositoryConfiguration) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/facade/mappers/api/EntityMapper.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/facade/mappers/api/EntityMapper.java
@@ -1,0 +1,17 @@
+package org.jboss.pnc.rest.facade.mappers.api;
+
+import org.jboss.pnc.model.GenericEntity;
+
+/**
+ *
+ * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
+ */
+public interface EntityMapper<DB extends GenericEntity<?>, Rest, Ref> {
+
+    DB toEntity(Rest buildConfiguration);
+
+    Ref toRef(DB buildConfiguration);
+
+    Rest toRest(DB buildConfiguration);
+
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/provider/AbstractProvider.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/provider/AbstractProvider.java
@@ -1,0 +1,169 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.rest.provider;
+
+import com.google.common.collect.ObjectArrays;
+
+import org.jboss.pnc.model.GenericEntity;
+import org.jboss.pnc.rest.facade.mappers.api.EntityMapper;
+import org.jboss.pnc.rest.validation.exceptions.RestValidationException;
+import org.jboss.pnc.rest.validation.groups.WhenCreatingNew;
+import org.jboss.pnc.rest.validation.groups.WhenDeleting;
+import org.jboss.pnc.rest.validation.groups.WhenUpdating;
+import org.jboss.pnc.spi.datastore.repositories.PageInfoProducer;
+import org.jboss.pnc.spi.datastore.repositories.SortInfoProducer;
+import org.jboss.pnc.spi.datastore.repositories.api.PageInfo;
+import org.jboss.pnc.spi.datastore.repositories.api.Predicate;
+import org.jboss.pnc.spi.datastore.repositories.api.RSQLPredicateProducer;
+import org.jboss.pnc.spi.datastore.repositories.api.Repository;
+import org.jboss.pnc.spi.datastore.repositories.api.SortInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
+import java.util.function.Function;
+
+import org.jboss.pnc.rest.provider.collection.CollectionInfo;
+import org.jboss.pnc.rest.provider.collection.CollectionInfoCollector;
+import static org.jboss.pnc.rest.utils.StreamHelper.nullableStreamOf;
+import org.jboss.pnc.rest.validation.ValidationBuilder;
+import org.jboss.pnc.rest.provider.api.Provider;
+
+/**
+ * Abstract provider with common functionality.
+ *
+ * @author Sebastian Laskawiec
+ */
+public abstract class AbstractProvider<DB extends GenericEntity<Integer>, Rest> implements Provider<DB, Rest> {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractProvider.class);
+
+    protected RSQLPredicateProducer rsqlPredicateProducer;
+
+    protected SortInfoProducer sortInfoProducer;
+
+    protected PageInfoProducer pageInfoProducer;
+
+    protected Repository<DB, Integer> repository;
+
+    protected EntityMapper<DB, Rest, ?> mapper;
+
+
+    public AbstractProvider(Repository<DB, Integer> repository, RSQLPredicateProducer rsqlPredicateProducer, SortInfoProducer sortInfoProducer,
+            PageInfoProducer pageInfoProducer) {
+        this.repository = repository;
+        this.rsqlPredicateProducer = rsqlPredicateProducer;
+        this.sortInfoProducer = sortInfoProducer;
+        this.pageInfoProducer = pageInfoProducer;
+    }
+
+    @Override
+    public CollectionInfo<Rest> getAll(int pageIndex, int pageSize, String sortingRsql, String query) {
+        return queryForCollection(pageIndex, pageSize, sortingRsql, query, new Predicate[0]);
+    }
+
+    @Override
+    public CollectionInfo<Rest> queryForCollection(int pageIndex, int pageSize, String sortingRsql, String query,
+            Predicate<DB>... predicates) {
+        Predicate<DB> rsqlPredicate = rsqlPredicateProducer.getPredicate(getDBEntityClass(), query);
+        PageInfo pageInfo = pageInfoProducer.getPageInfo(pageIndex, pageSize);
+        SortInfo sortInfo = sortInfoProducer.getSortInfo(sortingRsql);
+
+        List<DB> collection;
+        int totalPages;
+        if(predicates == null) {
+            collection = repository.queryWithPredicates(pageInfo, sortInfo, rsqlPredicate);
+            totalPages = (repository.count(rsqlPredicate) + pageSize - 1) / pageSize;
+        } else {
+            collection = repository.queryWithPredicates(pageInfo, sortInfo, ObjectArrays.concat(rsqlPredicate, predicates));
+            totalPages = (repository.count(ObjectArrays.concat(rsqlPredicate, predicates)) + pageSize - 1) / pageSize;
+        }
+
+        return nullableStreamOf(collection)
+                .map(toRESTModel())
+                .collect(new CollectionInfoCollector<>(pageIndex, pageSize, totalPages));
+    }
+
+    @Override
+    public Rest getSpecific(Integer id) {
+        DB dbEntity = repository.queryById(id);
+        if (dbEntity != null) {
+            return toRESTModel().apply(dbEntity);
+        }
+        return null;
+    }
+
+    @Override
+    public Integer store(Rest restEntity) throws RestValidationException {
+        validateBeforeSaving(restEntity);
+        log.debug("Storing entity: " + restEntity.toString());
+        return repository.save(toDBModel().apply(restEntity)).getId();
+    }
+
+    @Override
+    public void update(Integer id, Rest restEntity) throws RestValidationException {
+        validateBeforeUpdating(id, restEntity);
+        log.debug("Updating entity: " + restEntity.toString());
+        repository.save(toDBModel().apply(restEntity));
+    }
+
+    @Override
+    public void delete(Integer id) throws RestValidationException {
+        validateBeforeDeleting(id);
+        repository.delete(id);
+    }
+
+    protected void validateBeforeUpdating(Integer id, Rest restEntity) throws RestValidationException {
+        ValidationBuilder.validateObject(restEntity, WhenUpdating.class)
+                .validateNotEmptyArgument()
+                .validateAnnotations()
+                .validateAgainstRepository(repository, id, true);
+    }
+
+    protected void validateBeforeSaving(Rest restEntity) throws RestValidationException {
+        ValidationBuilder.validateObject(restEntity, WhenCreatingNew.class)
+                .validateNotEmptyArgument().validateAnnotations();
+    }
+
+    protected void validateBeforeDeleting(Integer id) throws RestValidationException {
+        ValidationBuilder.validateObject(WhenDeleting.class)
+                .validateAgainstRepository(repository, id, true)
+                .validateAnnotations();
+    }
+
+    protected Function<? super DB, ? extends Rest> toRESTModel() {
+        return mapper::toRest;
+    }
+
+    protected Function<? super Rest, ? extends DB> toDBModel() {
+        return mapper::toEntity;
+    }
+
+    public Class<DB> getDBEntityClass() {
+        ParameterizedType superclass = (ParameterizedType) getClass().getGenericSuperclass();
+        return (Class<DB>) superclass.getActualTypeArguments()[0];
+    }
+
+    public Class<DB> getRESTEntityClass() {
+        ParameterizedType superclass = (ParameterizedType) getClass().getGenericSuperclass();
+        return (Class<DB>) superclass.getActualTypeArguments()[1];
+    }
+
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProviderImpl.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/provider/BuildConfigurationProviderImpl.java
@@ -1,0 +1,231 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.provider;
+
+import org.jboss.pnc.common.json.ConfigurationParseException;
+import org.jboss.pnc.model.BuildConfiguration;
+import org.jboss.pnc.model.BuildConfigurationSet;
+import org.jboss.pnc.model.ProductVersion;
+import org.jboss.pnc.rest.model.BuildConfigurationRest;
+import org.jboss.pnc.rest.model.RepositoryConfigurationRef;
+import org.jboss.pnc.rest.provider.api.BuildConfigurationProvider;
+import org.jboss.pnc.rest.provider.collection.CollectionInfo;
+import org.jboss.pnc.rest.validation.ConflictedEntryValidator;
+import org.jboss.pnc.rest.validation.ValidationBuilder;
+import org.jboss.pnc.rest.validation.exceptions.InvalidEntityException;
+import org.jboss.pnc.rest.validation.exceptions.RestValidationException;
+import org.jboss.pnc.rest.validation.groups.WhenCreatingNew;
+import org.jboss.pnc.rest.validation.groups.WhenUpdating;
+import org.jboss.pnc.spi.datastore.repositories.BuildConfigurationRepository;
+import org.jboss.pnc.spi.datastore.repositories.BuildConfigurationSetRepository;
+import org.jboss.pnc.spi.datastore.repositories.PageInfoProducer;
+import org.jboss.pnc.spi.datastore.repositories.ProductVersionRepository;
+import org.jboss.pnc.spi.datastore.repositories.SortInfoProducer;
+import org.jboss.pnc.spi.datastore.repositories.api.RSQLPredicateProducer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.jboss.pnc.rest.validation.exceptions.ConflictedEntryException;
+import static org.jboss.pnc.spi.datastore.predicates.BuildConfigurationPredicates.isNotArchived;
+import static org.jboss.pnc.spi.datastore.predicates.BuildConfigurationPredicates.withBuildConfigurationSetId;
+import static org.jboss.pnc.spi.datastore.predicates.BuildConfigurationPredicates.withDependantConfiguration;
+import static org.jboss.pnc.spi.datastore.predicates.BuildConfigurationPredicates.withName;
+import static org.jboss.pnc.spi.datastore.predicates.BuildConfigurationPredicates.withProductId;
+import static org.jboss.pnc.spi.datastore.predicates.BuildConfigurationPredicates.withProductVersionId;
+import static org.jboss.pnc.spi.datastore.predicates.BuildConfigurationPredicates.withProjectId;
+
+@Stateless
+public class BuildConfigurationProviderImpl extends AbstractProvider<BuildConfiguration, BuildConfigurationRest> implements BuildConfigurationProvider {
+
+    private final Logger logger = LoggerFactory.getLogger(BuildConfigurationProviderImpl.class);
+
+    private static final Pattern REPOSITORY_NAME_PATTERN = Pattern.compile("(\\/[\\w\\.:\\~_-]+)+(\\.git)(?:\\/?|\\#[\\d\\w\\.\\-_]+?)$");
+
+    private final BuildConfigurationSetRepository buildConfigurationSetRepository;
+
+    private final ProductVersionRepository productVersionRepository;
+
+    @Inject
+    public BuildConfigurationProviderImpl(BuildConfigurationRepository buildConfigurationRepository,
+            BuildConfigurationSetRepository buildConfigurationSetRepository,
+            RSQLPredicateProducer rsqlPredicateProducer, SortInfoProducer sortInfoProducer, PageInfoProducer pageInfoProducer,
+            ProductVersionRepository productVersionRepository) throws ConfigurationParseException {
+        super(buildConfigurationRepository, rsqlPredicateProducer, sortInfoProducer, pageInfoProducer);
+        this.buildConfigurationSetRepository = buildConfigurationSetRepository;
+        this.productVersionRepository = productVersionRepository;
+    }
+
+    @Override
+    public CollectionInfo<BuildConfigurationRest> getAllNonArchived(Integer pageIndex, Integer pageSize, String sortingRsql,
+            String query) {
+        return queryForCollection(pageIndex, pageSize, sortingRsql, query, isNotArchived());
+    }
+
+    @Override
+    public CollectionInfo<BuildConfigurationRest> getAllForProject(Integer pageIndex, Integer pageSize, String sortingRsql,
+            String query, Integer projectId) {
+        return queryForCollection(pageIndex, pageSize, sortingRsql, query, withProjectId(projectId), isNotArchived());
+    }
+
+    @Override
+    public CollectionInfo<BuildConfigurationRest> getAllForProduct(int pageIndex, int pageSize, String sortingRsql,
+            String query, Integer productId) {
+        return queryForCollection(pageIndex, pageSize, sortingRsql, query, withProductId(productId), isNotArchived());
+    }
+
+    @Override
+    public CollectionInfo<BuildConfigurationRest> getAllForProductAndProductVersion(int pageIndex, int pageSize,
+            String sortingRsql, String query, Integer productId, Integer versionId) {
+        return queryForCollection(pageIndex, pageSize, sortingRsql, query, withProductVersionId(versionId), isNotArchived());
+    }
+
+    @Override
+    public CollectionInfo<BuildConfigurationRest> getAllForBuildConfigurationSet(int pageIndex, int pageSize,
+            String sortingRsql, String query, Integer buildConfigurationSetId) {
+        return queryForCollection(pageIndex, pageSize, sortingRsql, query,
+                withBuildConfigurationSetId(buildConfigurationSetId), isNotArchived());
+    }
+
+    @Override
+    protected void validateBeforeSaving(BuildConfigurationRest buildConfigurationRest) throws RestValidationException {
+        super.validateBeforeSaving(buildConfigurationRest);
+        validateIfItsNotConflicted(buildConfigurationRest);
+        validateRepositoryConfigurationId(buildConfigurationRest.getRepositoryConfiguration());
+    }
+
+    @Override
+    protected void validateBeforeUpdating(Integer id, BuildConfigurationRest buildConfigurationRest)
+            throws RestValidationException {
+        super.validateBeforeUpdating(id, buildConfigurationRest);
+        validateIfItsNotConflicted(buildConfigurationRest);
+        validateDependencies(buildConfigurationRest.getId(), buildConfigurationRest.getDependencyIds());
+    }
+
+    private void validateRepositoryConfigurationId(RepositoryConfigurationRef repositoryConfiguration) throws InvalidEntityException {
+        if (repositoryConfiguration == null)
+            throw new InvalidEntityException("RepositoryConfiguration entity has to be created before creating a new BuildConfiguration.");
+    }
+
+    private void validateDependencies(Integer buildConfigId, Set<Integer> dependenciesIds) throws InvalidEntityException {
+        if (dependenciesIds == null || dependenciesIds.isEmpty()) {
+            return;
+        }
+
+        BuildConfiguration buildConfig = repository.queryById(buildConfigId);
+        for (Integer dependencyId : dependenciesIds) {
+
+            ValidationBuilder.validateObject(buildConfig, WhenUpdating.class).validateCondition(
+                    !buildConfig.getId().equals(dependencyId), "A build configuration cannot depend on itself");
+
+            BuildConfiguration dependency = repository.queryById(dependencyId);
+            ValidationBuilder.validateObject(buildConfig, WhenUpdating.class)
+                    .validateCondition(!dependency.getAllDependencies().contains(buildConfig), "Cannot add dependency from : "
+                            + buildConfig.getId() + " to: " + dependencyId + " because it would introduce a cyclic dependency");
+        }
+    }
+
+    private void validateIfItsNotConflicted(BuildConfigurationRest buildConfigurationRest)
+            throws ConflictedEntryException, InvalidEntityException {
+        ValidationBuilder.validateObject(buildConfigurationRest, WhenUpdating.class).validateConflict(() -> {
+            BuildConfiguration buildConfigurationFromDB =
+                    repository.queryByPredicates(withName(buildConfigurationRest.getName()), isNotArchived());
+
+            // don't validate against myself
+            if (buildConfigurationFromDB != null && !buildConfigurationFromDB.getId().equals(buildConfigurationRest.getId())) {
+                return new ConflictedEntryValidator.ConflictedEntryValidationError(buildConfigurationFromDB.getId(),
+                        BuildConfiguration.class, "Build configuration with the same name already exists");
+            }
+            return null;
+        });
+    }
+
+    public void archive(Integer buildConfigurationId)  throws RestValidationException {
+        ValidationBuilder.validateObject(WhenUpdating.class).validateAgainstRepository(repository, buildConfigurationId,
+                true);
+        BuildConfiguration buildConfiguration = repository.queryById(buildConfigurationId);
+        buildConfiguration.setArchived(true);
+
+        // if a build configuration is archived, unlink the build configuration from the build configuration sets it
+        // is associated with
+        for (BuildConfigurationSet bcs: buildConfiguration.getBuildConfigurationSets()) {
+            bcs.removeBuildConfiguration(buildConfiguration);
+            buildConfigurationSetRepository.save(bcs);
+        }
+
+        repository.save(buildConfiguration);
+    }
+
+    public Integer clone(Integer buildConfigurationId) throws RestValidationException {
+        ValidationBuilder.validateObject(WhenCreatingNew.class).validateAgainstRepository(repository, buildConfigurationId, true);
+        BuildConfiguration buildConfiguration = repository.queryById(buildConfigurationId);
+        BuildConfiguration clonedBuildConfiguration = buildConfiguration.clone();
+        clonedBuildConfiguration = repository.save(clonedBuildConfiguration);
+        logger.debug("Cloned saved BuildConfiguration: {}", clonedBuildConfiguration);
+        return clonedBuildConfiguration.getId();
+    }
+
+    @Override
+    public void addDependency(Integer configId, Integer dependencyId) throws RestValidationException {
+        BuildConfiguration buildConfig = repository.queryById(configId);
+        BuildConfiguration dependency = repository.queryById(dependencyId);
+
+        ValidationBuilder.validateObject(buildConfig, WhenUpdating.class)
+                .validateCondition(buildConfig != null, "No build config exists with id: " + configId)
+                .validateCondition(dependency != null, "No dependency build config exists with id: " + dependencyId)
+                .validateCondition(!configId.equals(dependencyId), "A build configuration cannot depend on itself")
+                .validateCondition(!dependency.getAllDependencies().contains(buildConfig), "Cannot add dependency from : "
+                        + configId + " to: " + dependencyId + " because it would introduce a cyclic dependency");
+        System.out.println("didn't throw any validation errors");
+        buildConfig.addDependency(dependency);
+        repository.save(buildConfig);
+    }
+
+    public void removeDependency(Integer configId, Integer dependencyId) throws RestValidationException {
+        BuildConfiguration buildConfig = repository.queryById(configId);
+        BuildConfiguration dependency = repository.queryById(dependencyId);
+        ValidationBuilder.validateObject(buildConfig, WhenUpdating.class)
+                .validateCondition(buildConfig != null, "No build config exists with id: " + configId)
+                .validateCondition(dependency != null, "No dependency build config exists with id: " + dependencyId);
+        buildConfig.removeDependency(dependency);
+        repository.save(buildConfig);
+    }
+
+    public void setProductVersion(Integer configId, Integer productVersionId) throws RestValidationException {
+        BuildConfiguration buildConfig = repository.queryById(configId);
+        ValidationBuilder.validateObject(buildConfig, WhenUpdating.class)
+                .validateCondition(buildConfig!=null, "No build config exists with id: " + configId);
+        ProductVersion productVersion = null;
+        if (productVersionId != null) {
+            productVersion = productVersionRepository.queryById(productVersionId);
+        }
+        buildConfig.setProductVersion(productVersion);
+        repository.save(buildConfig);
+    }
+
+    @Override
+    public CollectionInfo<BuildConfigurationRest> getDependencies(int pageIndex, int pageSize, String sortingRsql, String query,
+            Integer configId) {
+        return queryForCollection(pageIndex, pageSize, sortingRsql, query, withDependantConfiguration(configId));
+    }
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/provider/api/BuildConfigurationProvider.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/provider/api/BuildConfigurationProvider.java
@@ -1,0 +1,34 @@
+package org.jboss.pnc.rest.provider.api;
+
+import org.jboss.pnc.model.BuildConfiguration;
+import org.jboss.pnc.rest.model.BuildConfigurationRest;
+import org.jboss.pnc.rest.provider.collection.CollectionInfo;
+import org.jboss.pnc.rest.validation.exceptions.RestValidationException;
+
+/**
+ *
+ * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
+ */
+public interface BuildConfigurationProvider extends Provider<BuildConfiguration, BuildConfigurationRest> {
+
+    void addDependency(Integer configId, Integer dependencyId) throws RestValidationException;
+
+    CollectionInfo<BuildConfigurationRest> getAllForBuildConfigurationSet(int pageIndex, int pageSize, String sortingRsql, String query, Integer buildConfigurationSetId);
+
+    CollectionInfo<BuildConfigurationRest> getAllForProduct(int pageIndex, int pageSize, String sortingRsql, String query, Integer productId);
+
+    CollectionInfo<BuildConfigurationRest> getAllForProductAndProductVersion(int pageIndex, int pageSize, String sortingRsql, String query, Integer productId, Integer versionId);
+
+    CollectionInfo<BuildConfigurationRest> getAllForProject(Integer pageIndex, Integer pageSize, String sortingRsql, String query, Integer projectId);
+
+    CollectionInfo<BuildConfigurationRest> getAllNonArchived(Integer pageIndex, Integer pageSize, String sortingRsql, String query);
+
+    CollectionInfo<BuildConfigurationRest> getDependencies(int pageIndex, int pageSize, String sortingRsql, String query, Integer configId);
+
+    void archive(Integer buildConfigurationId) throws RestValidationException;
+
+    Integer clone(Integer buildConfigurationId) throws RestValidationException;
+
+    void removeDependency(Integer configId, Integer dependencyId) throws RestValidationException;
+
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/provider/api/Provider.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/provider/api/Provider.java
@@ -1,0 +1,25 @@
+package org.jboss.pnc.rest.provider.api;
+
+import org.jboss.pnc.rest.provider.collection.CollectionInfo;
+import org.jboss.pnc.rest.validation.exceptions.RestValidationException;
+import org.jboss.pnc.spi.datastore.repositories.api.Predicate;
+
+/**
+ *
+ * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
+ */
+public interface Provider<DB, Rest> {
+
+    void delete(Integer id) throws RestValidationException;
+
+    CollectionInfo<Rest> getAll(int pageIndex, int pageSize, String sortingRsql, String query);
+
+    Rest getSpecific(Integer id);
+
+    CollectionInfo<Rest> queryForCollection(int pageIndex, int pageSize, String sortingRsql, String query, Predicate<DB>... predicates);
+
+    Integer store(Rest restEntity) throws RestValidationException;
+
+    void update(Integer id, Rest restEntity) throws RestValidationException;
+
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/provider/collection/CollectionInfo.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/provider/collection/CollectionInfo.java
@@ -1,0 +1,58 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.rest.provider.collection;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * JPA Collection info
+ *
+ * @author Sebastian Laskawiec
+ */
+public class CollectionInfo<T> {
+
+    private final Integer pageIndex;
+    private final Integer pageSize;
+    private final Integer totalPages;
+    private final Collection<T> content;
+
+    public CollectionInfo(Integer pageIndex, Integer pageSize, Integer totalPages, Collection<T> content) {
+        this.pageIndex = pageIndex;
+        this.pageSize = pageSize;
+        this.totalPages = totalPages;
+        this.content = Collections.unmodifiableCollection(content);
+    }
+
+    public Integer getPageIndex() {
+        return pageIndex;
+    }
+
+    public Integer getPageSize() {
+        return pageSize;
+    }
+
+    public Integer getTotalPages() {
+        return totalPages;
+    }
+
+    public Collection<T> getContent() {
+        return content;
+    }
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/provider/collection/CollectionInfoCollector.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/provider/collection/CollectionInfoCollector.java
@@ -1,0 +1,75 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.rest.provider.collection;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+/**
+ * Collector for generating Collection info
+ *
+ * @author Sebastian Laskawiec
+ */
+public class CollectionInfoCollector<T> implements Collector<T, List<T>, CollectionInfo<T>> {
+
+    private final int pageIndex;
+    private final int pageSize;
+    private final int totalPages;
+
+    public CollectionInfoCollector(int pageIndex, int pageSize, int totalPages) {
+        this.pageIndex = pageIndex;
+        this.pageSize = pageSize;
+        this.totalPages = totalPages;
+    }
+
+    @Override
+    public Supplier<List<T>> supplier() {
+        return ArrayList::new;
+    }
+
+    @Override
+    public BiConsumer<List<T>, T> accumulator() {
+        return (list, t) -> list.add(t);
+    }
+
+    @Override
+    public BinaryOperator<List<T>> combiner() {
+        return (left, right) -> {
+            left.addAll(right);
+            return left;
+        };
+    }
+
+    @Override
+    public Function<List<T>, CollectionInfo<T>> finisher() {
+        return list -> new CollectionInfo<>(pageIndex, pageSize, totalPages, list);
+    }
+
+    @Override
+    public Set<Characteristics> characteristics() {
+        return EnumSet.of(Characteristics.UNORDERED);
+    }
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/utils/StreamHelper.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/utils/StreamHelper.java
@@ -1,0 +1,40 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.utils;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class StreamHelper {
+
+    public static <T> Stream<T> nullableStreamOf(Collection<T> nullableCollection) {
+        if(nullableCollection == null) {
+            return Stream.empty();
+        }
+        return nullableCollection.stream();
+    }
+
+    public static <T> Stream<T> nullableStreamOf(Iterable<T> nullableIterable) {
+        if(nullableIterable == null || !nullableIterable.iterator().hasNext()) {
+            return Stream.empty();
+        }
+        return StreamSupport.stream(nullableIterable.spliterator(), false);
+    }
+
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/ConflictedEntryValidator.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/ConflictedEntryValidator.java
@@ -1,0 +1,58 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.rest.validation;
+
+import org.jboss.pnc.model.GenericEntity;
+
+/**
+ * Conflict validation class
+ *
+ * @author Sebastian Laskawiec
+ */
+@FunctionalInterface
+public interface ConflictedEntryValidator {
+
+    class ConflictedEntryValidationError {
+        private final Integer conflictedRecordId;
+        private final Class<? extends GenericEntity<?>> conflictedEntity;
+        private final String message;
+
+        public ConflictedEntryValidationError(Integer conflictedRecordId, Class<? extends GenericEntity<?>> conflictedEntity,
+                String message) {
+            this.conflictedRecordId = conflictedRecordId;
+            this.conflictedEntity = conflictedEntity;
+            this.message = message;
+        }
+
+        public Integer getConflictedRecordId() {
+            return conflictedRecordId;
+        }
+
+        public Class<? extends GenericEntity<?>> getConflictedEntity() {
+            return conflictedEntity;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    ConflictedEntryValidationError validate();
+
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/ValidationBuilder.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/ValidationBuilder.java
@@ -1,0 +1,137 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.rest.validation;
+
+import org.jboss.pnc.rest.validation.exceptions.ConflictedEntryException;
+import org.jboss.pnc.model.GenericEntity;
+import org.jboss.pnc.rest.validation.exceptions.EmptyEntityException;
+import org.jboss.pnc.rest.validation.exceptions.InvalidEntityException;
+import org.jboss.pnc.rest.validation.exceptions.RepositoryViolationException;
+import org.jboss.pnc.rest.validation.groups.ValidationGroup;
+import org.jboss.pnc.spi.datastore.repositories.api.Repository;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+
+public class ValidationBuilder<T> {
+
+    private Class<? extends ValidationGroup> validationGroup;
+    private T objectToBeValidated;
+
+    private static Validator validator;
+
+    static {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    private ValidationBuilder(Class<? extends ValidationGroup> validationGroup, T objectToBeValidated) {
+        this.validationGroup = validationGroup;
+        this.objectToBeValidated = objectToBeValidated;
+    }
+
+    public static ValidationBuilder validateObject(Object object, Class<? extends ValidationGroup> validationGroup) {
+        if(validationGroup == ValidationGroup.class) {
+            throw new IllegalArgumentException("Use validation subclasses");
+        }
+
+        return new ValidationBuilder(validationGroup, object);
+    }
+
+    public static ValidationBuilder validateObject(Class<? extends ValidationGroup> validationGroup) {
+        return validateObject(null, validationGroup);
+    }
+
+    public ValidationBuilder validateAnnotations() throws InvalidEntityException {
+        if(objectToBeValidated != null) {
+            Set<ConstraintViolation<T>> constraintViolations = validator.validate(objectToBeValidated, validationGroup);
+            if(!constraintViolations.isEmpty()) {
+                throw new InvalidEntityException(constraintViolations.iterator().next());
+            }
+        }
+        return this;
+    }
+
+    public ValidationBuilder validateField(String property, Object value) throws InvalidEntityException {
+        if(objectToBeValidated != null) {
+            try {
+                Field field = objectToBeValidated.getClass().getDeclaredField(property);
+                field.setAccessible(true);
+                Object valueFromObject = field.get(objectToBeValidated);
+                if((value == null && valueFromObject == null) || (value != null && value.equals(valueFromObject)))
+                    return this;
+                throw new InvalidEntityException(field);
+            } catch (NoSuchFieldException e) {
+                throw new IllegalArgumentException("No such field", e);
+            } catch (IllegalAccessException e) {
+                throw new IllegalArgumentException("Could not access field", e);
+            }
+        }
+        return this;
+    }
+
+    public ValidationBuilder validateConflict(ConflictedEntryValidator validate) throws
+            ConflictedEntryException {
+        ConflictedEntryValidator.ConflictedEntryValidationError validationError = validate.validate();
+        if(validationError != null) {
+            throw new ConflictedEntryException(validationError.getMessage(), validationError.getConflictedEntity(), validationError.getConflictedRecordId());
+        }
+        return this;
+    }
+
+    public ValidationBuilder validateNotEmptyArgument() throws EmptyEntityException {
+        if(objectToBeValidated == null) {
+            throw new EmptyEntityException("Input object is null");
+        }
+        return this;
+    }
+
+    public <DBEntity extends GenericEntity<ID>, ID extends Number> ValidationBuilder validateAgainstRepository(Repository<DBEntity, ID> repository, ID id, boolean shouldExist)
+            throws RepositoryViolationException, EmptyEntityException {
+
+        if(id == null) {
+            throw new EmptyEntityException("Id is null");
+        }
+
+        DBEntity dbEntity = repository.queryById(id);
+        if((!shouldExist && dbEntity != null) || (shouldExist && dbEntity == null)) {
+            StringBuilder sb = new StringBuilder("Entity should ");
+            if(!shouldExist) {
+                sb.append(" not ");
+            }
+            sb.append("exist in the DB");
+            throw new RepositoryViolationException(sb.toString());
+        }
+        return this;
+    }
+
+    public ValidationBuilder validateCondition(boolean condition, String message)
+            throws InvalidEntityException {
+        if(!condition) {
+            throw new InvalidEntityException(message);
+        }
+        return this;
+    }
+
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/exceptions/ConflictedEntryException.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/exceptions/ConflictedEntryException.java
@@ -1,0 +1,50 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.validation.exceptions;
+
+import org.jboss.pnc.model.GenericEntity;
+import org.jboss.pnc.rest.validation.exceptions.RestValidationException;
+
+import java.util.Optional;
+
+import org.jboss.pnc.rest.validation.exceptions.model.ConflictedEntryDetailsRest;
+
+public class ConflictedEntryException extends RestValidationException {
+
+    private final Integer conflictedRecordId;
+    private final Class<? extends GenericEntity<?>> conflictedEntity;
+
+    public ConflictedEntryException(String message, Class<? extends GenericEntity<?>> conflictedEntity, Integer conflictedId) {
+        super(message);
+        this.conflictedRecordId = conflictedId;
+        this.conflictedEntity = conflictedEntity;
+    }
+
+    public Integer getConflictedRecordId() {
+        return conflictedRecordId;
+    }
+
+    public Class<? extends GenericEntity<?>> getConflictedEntity() {
+        return conflictedEntity;
+    }
+
+    @Override
+    public Optional<Object> getRestModelForException() {
+        return Optional.of(new ConflictedEntryDetailsRest(this));
+    }
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/exceptions/EmptyEntityException.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/exceptions/EmptyEntityException.java
@@ -1,0 +1,52 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.rest.validation.exceptions;
+
+import java.util.Optional;
+
+public class EmptyEntityException extends RestValidationException {
+
+    public EmptyEntityException(String message) {
+        super(message);
+    }
+
+    @Override
+    public Optional<Object> getRestModelForException() {
+        return Optional.empty();
+    }
+
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/exceptions/EntityNotFoundException.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/exceptions/EntityNotFoundException.java
@@ -1,0 +1,35 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.validation.exceptions;
+
+import java.util.Optional;
+
+/**
+ * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
+ */
+public class EntityNotFoundException extends RestValidationException {
+
+    public EntityNotFoundException(String message) {
+        super(message);
+    }
+
+    @Override
+    public Optional<Object> getRestModelForException() {
+        return Optional.empty();
+    }
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/exceptions/InvalidEntityException.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/exceptions/InvalidEntityException.java
@@ -1,0 +1,66 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.rest.validation.exceptions;
+
+import org.jboss.pnc.rest.validation.exceptions.model.InvalidEntityDetailsRest;
+
+import javax.validation.ConstraintViolation;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+public class InvalidEntityException extends RestValidationException {
+
+    private final String field;
+
+    public InvalidEntityException(String message) {
+        super(message);
+        this.field = null;
+    }
+
+    public InvalidEntityException(Field field) {
+        super("Field validation error occurred. Field: " + field.getName());
+        this.field = field.getName();
+    }
+
+    public InvalidEntityException(ConstraintViolation<?> validationProblem) {
+        super("Field validation error occurred. " + getErrorDescription(validationProblem));
+        this.field = getFieldName(validationProblem);
+    }
+
+    private static String getErrorDescription(ConstraintViolation<?> validationProblem) {
+        String field = getFieldName(validationProblem);
+        String message = validationProblem.getMessage();
+        return "Field: " + field + ", problem: " + message;
+    }
+
+    private static String getFieldName(ConstraintViolation<?> validationProblem) {
+        return validationProblem.getPropertyPath().iterator().next().getName();
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    @Override
+    public Optional<Object> getRestModelForException() {
+        return Optional.of(new InvalidEntityDetailsRest(this));
+    }
+
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/exceptions/RepositoryViolationException.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/exceptions/RepositoryViolationException.java
@@ -1,0 +1,56 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.rest.validation.exceptions;
+
+import java.util.Optional;
+
+public class RepositoryViolationException extends RestValidationException {
+
+    public RepositoryViolationException(String message) {
+        super(message);
+    }
+
+    public RepositoryViolationException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public Optional<Object> getRestModelForException() {
+        return Optional.empty();
+    }
+
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/exceptions/model/ConflictedEntryDetailsRest.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/exceptions/model/ConflictedEntryDetailsRest.java
@@ -1,0 +1,65 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.validation.exceptions.model;
+
+import org.jboss.pnc.rest.validation.exceptions.ConflictedEntryException;
+
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType
+public class ConflictedEntryDetailsRest {
+
+    private String conflictedRecordId;
+    private String conflictedEntity;
+    private ConflictedEntryException conflictedEntryException;
+
+    public ConflictedEntryDetailsRest() {
+    }
+
+    public ConflictedEntryDetailsRest(ConflictedEntryException conflictedEntryException) {
+        this.conflictedEntryException = conflictedEntryException;
+        this.conflictedEntity = conflictedEntryException.getConflictedEntity().getSimpleName();
+        this.conflictedRecordId = conflictedEntryException.getConflictedRecordId().toString();
+    }
+
+    public String getConflictedRecordId() {
+        return conflictedRecordId;
+    }
+
+    public String getConflictedEntity() {
+        return conflictedEntity;
+    }
+}

--- a/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/exceptions/model/InvalidEntityDetailsRest.java
+++ b/prototype-facade/src/main/java/org/jboss/pnc/rest/validation/exceptions/model/InvalidEntityDetailsRest.java
@@ -1,0 +1,57 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.validation.exceptions.model;
+
+import org.jboss.pnc.rest.validation.exceptions.InvalidEntityException;
+
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType
+public class InvalidEntityDetailsRest {
+
+    private String field;
+
+    public InvalidEntityDetailsRest() {
+    }
+
+    public InvalidEntityDetailsRest(InvalidEntityException invalidEntityException) {
+        this.field = invalidEntityException.getField();
+    }
+
+    public String getField() {
+        return field;
+    }
+}

--- a/prototype-rest-api/pom.xml
+++ b/prototype-rest-api/pom.xml
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source.
+    Copyright 2014 Red Hat, Inc., and individual contributors
+    as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>parent</artifactId>
+    <groupId>org.jboss.pnc</groupId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>prototype-rest-api</artifactId>
+
+  <description>REST API. This is a series of classes that use JAX-RS to translate HTTP communications to calls into the action controllers in the core, and format any output (such as constructing resource URLs, etc.).</description>
+
+    <properties>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+    </properties>
+
+
+  <dependencies>
+      <!-- Project dependencies -->
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>prototype-rest-model</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Remote dependencies -->
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.websocket</groupId>
+      <artifactId>jboss-websocket-api_1.0_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ejb</groupId>
+      <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-jaxrs</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.javassist</groupId>
+          <artifactId>javassist</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>joda-time</groupId>
+          <artifactId>joda-time</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-envers</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss</groupId>
+      <artifactId>jboss-common-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- TODO only here as lombok is too eager to do everything-->
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>test-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.el</groupId>
+      <artifactId>javax.el-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.web</groupId>
+      <artifactId>javax.el</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-validator</groupId>
+      <artifactId>commons-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>pnc-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>datastore</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>${project.artifactId}</finalName>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+
+    <!-- required for integration tests -->
+    <plugins>
+      <plugin>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <attachClasses>true</attachClasses>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+     <profile>
+        <id>auth</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <executions>
+                      <execution>
+                        <id>copy-webconfig</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                          <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                          <overwrite>true</overwrite>
+                          <outputDirectory>${project.build.directory}/${project.artifactId}/WEB-INF/</outputDirectory>
+                          <resources>
+                            <resource>
+                              <directory>${project.basedir}/src/main/webconfig/auth</directory>
+                            </resource>
+                          </resources>
+                        </configuration>
+                      </execution>
+                    </executions>
+                  </plugin>
+            </plugins>
+         </build>
+     </profile>
+     <profile>
+        <id>noauth</id>
+        <activation>
+            <activeByDefault>true</activeByDefault>
+        </activation>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <executions>
+                      <execution>
+                        <id>copy-webconfig</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                          <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                          <overwrite>true</overwrite>
+                          <outputDirectory>${project.build.directory}/${project.artifactId}/WEB-INF/</outputDirectory>
+                          <resources>
+                            <resource>
+                              <directory>${project.basedir}/src/main/webconfig/noauth</directory>
+                            </resource>
+                          </resources>
+                        </configuration>
+                      </execution>
+                    </executions>
+                  </plugin>
+            </plugins>
+         </build>
+     </profile>
+
+    <profile>
+        <id>auth-container-eap</id>
+        <activation>
+            <property>
+                <name>auth.eap.home</name>
+            </property>
+        </activation>
+      <build>
+        <plugins>
+              <plugin>
+                <groupId>org.jboss.as.plugins</groupId>
+                <artifactId>jboss-as-maven-plugin</artifactId>
+                <executions>
+                  <execution>
+                    <id>start-server</id>
+                    <phase>generate-test-resources</phase>
+                    <goals>
+                      <goal>start</goal>
+                    </goals>
+                    <configuration>
+                      <jbossHome>${auth.eap.home}</jbossHome>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>shutdown-server</id>
+                    <phase>process-test-resources</phase>
+                    <goals>
+                      <goal>shutdown</goal>
+                    </goals>
+                  </execution>
+                </executions>
+              </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/prototype-rest-api/src/main/java/org/jboss/pnc/rest/api/BuildConfigurationEndpoint.java
+++ b/prototype-rest-api/src/main/java/org/jboss/pnc/rest/api/BuildConfigurationEndpoint.java
@@ -1,0 +1,241 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.api;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import java.util.Map;
+
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.CONFLICTED_CODE;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.CONFLICTED_DESCRIPTION;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.ENTITY_CREATED_CODE;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.ENTITY_CREATED_DESCRIPTION;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.INVALID_CODE;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.INVALID_DESCRIPTION;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.NOT_FOUND_CODE;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.NOT_FOUND_DESCRIPTION;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.NO_CONTENT_CODE;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.NO_CONTENT_DESCRIPTION;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.PAGE_INDEX_DEFAULT_VALUE;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.PAGE_INDEX_DESCRIPTION;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.PAGE_INDEX_QUERY_PARAM;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.PAGE_SIZE_DEFAULT_VALUE;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.PAGE_SIZE_DESCRIPTION;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.PAGE_SIZE_QUERY_PARAM;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.QUERY_DESCRIPTION;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.QUERY_QUERY_PARAM;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.SERVER_ERROR_CODE;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.SERVER_ERROR_DESCRIPTION;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.SORTING_DESCRIPTION;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.SORTING_QUERY_PARAM;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.SUCCESS_CODE;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.SUCCESS_DESCRIPTION;
+import org.jboss.pnc.rest.model.BuildConfigurationRest;
+import org.jboss.pnc.rest.model.BuildConfigurationRest.BuildConfigurationPage;
+import org.jboss.pnc.rest.model.BuildConfigurationRest.BuildConfigurationSingleton;
+import org.jboss.pnc.rest.model.response.error.ErrorResponseRest;
+import org.jboss.pnc.rest.validation.exceptions.RestValidationException;
+
+import javax.validation.ValidationException;
+
+@Api(value = "/build-configurations", description = "Build configuration entities")
+@Path("/build-configurations")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface BuildConfigurationEndpoint {
+
+    @ApiOperation(value = "Gets all Build Configurations")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION, response = BuildConfigurationPage.class),
+            @ApiResponse(code = NO_CONTENT_CODE, message = NO_CONTENT_DESCRIPTION, response = BuildConfigurationPage.class),
+            @ApiResponse(code = INVALID_CODE, message = INVALID_DESCRIPTION, response = ErrorResponseRest.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = ErrorResponseRest.class)
+    })
+    @GET
+    public Response getAll(@ApiParam(value = PAGE_INDEX_DESCRIPTION) @QueryParam(PAGE_INDEX_QUERY_PARAM) @DefaultValue(PAGE_INDEX_DEFAULT_VALUE) int pageIndex,
+            @ApiParam(value = PAGE_SIZE_DESCRIPTION) @QueryParam(PAGE_SIZE_QUERY_PARAM) @DefaultValue(PAGE_SIZE_DEFAULT_VALUE) int pageSize,
+            @ApiParam(value = SORTING_DESCRIPTION) @QueryParam(SORTING_QUERY_PARAM) String sort,
+            @ApiParam(value = QUERY_DESCRIPTION, required = false) @QueryParam(QUERY_QUERY_PARAM) String q);
+
+    @ApiOperation(value = "Creates a new Build Configuration.")
+    @ApiResponses(value = {
+            @ApiResponse(code = ENTITY_CREATED_CODE, message = ENTITY_CREATED_DESCRIPTION, response = BuildConfigurationSingleton.class),
+            @ApiResponse(code = INVALID_CODE, message = INVALID_DESCRIPTION, response = ErrorResponseRest.class),
+            @ApiResponse(code = CONFLICTED_CODE, message = CONFLICTED_DESCRIPTION, response = ErrorResponseRest.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = ErrorResponseRest.class)
+    })
+    @POST
+    public Response createNew(BuildConfigurationRest buildConfigurationRest, @Context UriInfo uriInfo);
+    
+    @GET
+    @Path("/supported-generic-parameters")
+    @ApiOperation(value = "Gets the minimal set of supported genericParameters and their description for the BuildConfiguration. "
+            + "There can be also other supported parameters not know by core.")
+    @ApiResponse(response = Map.class, code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION)
+    public Response getSupportedGenericParameters();
+
+    @ApiOperation(value = "Gets a specific Build Configuration")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION, response = BuildConfigurationSingleton.class),
+            @ApiResponse(code = NOT_FOUND_CODE, message = NOT_FOUND_DESCRIPTION, response = BuildConfigurationSingleton.class),
+            @ApiResponse(code = INVALID_CODE, message = INVALID_DESCRIPTION, response = ErrorResponseRest.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = ErrorResponseRest.class)
+    })
+    @GET
+    @Path("/{id}")
+    public Response getSpecific(
+            @ApiParam(value = "Build Configuration id", required = true) @PathParam("id") Integer id);
+
+    @ApiOperation(value = "Updates an existing Build Configuration")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION),
+            @ApiResponse(code = INVALID_CODE, message = INVALID_DESCRIPTION, response = ErrorResponseRest.class),
+            @ApiResponse(code = CONFLICTED_CODE, message = CONFLICTED_DESCRIPTION, response = ErrorResponseRest.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = ErrorResponseRest.class)
+    })
+    @PUT
+    @Path("/{id}")
+    public Response update(@ApiParam(value = "Build Configuration id", required = true) @PathParam("id") Integer id,
+            BuildConfigurationRest buildConfigurationRest);
+
+    @ApiOperation(value = "Removes a specific Build Configuration")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION),
+            @ApiResponse(code = INVALID_CODE, message = INVALID_DESCRIPTION, response = ErrorResponseRest.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = ErrorResponseRest.class)
+    })
+    @DELETE
+    @Path("/{id}")
+    public Response deleteSpecific(@ApiParam(value = "Build Configuration id", required = true) @PathParam("id") Integer id);
+
+    @ApiOperation(value = "Clones an existing Build Configuration")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION, response = BuildConfigurationSingleton.class),
+            @ApiResponse(code = INVALID_CODE, message = INVALID_DESCRIPTION, response = BuildConfigurationSingleton.class),
+            @ApiResponse(code = CONFLICTED_CODE, message = CONFLICTED_DESCRIPTION, response = BuildConfigurationSingleton.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = BuildConfigurationSingleton.class)
+    })
+    @POST
+    @Path("/{id}/clone")
+    public Response clone(@ApiParam(value = "Build Configuration id", required = true) @PathParam("id") Integer id,
+            @Context UriInfo uriInfo);
+
+    @ApiOperation(value = "Gets all Build Configurations of a Project")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION, response = BuildConfigurationPage.class),
+            @ApiResponse(code = NO_CONTENT_CODE, message = NO_CONTENT_DESCRIPTION, response = BuildConfigurationPage.class),
+            @ApiResponse(code = INVALID_CODE, message = INVALID_DESCRIPTION, response = BuildConfigurationPage.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = BuildConfigurationPage.class)
+    })
+    @GET
+    @Path("/projects/{projectId}")
+    public Response getAllByProjectId(@ApiParam(value = PAGE_INDEX_DESCRIPTION) @QueryParam(PAGE_INDEX_QUERY_PARAM) @DefaultValue(PAGE_INDEX_DEFAULT_VALUE) int pageIndex,
+            @ApiParam(value = PAGE_SIZE_DESCRIPTION) @QueryParam(PAGE_SIZE_QUERY_PARAM) @DefaultValue(PAGE_SIZE_DEFAULT_VALUE) int pageSize,
+            @ApiParam(value = SORTING_DESCRIPTION) @QueryParam(SORTING_QUERY_PARAM) String sort,
+            @ApiParam(value = QUERY_DESCRIPTION, required = false) @QueryParam(QUERY_QUERY_PARAM) String q,
+            @ApiParam(value = "Project id", required = true) @PathParam("projectId") Integer projectId);
+
+    @ApiOperation(value = "Gets all Build Configurations of a Product")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION, response = BuildConfigurationPage.class),
+            @ApiResponse(code = NO_CONTENT_CODE, message = NO_CONTENT_DESCRIPTION, response = BuildConfigurationPage.class),
+            @ApiResponse(code = INVALID_CODE, message = INVALID_DESCRIPTION, response = BuildConfigurationPage.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = BuildConfigurationPage.class)
+    })
+    @GET
+    @Path("/products/{productId}")
+    public Response getAllByProductId(@ApiParam(value = PAGE_INDEX_DESCRIPTION) @QueryParam(PAGE_INDEX_QUERY_PARAM) @DefaultValue(PAGE_INDEX_DEFAULT_VALUE) int pageIndex,
+            @ApiParam(value = PAGE_SIZE_DESCRIPTION) @QueryParam(PAGE_SIZE_QUERY_PARAM) @DefaultValue(PAGE_SIZE_DEFAULT_VALUE) int pageSize,
+            @ApiParam(value = SORTING_DESCRIPTION) @QueryParam(SORTING_QUERY_PARAM) String sort,
+            @ApiParam(value = QUERY_DESCRIPTION, required = false) @QueryParam(QUERY_QUERY_PARAM) String q,
+            @ApiParam(value = "Product id", required = true) @PathParam("productId") Integer productId);
+
+    @ApiOperation(value = "Gets all Build Configurations of the Specified Product Version")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION, response = BuildConfigurationPage.class),
+            @ApiResponse(code = NO_CONTENT_CODE, message = NO_CONTENT_DESCRIPTION, response = BuildConfigurationPage.class),
+            @ApiResponse(code = INVALID_CODE, message = INVALID_DESCRIPTION, response = ErrorResponseRest.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = ErrorResponseRest.class)
+    })
+    @GET
+    @Path("/products/{productId}/product-versions/{versionId}")
+    public Response getAllByProductVersionId(@ApiParam(value = PAGE_INDEX_DESCRIPTION) @QueryParam(PAGE_INDEX_QUERY_PARAM) @DefaultValue(PAGE_INDEX_DEFAULT_VALUE) int pageIndex,
+            @ApiParam(value = PAGE_SIZE_DESCRIPTION) @QueryParam(PAGE_SIZE_QUERY_PARAM) @DefaultValue(PAGE_SIZE_DEFAULT_VALUE) int pageSize,
+            @ApiParam(value = SORTING_DESCRIPTION) @QueryParam(SORTING_QUERY_PARAM) String sort,
+            @ApiParam(value = QUERY_DESCRIPTION, required = false) @QueryParam(QUERY_QUERY_PARAM) String q,
+            @ApiParam(value = "Product id", required = true) @PathParam("productId") Integer productId,
+            @ApiParam(value = "Product Version id", required = true) @PathParam("versionId") Integer versionId);
+
+    @ApiOperation(value = "Get the direct dependencies of the specified configuration")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION, response = BuildConfigurationPage.class),
+            @ApiResponse(code = NO_CONTENT_CODE, message = NO_CONTENT_DESCRIPTION, response = BuildConfigurationPage.class),
+            @ApiResponse(code = INVALID_CODE, message = INVALID_DESCRIPTION, response = ErrorResponseRest.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = ErrorResponseRest.class)
+    })
+    @GET
+    @Path("/{id}/dependencies")
+    public Response getDependencies(@ApiParam(value = PAGE_INDEX_DESCRIPTION) @QueryParam(PAGE_INDEX_QUERY_PARAM) @DefaultValue(PAGE_INDEX_DEFAULT_VALUE) int pageIndex,
+            @ApiParam(value = PAGE_SIZE_DESCRIPTION) @QueryParam(PAGE_SIZE_QUERY_PARAM) @DefaultValue(PAGE_SIZE_DEFAULT_VALUE) int pageSize,
+            @ApiParam(value = SORTING_DESCRIPTION) @QueryParam(SORTING_QUERY_PARAM) String sort,
+            @ApiParam(value = QUERY_DESCRIPTION, required = false) @QueryParam(QUERY_QUERY_PARAM) String q,
+            @ApiParam(value = "Build configuration id", required = true) @PathParam("id") Integer id);
+
+    @ApiOperation(value = "Adds a dependency to the specified config")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION),
+            @ApiResponse(code = INVALID_CODE, message = INVALID_DESCRIPTION, response = ErrorResponseRest.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = ErrorResponseRest.class)
+    })
+    @POST
+    @Path("/{id}/dependencies")
+    public Response addDependency(@ApiParam(value = "Build Configuration id", required = true) @PathParam("id") Integer id,
+            BuildConfigurationRest dependency);
+
+    @ApiOperation(value = "Removes a configuration from the specified config set")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION),
+            @ApiResponse(code = INVALID_CODE, message = INVALID_DESCRIPTION, response = ErrorResponseRest.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = ErrorResponseRest.class)
+    })
+    @DELETE
+    @Path("/{id}/dependencies/{dependencyId}")
+    public Response removeDependency(
+            @ApiParam(value = "Build configuration set id", required = true) @PathParam("id") Integer id,
+            @ApiParam(value = "Build configuration id", required = true) @PathParam("dependencyId") Integer dependencyId);
+
+}

--- a/prototype-rest-api/src/main/java/org/jboss/pnc/rest/configuration/SwaggerConstants.java
+++ b/prototype-rest-api/src/main/java/org/jboss/pnc/rest/configuration/SwaggerConstants.java
@@ -1,0 +1,73 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.rest.configuration;
+
+
+/**
+ * Constants for Swagger documentation API.
+ *
+ * @author Sebastian Laskawiec
+ */
+public interface SwaggerConstants {
+
+    public static final String SUCCESS_DESCRIPTION = "Success with results";
+    public static final int SUCCESS_CODE = 200;
+
+    public static final String ENTITY_CREATED_DESCRIPTION = "Entity successfully created";
+    public static final int ENTITY_CREATED_CODE = 200;
+
+    public static final String NO_CONTENT_DESCRIPTION = "Success but no content provided";
+    public static final int NO_CONTENT_CODE = 204;
+
+    public static final String INVALID_DESCRIPTION = "Invalid input parameters or validation error";
+    public static final int INVALID_CODE = 400;
+
+    public static final String CONFLICTED_DESCRIPTION = "Conflict while saving an entity";
+    public static final int CONFLICTED_CODE = 409;
+
+    public static final String SERVER_ERROR_DESCRIPTION = "Server error";
+    public static final int SERVER_ERROR_CODE = 500;
+
+    public static final String FORBIDDEN_DESCRIPTION = "User must be logged in.";
+    public static final int FORBIDDEN_CODE = 403;
+
+    public static final String NOT_FOUND_DESCRIPTION = "Can not find specified result";
+    public static final int NOT_FOUND_CODE = 404;
+
+    public static final String PAGE_INDEX_DESCRIPTION = "Page Index";
+    public static final String PAGE_INDEX_QUERY_PARAM = "pageIndex";
+    public static final String PAGE_INDEX_DEFAULT_VALUE = "0";
+
+    public static final String PAGE_SIZE_DESCRIPTION = "Pagination size";
+    public static final String PAGE_SIZE_QUERY_PARAM = "pageSize";
+    public static final String PAGE_SIZE_DEFAULT_VALUE = "50";
+
+    public static final String SORTING_DESCRIPTION = "Sorting RSQL";
+    public static final String SORTING_QUERY_PARAM = "sort";
+
+    public static final String QUERY_DESCRIPTION = "RSQL Query";
+    public static final String QUERY_QUERY_PARAM = "q";
+
+    public static final String SEARCH_DESCRIPTION = "Since this endpoint does not support queries, " +
+            "fulltext search is hard-coded for some predefined fields (record id, configuration name) " +
+            "and performed using this argument. " +
+            "Empty string leaves all data unfiltered.";
+    public static final String SEARCH_QUERY_PARAM = "search";
+    public static final String SEARCH_DEFAULT_VALUE = "";
+}

--- a/prototype-rest-model/pom.xml
+++ b/prototype-rest-model/pom.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source.
+    Copyright 2014 Red Hat, Inc., and individual contributors
+    as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>parent</artifactId>
+    <groupId>org.jboss.pnc</groupId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>prototype-rest-model</artifactId>
+  <packaging>jar</packaging>
+
+  <description>REST DTO.</description>
+
+  <dependencies>
+      <!-- Project dependencies -->
+
+    <!-- Remote dependencies -->
+    <dependency>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+    <!-- TODO only here as lombok is too eager to do everything-->
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-validator</groupId>
+      <artifactId>commons-validator</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>test-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>pnc-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>${project.artifactId}</finalName>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>auth-container-eap</id>
+      <activation>
+        <property>
+          <name>auth.eap.home</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jboss.as.plugins</groupId>
+            <artifactId>jboss-as-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>start-server</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+                <configuration>
+                  <jbossHome>${auth.eap.home}</jbossHome>
+                </configuration>
+              </execution>
+              <execution>
+                <id>shutdown-server</id>
+                <phase>process-test-resources</phase>
+                <goals>
+                  <goal>shutdown</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/BuildConfigurationRef.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/BuildConfigurationRef.java
@@ -1,0 +1,60 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.model;
+
+import org.jboss.pnc.rest.model.enums.BuildType;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class BuildConfigurationRef {
+
+    private final int id;
+
+    private final String name;
+
+    private final String description;
+
+    private final String buildScript;
+
+    private final String scmRevision;
+
+    private final Instant creationTime;
+
+    private final Instant lastModificationTime;
+
+    private final boolean archived;
+
+    private final BuildType buildType;
+
+    private final Integer productVersionId;
+
+    private final Map<String, String> genericParameters;
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class BuildConfigurationRefBuilder {
+    }
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/BuildConfigurationRest.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/BuildConfigurationRest.java
@@ -1,0 +1,92 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.model;
+
+import org.jboss.pnc.rest.model.enums.BuildType;
+import org.jboss.pnc.rest.model.response.Page;
+import org.jboss.pnc.rest.model.response.Singleton;
+import org.jboss.pnc.rest.validation.groups.WhenCreatingNew;
+import org.jboss.pnc.rest.validation.groups.WhenUpdating;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Null;
+import javax.validation.constraints.Pattern;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class BuildConfigurationRest implements RestEntity {
+
+    public static abstract class BuildConfigurationPage extends Page<BuildConfigurationRest> {
+    }
+
+    public static class BuildConfigurationSingleton extends Singleton<BuildConfigurationRest> {
+    }
+
+    @NotNull(groups = WhenUpdating.class)
+    @Null(groups = WhenCreatingNew.class)
+    private final Integer id;
+
+    @NotNull(groups = WhenCreatingNew.class)
+    @Pattern(regexp = "^[a-zA-Z0-9_.][a-zA-Z0-9_.-]*(?<!\\.git)$", groups = {WhenCreatingNew.class, WhenUpdating.class})
+    private final String name;
+
+    private final String description;
+
+    private final String buildScript;
+
+    @NotNull
+    private final RepositoryConfigurationRef repositoryConfiguration;
+
+    private final String scmRevision;
+
+    private final Instant creationTime;
+
+    private final Instant lastModificationTime;
+
+    private final boolean archived;
+
+    @NotNull(groups = WhenCreatingNew.class)
+    private final ProjectRef project;
+
+    @NotNull(groups = {WhenCreatingNew.class, WhenUpdating.class})
+    private final BuildType buildType;
+
+    @NotNull(groups = {WhenCreatingNew.class, WhenUpdating.class})
+    private final BuildEnvironmentRef environment;
+
+    private final Set<Integer> dependencyIds;
+
+    private final Integer productVersionId;
+
+    private final Set<Integer> buildConfigurationSetIds;
+
+    private final Map<String, String> genericParameters;
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class BuildConfigurationRestBuilder {
+    }
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/BuildEnvironmentRef.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/BuildEnvironmentRef.java
@@ -1,0 +1,22 @@
+package org.jboss.pnc.rest.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ *
+ * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
+ */
+@Data
+@Builder
+public class BuildEnvironmentRef {
+
+    private final int id; // Note int instead of Integer - Ref always reference existing entity.
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class BuildEnvironmentRefBuilder {
+    }
+
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/ProjectRef.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/ProjectRef.java
@@ -1,0 +1,21 @@
+package org.jboss.pnc.rest.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ *
+ * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
+ */
+@Data
+@Builder
+public class ProjectRef {
+
+    private final int id; // Note int instead of Integer - Ref always reference existing entity.
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class ProjectRefBuilder {
+    }
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/RepositoryConfigurationRef.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/RepositoryConfigurationRef.java
@@ -1,0 +1,27 @@
+package org.jboss.pnc.rest.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ *
+ * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
+ */
+@Data
+@Builder
+public class RepositoryConfigurationRef {
+
+    private final int id; // Note int instead of Integer - Ref always reference existing entity.
+
+    private final String internalUrl;
+
+    private final String externalUrl;
+
+    private final boolean preBuildSyncEnabled;
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class RepositoryConfigurationRefBuilder {
+    }
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/RestEntity.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/RestEntity.java
@@ -1,0 +1,9 @@
+package org.jboss.pnc.rest.model;
+
+/**
+ *
+ * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
+ */
+public interface RestEntity {
+
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/enums/BuildType.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/enums/BuildType.java
@@ -1,0 +1,28 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.model.enums;
+//TODO: I would actually move these to some common module maybe.
+/**
+ * BuildType is used to define pre-build operations and to set proper repository.
+ *
+ * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
+ */
+public enum BuildType {
+    MVN,
+    NPM
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/response/AcceptedResponse.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/response/AcceptedResponse.java
@@ -1,0 +1,48 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.model.response;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
+ */
+@Data
+@Builder
+@JsonDeserialize(builder = AcceptedResponse.AcceptedResponseBuilder.class)
+public class AcceptedResponse {
+
+    /**
+     * Id of the started operation
+     */
+    private final String id;
+
+    /**
+     * Url to subscribe to operation updates.
+     */
+    private final String pushUpdatesUrl;
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class AcceptedResponseBuilder {
+    }
+
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/response/Page.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/response/Page.java
@@ -1,0 +1,67 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.rest.model.response;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import lombok.Data;
+
+/**
+ * Collection REST response.
+ *
+ * @author Sebastian Laskawiec
+ */
+@ApiModel(description = "Results with additional Paging information")
+@Data
+public class Page<T> {
+
+    @ApiModelProperty("Page index")
+    private final int pageIndex;
+
+    @ApiModelProperty("Number of records per page")
+    private final int pageSize;
+
+    @ApiModelProperty("Total pages provided by this query or -1 if unknown")
+    private final int totalPages;
+
+    @ApiModelProperty("Embedded collection of data")
+    private final Collection<T> content;
+
+    /**
+     * Creates new empty page.
+     */
+    public Page() {
+        this.pageIndex = 0;
+        this.pageSize = 0;
+        this.totalPages = 0;
+        this.content = Collections.emptyList();
+    }
+
+    public Page(int pageIndex, int pageSize, int totalPages, Collection<T> content) {
+        this.pageIndex = pageIndex;
+        this.pageSize = pageSize;
+        this.totalPages = totalPages;
+        this.content = Collections.unmodifiableCollection(content);
+    }
+
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/response/ResultRest.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/response/ResultRest.java
@@ -1,0 +1,80 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.model.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+/**
+ * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
+ */
+@Getter
+public class ResultRest {
+
+    private final String id;
+
+    private final String name;
+
+    private final Status status;
+
+    private final String message;
+
+    public ResultRest(String id, String name, Status status) {
+        this.id = id;
+        this.name = name;
+        this.status = status;
+        message = "";
+    }
+
+    @JsonCreator
+    public ResultRest(
+            @JsonProperty("id") String id,
+            @JsonProperty("name") String name,
+            @JsonProperty("status") Status status,
+            @JsonProperty("message") String message) {
+        this.id = id;
+        this.name = name;
+        this.status = status;
+        this.message = message;
+    }
+
+    @JsonIgnore
+    public boolean isSuccess() {
+        return status.isSuccess();
+    }
+
+    public enum Status {
+        ACCEPTED(true),
+        SUCCESS(true),
+        REJECTED(false),
+        FAILED(false),
+        SYSTEM_ERROR(false);
+
+        private boolean success;
+
+        Status(boolean success) {
+            this.success = success;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+    }
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/response/Singleton.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/response/Singleton.java
@@ -1,0 +1,45 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.model.response;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import lombok.Data;
+
+/**
+ * Singleton REST response.
+ *
+ * @author Sebastian Laskawiec
+ */
+@ApiModel(description = "Wrapped results")
+@Data
+public class Singleton<T> {
+
+    @ApiModelProperty("Content of the response")
+    private final T content;
+
+    protected Singleton() {
+        content = null;
+    }
+
+    public Singleton(T content) {
+        this.content = content;
+    }
+
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/response/error/ErrorResponseRest.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/model/response/error/ErrorResponseRest.java
@@ -1,0 +1,48 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.model.response.error;
+
+import org.jboss.pnc.rest.validation.exceptions.RestValidationException;
+
+import lombok.Data;
+
+@Data
+public class ErrorResponseRest {
+
+    private final String errorType;
+    private final String errorMessage;
+    private final Object details;
+
+    public ErrorResponseRest(String errorType, String errorMessage) {
+        this.errorType = errorType;
+        this.errorMessage = errorMessage;
+        this.details = null;
+    }
+
+    public ErrorResponseRest(Exception e) {
+        this.errorType = e.getClass().getSimpleName();
+        this.errorMessage = e.getMessage();
+        this.details = null;
+    }
+
+    public ErrorResponseRest(RestValidationException e) {
+        this.errorType = e.getClass().getSimpleName();
+        this.errorMessage = e.getMessage();
+        this.details = e.getRestModelForException().orElse(null);
+    }
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/validation/exceptions/RestValidationException.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/validation/exceptions/RestValidationException.java
@@ -1,0 +1,50 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.rest.validation.exceptions;
+
+import java.util.Optional;
+
+/**
+ * TopMost Validation Exception
+ *
+ * @author Sebastian Laskawiec
+ */
+public abstract class RestValidationException extends RuntimeException {
+
+    public RestValidationException() {
+    }
+
+    public RestValidationException(String message) {
+        super(message);
+    }
+
+    public RestValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RestValidationException(Throwable cause) {
+        super(cause);
+    }
+
+    public RestValidationException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public abstract Optional<Object> getRestModelForException();
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/validation/groups/ValidationGroup.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/validation/groups/ValidationGroup.java
@@ -1,0 +1,29 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.rest.validation.groups;
+
+/**
+ * Parent validation group interface
+ *
+ * @author Sebastian Laskawiec
+ * @deprecated Do not use this interface directly
+ */
+@Deprecated
+public interface ValidationGroup {
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/validation/groups/WhenCreatingNew.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/validation/groups/WhenCreatingNew.java
@@ -1,0 +1,27 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.rest.validation.groups;
+
+/**
+ * Marker interface for creating new entity.
+ *
+ * @author Sebastian Laskawiec
+ */
+public interface WhenCreatingNew extends ValidationGroup {
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/validation/groups/WhenDeleting.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/validation/groups/WhenDeleting.java
@@ -1,0 +1,26 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.validation.groups;
+
+/**
+ * Marker interface for deleting entity.
+ *
+ * @author Sebastian Laskawiec
+ */
+public interface WhenDeleting extends ValidationGroup {
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/validation/groups/WhenUpdating.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/validation/groups/WhenUpdating.java
@@ -1,0 +1,26 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.validation.groups;
+
+/**
+ * Marker interface for updating entity.
+ *
+ * @author Sebastian Laskawiec
+ */
+public interface WhenUpdating extends ValidationGroup {
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/validation/validators/ScmUrl.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/validation/validators/ScmUrl.java
@@ -1,0 +1,41 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.validation.validators;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+/**
+ * Author: Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * Date: 3/12/16
+ * Time: 5:01 PM
+ */
+
+
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Constraint(validatedBy = ScmUrlValidator.class)
+public @interface ScmUrl {
+    String message() default "{org.jboss.pnc.rest.validation.InvalidScmUrl.message}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/prototype-rest-model/src/main/java/org/jboss/pnc/rest/validation/validators/ScmUrlValidator.java
+++ b/prototype-rest-model/src/main/java/org/jboss/pnc/rest/validation/validators/ScmUrlValidator.java
@@ -1,0 +1,105 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.validation.validators;
+
+import org.apache.commons.validator.routines.UrlValidator;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * Author: Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * Date: 3/12/16
+ * Time: 5:01 PM
+ */
+public class ScmUrlValidator implements ConstraintValidator<ScmUrl, String>{
+
+    @Override
+    public void initialize(ScmUrl constraintAnnotation) {}
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return isValid(value);
+    }
+
+
+    /******************************************************
+     * STATIC:
+     ******************************************************/
+    private static final char USERNAME_INDICATOR = '@';
+    private static final Pattern USERNAME_PATTERN = Pattern.compile("[\\.\\-_%\\w]+", Pattern.UNICODE_CHARACTER_CLASS);
+    private static final UrlValidator validator = new UrlValidator(new String[]{"http", "https", "git", "ssh", "git+ssh"});
+
+    public static boolean isValid(String url) {
+        if (url == null || "".equals(url)) {
+            return true;
+        }
+
+        if (hasNoProtocol(url)) {
+            url = prepareDefaultProtocolUrl(url);
+        }
+
+        String username = getUsername(url);
+        if (username != null) {
+            if (!isValidUsername(username)) {
+                return false;
+            }
+            url = url.replaceFirst(username, "");
+        }
+        return validator.isValid(url);
+    }
+
+    private static String prepareDefaultProtocolUrl(String url) {
+        url = url.replaceFirst(":", "/");
+        url = "ssh://" + url;
+        return url;
+    }
+
+    private static boolean hasNoProtocol(String url) {
+        return !url.contains("://");
+    }
+
+    private static boolean isValidUsername(String username) {
+        username = username.replaceFirst("" + USERNAME_INDICATOR, "");
+        String[] usernameParts = username.split(":");
+        return Stream.of(usernameParts)
+                .allMatch(p -> USERNAME_PATTERN.matcher(p).matches());
+    }
+
+    /**
+     * Returns a String with username.
+     * '@' character or whatever indicator of it being username is included in the returned value
+     *
+     * @param url url to extract username from
+     * @return username if username is specified in the url, null otherwise
+     */
+    private static String getUsername(String url) {
+        int atIndex = url.lastIndexOf(USERNAME_INDICATOR);
+        if (atIndex < 0) {
+            return null;
+        }
+        String username = url.substring(0, atIndex + 1);
+        int slashIndex = username.lastIndexOf('/');
+        if (slashIndex > 0) {
+            username = username.substring(slashIndex + 1);
+        }
+        return username;
+    }
+}

--- a/prototype-rest/pom.xml
+++ b/prototype-rest/pom.xml
@@ -1,0 +1,371 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source.
+    Copyright 2014 Red Hat, Inc., and individual contributors
+    as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>parent</artifactId>
+    <groupId>org.jboss.pnc</groupId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>prototype-rest</artifactId>
+  <packaging>war</packaging>
+
+  <description>REST API. This is a series of classes that use JAX-RS to translate HTTP communications to calls into the action controllers in the core, and format any output (such as constructing resource URLs, etc.).</description>
+
+    <properties>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+    </properties>
+
+
+  <dependencies>
+    <!-- Project dependencies -->
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>auth</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>moduleconfig</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>build-executor</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>model</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>messaging</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.pnc</groupId>
+        <artifactId>metrics</artifactId>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.pnc</groupId>
+        <artifactId>prototype-rest-model</artifactId>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.pnc</groupId>
+        <artifactId>prototype-rest-api</artifactId>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.jboss.pnc</groupId>
+        <artifactId>prototype-facade</artifactId>
+        <scope>provided</scope>
+    </dependency>
+
+    <!-- Remote dependencies -->
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.websocket</groupId>
+      <artifactId>jboss-websocket-api_1.0_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ejb</groupId>
+      <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-jaxrs</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.javassist</groupId>
+          <artifactId>javassist</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>joda-time</groupId>
+          <artifactId>joda-time</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-envers</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss</groupId>
+      <artifactId>jboss-common-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- TODO only here as lombok is too eager to do everything-->
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>test-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.el</groupId>
+      <artifactId>javax.el-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.web</groupId>
+      <artifactId>javax.el</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-validator</groupId>
+      <artifactId>commons-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>pnc-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>datastore</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>${project.artifactId}</finalName>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+
+    <!-- required for integration tests -->
+    <plugins>
+      <plugin>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <attachClasses>true</attachClasses>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+     <profile>
+        <id>auth</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <executions>
+                      <execution>
+                        <id>copy-webconfig</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                          <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                          <overwrite>true</overwrite>
+                          <outputDirectory>${project.build.directory}/${project.artifactId}/WEB-INF/</outputDirectory>
+                          <resources>
+                            <resource>
+                              <directory>${project.basedir}/src/main/webconfig/auth</directory>
+                            </resource>
+                          </resources>
+                        </configuration>
+                      </execution>
+                    </executions>
+                  </plugin>
+            </plugins>
+         </build>
+     </profile>
+     <profile>
+        <id>noauth</id>
+        <activation>
+            <activeByDefault>true</activeByDefault>
+        </activation>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <executions>
+                      <execution>
+                        <id>copy-webconfig</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                          <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                          <overwrite>true</overwrite>
+                          <outputDirectory>${project.build.directory}/${project.artifactId}/WEB-INF/</outputDirectory>
+                          <resources>
+                            <resource>
+                              <directory>${project.basedir}/src/main/webconfig/noauth</directory>
+                            </resource>
+                          </resources>
+                        </configuration>
+                      </execution>
+                    </executions>
+                  </plugin>
+            </plugins>
+         </build>
+     </profile>
+
+    <profile>
+        <id>auth-container-eap</id>
+        <activation>
+            <property>
+                <name>auth.eap.home</name>
+            </property>
+        </activation>
+      <build>
+        <plugins>
+              <plugin>
+                <groupId>org.jboss.as.plugins</groupId>
+                <artifactId>jboss-as-maven-plugin</artifactId>
+                <executions>
+                  <execution>
+                    <id>start-server</id>
+                    <phase>generate-test-resources</phase>
+                    <goals>
+                      <goal>start</goal>
+                    </goals>
+                    <configuration>
+                      <jbossHome>${auth.eap.home}</jbossHome>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>shutdown-server</id>
+                    <phase>process-test-resources</phase>
+                    <goals>
+                      <goal>shutdown</goal>
+                    </goals>
+                  </execution>
+                </executions>
+              </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/AllOtherExceptionsMapper.java
+++ b/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/AllOtherExceptionsMapper.java
@@ -1,0 +1,84 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.configuration;
+
+import org.jboss.pnc.rest.model.response.error.ErrorResponseRest;
+import org.jboss.resteasy.spi.Failure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+
+/**
+ * Mapper that catches all exception and extracts the http status code from the JAXRS/RESTEASY runtime exception.
+ * Status code extraction is required for proper response error codes eg. 404.
+ */
+@Provider
+public class AllOtherExceptionsMapper implements ExceptionMapper<Exception> {
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    @Override
+    public Response toResponse(Exception e) {
+        int status = Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
+        Response response = null;
+
+        if (e instanceof WebApplicationException) {
+            response = ((WebApplicationException) e).getResponse();
+            logger.debug("An exception occurred when processing REST response", e);
+        } else if (e instanceof Failure) { //Resteasy support
+            Failure failure = ((Failure)e);
+            if (failure.getErrorCode() > 0) {
+                status = failure.getErrorCode();
+            }
+            response = failure.getResponse();
+            logger.debug("An exception occurred when processing REST response", e);
+        } else {
+            logger.error("An exception occurred when processing REST response", e);
+        }
+
+        Response.ResponseBuilder builder;
+
+        if (response != null) {
+            builder = Response.status(response.getStatus());
+//            b.entity(response.getEntity());
+
+            //copy headers
+            for (String headerName : response.getMetadata().keySet()) {
+                List<Object> headerValues = response.getMetadata().get(headerName);
+                for (Object headerValue : headerValues) {
+                    builder.header(headerName, headerValue);
+                }
+            }
+        } else {
+            builder = Response.status(status);
+        }
+
+        builder.entity(new ErrorResponseRest(e)).type(MediaType.APPLICATION_JSON);
+
+        return builder.build();
+
+    }
+}

--- a/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/BuildConfigurationSupportedGenericParameters.java
+++ b/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/BuildConfigurationSupportedGenericParameters.java
@@ -1,0 +1,56 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.configuration;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Provider of statically defined BuildConfiguration generic parameters,
+ * that are known to the Orchestrator.
+ * 
+ * The parameters are set in the resources file
+ * 
+ * @author Jakub Bartecek &lt;jbartece@redhat.com&gt;
+ *
+ */
+@ApplicationScoped
+public class BuildConfigurationSupportedGenericParameters {
+
+    private static final String RESOURCES_FILE = "buildConfigurationSupportedGenericParameters.properties";
+
+    private Map<String, String> supportedGenericParameters = new HashMap<>();
+
+    public BuildConfigurationSupportedGenericParameters() throws FileNotFoundException, IOException {
+        Properties props = new Properties();
+        props.load(new InputStreamReader(getClass().getClassLoader().getResourceAsStream(
+                RESOURCES_FILE)));
+        props.forEach((key, value) -> supportedGenericParameters.put(key.toString(),
+                value.toString()));
+    }
+
+    public Map<String, String> getSupportedGenericParameters() {
+        return supportedGenericParameters;
+    }
+}

--- a/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/BuildConflictExceptionMapper.java
+++ b/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/BuildConflictExceptionMapper.java
@@ -1,0 +1,60 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.configuration;
+
+import org.jboss.pnc.rest.model.response.error.ErrorResponseRest;
+import org.jboss.pnc.spi.exception.BuildConflictException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import java.lang.invoke.MethodHandles;
+
+@Provider
+public class BuildConflictExceptionMapper implements ExceptionMapper<BuildConflictException> {
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    @Override
+    public Response toResponse(BuildConflictException e) {
+        Response.Status status = Response.Status.CONFLICT;
+        logger.debug("A BuildConflict error occurred when processing REST call", e);
+        return Response.status(status).entity(new ErrorResponseRest(e)).build();
+    }
+}

--- a/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/JaxRsActivator.java
+++ b/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/JaxRsActivator.java
@@ -1,0 +1,114 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.configuration;
+
+import io.swagger.jaxrs.config.BeanConfig;
+
+import org.jboss.pnc.rest.configuration.metrics.GeneralRestMetricsFilter;
+import org.jboss.pnc.rest.configuration.metrics.TimedMetric;
+import org.jboss.pnc.rest.configuration.metrics.TimedMetricFilter;
+import org.jboss.pnc.rest.endpoint.BuildConfigurationEndpointImpl;
+import org.jboss.resteasy.plugins.interceptors.CorsFilter;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+@ApplicationPath("/rest")
+public class JaxRsActivator extends Application {
+
+    private Set<Object> singletons = new HashSet<Object>();
+
+    public JaxRsActivator() throws IOException {
+        configureSwagger();
+        configureCors();
+    }
+
+    @Override
+    public Set<Object> getSingletons() {
+        return singletons;
+    }
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        Set<Class<?>> resources = new HashSet<>();
+        addSwaggerResources(resources);
+        addProjectResources(resources);
+        addMetricsResources(resources);
+        return resources;
+    }
+
+    private void configureCors () {
+        CorsFilter corsFilter = new CorsFilter();
+        corsFilter.getAllowedOrigins().add("*");
+        corsFilter.setAllowedMethods("OPTIONS, GET, POST, DELETE, PUT, PATCH");
+        singletons.add(corsFilter);
+    }
+
+    private final void configureSwagger() throws IOException {
+        BeanConfig swaggerConfig = new BeanConfig();
+        swaggerConfig.setVersion("1.0.0");
+        swaggerConfig.setBasePath(getRestBasePath());
+        swaggerConfig.setPrettyPrint(true);
+        swaggerConfig.setResourcePackage("org.jboss.pnc.rest");
+        swaggerConfig.setScan(true);
+    }
+
+    private void addProjectResources(Set<Class<?>> resources) {
+        addEndpoints(resources);
+        addExceptionMappers(resources);
+    }
+
+    private void addEndpoints(Set<Class<?>> resources) {
+        resources.add(BuildConfigurationEndpointImpl.class);
+    }
+
+    private void addExceptionMappers(Set<Class<?>> resources) {
+        resources.add(ValidationExceptionExceptionMapper.class);
+        resources.add(BuildConflictExceptionMapper.class);
+        resources.add(AllOtherExceptionsMapper.class);
+    }
+
+
+    private void addSwaggerResources(Set<Class<?>> resources) {
+        resources.add(io.swagger.jaxrs.listing.ApiListingResource.class);
+        resources.add(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+    }
+
+    private void addMetricsResources(Set<Class<?>> resources) {
+        resources.add(GeneralRestMetricsFilter.class);
+        resources.add(TimedMetric.class);
+        resources.add(TimedMetricFilter.class);
+    }
+
+    private String getRestBasePath() throws IOException {
+        URL resource = Thread.currentThread().getContextClassLoader().getResource("/swagger.properties");
+        Properties properties = new Properties();
+        try (InputStream inStream = resource.openStream()) {
+            properties.load(inStream);
+        }
+        return properties.getProperty("baseUrl");
+    }
+
+}

--- a/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/ValidationExceptionExceptionMapper.java
+++ b/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/ValidationExceptionExceptionMapper.java
@@ -1,0 +1,66 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.configuration;
+
+import org.jboss.pnc.rest.model.response.error.ErrorResponseRest;
+import org.jboss.pnc.rest.validation.exceptions.ConflictedEntryException;
+import org.jboss.pnc.rest.validation.exceptions.RestValidationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import java.lang.invoke.MethodHandles;
+
+@Provider
+public class ValidationExceptionExceptionMapper implements ExceptionMapper<RestValidationException> {
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    @Override
+    public Response toResponse(RestValidationException e) {
+        Response.Status status = Response.Status.BAD_REQUEST;
+        if(e instanceof ConflictedEntryException) {
+            status = Response.Status.CONFLICT;
+            logger.debug("A ConflictedEntry error occurred when processing REST call", e);
+        } else {
+            logger.warn("A validation error occurred when processing REST call", e);
+        }
+        return Response.status(status).entity(new ErrorResponseRest(e)).build();
+    }
+}

--- a/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/metrics/GeneralRestMetricsFilter.java
+++ b/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/metrics/GeneralRestMetricsFilter.java
@@ -1,0 +1,70 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.configuration.metrics;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.jboss.pnc.metrics.MetricsConfiguration;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+@Provider
+public class GeneralRestMetricsFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private static final String METRICS_RATE_KEY = "pnc.rest.all.rate";
+    private static final String METRICS_TIMER_KEY = "pnc.rest.all.timer";
+
+    @Inject
+    private MetricsConfiguration metricsConfiguration;
+
+    @Inject
+    private HttpServletRequest servletRequest;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+
+        MetricRegistry registry = metricsConfiguration.getMetricRegistry();
+
+        Timer timer = registry.timer(METRICS_TIMER_KEY);
+        Meter meter = registry.meter(METRICS_RATE_KEY);
+
+        Timer.Context counter = timer.time();
+        meter.mark();
+
+        servletRequest.setAttribute("timer.context", counter);
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+
+        Timer.Context tc = (Timer.Context) servletRequest.getAttribute("timer.context");
+
+        if (tc != null) {
+            tc.stop();
+            servletRequest.removeAttribute("timer.context");
+        }
+    }
+}

--- a/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/metrics/TimedMetric.java
+++ b/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/metrics/TimedMetric.java
@@ -1,0 +1,33 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.configuration.metrics;
+
+import javax.ws.rs.NameBinding;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotate this to any REST method to get a timer and request rate of the particular method reported
+ */
+@NameBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface TimedMetric {
+}

--- a/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/metrics/TimedMetricFilter.java
+++ b/prototype-rest/src/main/java/org/jboss/pnc/rest/configuration/metrics/TimedMetricFilter.java
@@ -1,0 +1,87 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.configuration.metrics;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.jboss.pnc.metrics.MetricsConfiguration;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+@Provider
+@Priority(Priorities.USER)
+@TimedMetric
+public class TimedMetricFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private static final String METRICS_KEY = "pnc.rest";
+    private static final String METRICS_RATE_KEY = ".rate";
+    private static final String METRICS_TIMER_KEY = ".timer";
+
+    @Context
+    private ResourceInfo resourceInfo;
+
+    @Inject
+    private MetricsConfiguration metricsConfiguration;
+
+    @Inject
+    private HttpServletRequest servletRequest;
+
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+
+        MetricRegistry registry = metricsConfiguration.getMetricRegistry();
+
+        String metricsName = METRICS_KEY +
+                name(resourceInfo.getResourceClass().getSimpleName(), resourceInfo.getResourceMethod().getName());
+
+        Timer timer = registry.timer(metricsName + METRICS_TIMER_KEY);
+        Meter meter = registry.meter(metricsName + METRICS_RATE_KEY);
+
+        Timer.Context counter = timer.time();
+        meter.mark();
+
+        servletRequest.setAttribute("timer.context.method", counter);
+
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+
+        Timer.Context tc = (Timer.Context) servletRequest.getAttribute("timer.context.method");
+
+        if (tc != null) {
+            tc.stop();
+            servletRequest.removeAttribute("timer.context.method");
+        }
+    }
+}

--- a/prototype-rest/src/main/java/org/jboss/pnc/rest/endpoint/AbstractEndpoint.java
+++ b/prototype-rest/src/main/java/org/jboss/pnc/rest/endpoint/AbstractEndpoint.java
@@ -1,0 +1,94 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.rest.endpoint;
+
+import org.jboss.pnc.model.GenericEntity;
+import org.jboss.pnc.rest.model.response.Page;
+import org.jboss.pnc.rest.model.response.Singleton;
+import org.jboss.pnc.rest.provider.api.Provider;
+import org.jboss.pnc.rest.provider.collection.CollectionInfo;
+import org.jboss.pnc.rest.validation.exceptions.RestValidationException;
+
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * Abstract endpoint class providing common functionality
+ *
+ * @author Sebastian Laskawiec
+ */
+public class AbstractEndpoint<DB extends GenericEntity<Integer>, Rest> {
+
+    protected Provider<DB, Rest> basicProvider;
+
+    @Deprecated
+    public AbstractEndpoint() {
+    }
+
+    public AbstractEndpoint(Provider<DB, Rest> basicProvider) {
+        this.basicProvider = basicProvider;
+    }
+
+    public Response getAll(int pageIndex, int pageSize, String sortingRsql, String rsql) {
+        return fromCollection(basicProvider.getAll(pageIndex, pageSize, sortingRsql, rsql));
+    }
+
+    public Response getSpecific(@NotNull Integer id) {
+        return fromSingleton(basicProvider.getSpecific(id));
+    }
+
+    public Response createNew(@NotNull Rest restEntity, UriInfo uriInfo) throws RestValidationException {
+        int id = basicProvider.store(restEntity);
+        UriBuilder uriBuilder = UriBuilder.fromUri(uriInfo.getRequestUri()).path("{id}");
+        return Response.created(uriBuilder.build(id)).entity(new Singleton(basicProvider.getSpecific(id))).build();
+    }
+
+    public Response update(Integer id, @NotNull Rest restEntity) throws RestValidationException {
+        basicProvider.update(id, restEntity);
+        return Response.ok().build();
+    }
+
+    protected Response delete(Integer id) throws RestValidationException {
+        basicProvider.delete(id);
+        return Response.ok().build();
+    }
+
+    protected <T> Response fromCollection(CollectionInfo<T> collection) {
+        if (collection == null || collection.getContent().isEmpty()) {
+            return Response.noContent().entity(new Page<>()).build();
+        }
+        Page<T> pageForResponse = new Page<>(collection.getPageIndex(), collection.getPageSize(),
+                collection.getTotalPages(), collection.getContent());
+        return Response.ok().entity(pageForResponse).build();
+    }
+
+    protected <T> Response fromSingleton(T singleton) {
+        if(singleton == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity(new Singleton(null)).build();
+        }
+        return Response.ok().entity(new Singleton(singleton)).build();
+    }
+
+    protected Response fromEmpty() {
+        return Response.ok().build();
+    }
+
+}

--- a/prototype-rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpointImpl.java
+++ b/prototype-rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildConfigurationEndpointImpl.java
@@ -1,0 +1,150 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.endpoint;
+
+import io.swagger.annotations.Api;
+
+import org.jboss.pnc.model.BuildConfiguration;
+import org.jboss.pnc.rest.api.BuildConfigurationEndpoint;
+import org.jboss.pnc.rest.configuration.BuildConfigurationSupportedGenericParameters;
+import org.jboss.pnc.rest.validation.exceptions.InvalidEntityException;
+import org.jboss.pnc.spi.BuildOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import java.lang.invoke.MethodHandles;
+
+import org.jboss.pnc.rest.model.BuildConfigurationRest;
+import org.jboss.pnc.rest.model.response.Singleton;
+import org.jboss.pnc.rest.provider.api.BuildConfigurationProvider;
+
+@Api(value = "/build-configurations", description = "Build configuration entities")
+@Path("/build-configurations")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class BuildConfigurationEndpointImpl extends AbstractEndpoint<BuildConfiguration, BuildConfigurationRest> implements BuildConfigurationEndpoint {
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private BuildConfigurationProvider buildConfigurationProvider;
+
+    private java.util.Map<String, String> buildConfigurationSupportedGenericParameters;
+
+    public static void checkBuildOptionsValidity(BuildOptions buildOptions) throws InvalidEntityException {
+        if (!buildOptions.isTemporaryBuild() && buildOptions.isTimestampAlignment()) {
+            // Combination timestampAlignment + standard build is not allowed
+            throw new InvalidEntityException("Combination of the build parameters is not allowed. Timestamp alignment is allowed only for temporary builds. ");
+        }
+    }
+
+    public BuildConfigurationEndpointImpl() {
+    }
+
+    @Inject
+    public BuildConfigurationEndpointImpl(
+            BuildConfigurationProvider buildConfigurationProvider,
+            BuildConfigurationSupportedGenericParameters supportedGenericParameters) {
+
+        super(buildConfigurationProvider);
+        this.buildConfigurationProvider = buildConfigurationProvider;
+
+        this.buildConfigurationSupportedGenericParameters = supportedGenericParameters
+                .getSupportedGenericParameters();
+    }
+
+    @Override
+    public Response getAll(int pageIndex, int pageSize, String sort, String q) {
+        return fromCollection(buildConfigurationProvider.getAllNonArchived(pageIndex, pageSize, sort, q));
+    }
+
+    @Override
+    public Response createNew(BuildConfigurationRest buildConfigurationRest, @Context UriInfo uriInfo) {
+        return super.createNew(buildConfigurationRest, uriInfo);
+    }
+
+    @Override
+    public Response getSupportedGenericParameters() {
+        return Response.ok().entity(buildConfigurationSupportedGenericParameters).build();
+    }
+
+    @Override
+    public Response getSpecific(Integer id) {
+        return super.getSpecific(id);
+    }
+
+    @Override
+    public Response update(Integer id, BuildConfigurationRest buildConfigurationRest) {
+        return super.update(id, buildConfigurationRest);
+    }
+
+    @Override
+    public Response deleteSpecific(Integer id) {
+        buildConfigurationProvider.archive(id);
+        return Response.ok().build();
+    }
+
+    @Override
+    public Response clone(Integer id, @Context UriInfo uriInfo) {
+        UriBuilder uriBuilder = UriBuilder.fromUri(uriInfo.getBaseUri()).path("/build-configurations/{id}");
+        int newId = buildConfigurationProvider.clone(id);
+        return Response.created(uriBuilder.build(newId)).entity(new Singleton(buildConfigurationProvider.getSpecific(newId))).build();
+    }
+
+    @Override
+    public Response getAllByProjectId(int pageIndex, int pageSize, String sort, String q, Integer projectId) {
+        return fromCollection(buildConfigurationProvider.getAllForProject(pageIndex, pageSize, sort, q, projectId));
+    }
+
+    @Override
+    public Response getAllByProductId(int pageIndex, int pageSize, String sort, String q, Integer productId) {
+        return fromCollection(buildConfigurationProvider.getAllForProduct(pageIndex, pageSize, sort, q, productId));
+    }
+
+    @Override
+    public Response getAllByProductVersionId(int pageIndex, int pageSize, String sort, String q, Integer productId, Integer versionId) {
+        return fromCollection(buildConfigurationProvider
+                .getAllForProductAndProductVersion(pageIndex, pageSize, sort, q, productId, versionId));
+    }
+
+    @Override
+    public Response getDependencies(int pageIndex, int pageSize, String sort, String q, Integer id) {
+        return fromCollection(buildConfigurationProvider.getDependencies(pageIndex, pageSize, sort, q, id));
+    }
+
+    @Override
+    public Response addDependency(Integer id, BuildConfigurationRest dependency) {
+        buildConfigurationProvider.addDependency(id, dependency.getId());
+        return fromEmpty();
+    }
+
+    @Override
+    public Response removeDependency(Integer id, Integer dependencyId) {
+        buildConfigurationProvider.removeDependency(id, dependencyId);
+        return fromEmpty();
+    }
+}

--- a/prototype-rest/src/main/resources/buildConfigurationSupportedGenericParameters.properties
+++ b/prototype-rest/src/main/resources/buildConfigurationSupportedGenericParameters.properties
@@ -1,0 +1,19 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2014 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+CUSTOM_PME_PARAMETERS=Additional parameters, which will be passed to the PME CLI executable during the alignment before the build. The format is as you would enter them on a command line, and each MUST start with a dash.

--- a/prototype-rest/src/main/resources/swagger.properties
+++ b/prototype-rest/src/main/resources/swagger.properties
@@ -1,0 +1,19 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2014 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+baseUrl=/pnc-rest/rest

--- a/prototype-rest/src/main/webconfig/auth/web.xml
+++ b/prototype-rest/src/main/webconfig/auth/web.xml
@@ -1,0 +1,112 @@
+<!--
+
+    JBoss, Home of Professional Open Source.
+    Copyright 2014 Red Hat, Inc., and individual contributors
+    as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+      version="3.0">
+
+    <module-name>rest</module-name>
+
+    <security-constraint>
+       <web-resource-collection>
+         <web-resource-name>All Access for api docs</web-resource-name>
+         <url-pattern>/rest/api-docs/*</url-pattern>
+       </web-resource-collection>
+    </security-constraint>
+
+    <security-constraint>
+       <web-resource-collection>
+         <web-resource-name>All Access for api docs</web-resource-name>
+         <url-pattern>/rest/api-docs</url-pattern>
+       </web-resource-collection>
+    </security-constraint>
+
+    <!-- Allow logged users to access debug data -->
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Authorized users access to debug data</web-resource-name>
+            <url-pattern>/rest/builds/ssh-credentials/*</url-pattern>
+            <http-method>GET</http-method>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>user</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <!-- Allow all users to access the GET endpoints -->
+    <security-constraint>
+       <web-resource-collection>
+         <web-resource-name>All Access for users on GET</web-resource-name>
+         <url-pattern>/rest/*</url-pattern>
+         <http-method>GET</http-method>
+         <http-method>OPTIONS</http-method>
+       </web-resource-collection>
+    </security-constraint>
+
+    <!-- Allow all logged users to access the other endpoints -->
+    <security-constraint>
+       <web-resource-collection>
+         <web-resource-name>Authorized users Access</web-resource-name>
+         <url-pattern>/rest/*</url-pattern>
+         <http-method>DELETE</http-method>
+         <http-method>PUT</http-method>
+         <http-method>HEAD</http-method>
+         <http-method>TRACE</http-method>
+         <http-method>POST</http-method>
+       </web-resource-collection>
+        <auth-constraint>
+            <role-name>user</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <login-config>
+        <auth-method>KEYCLOAK</auth-method>
+        <realm-name>this is ignored currently</realm-name>
+    </login-config>
+
+    <security-role>
+        <role-name>admin</role-name>
+    </security-role>
+    <security-role>
+        <role-name>user</role-name>
+    </security-role>
+
+  <!-- see noauth/web.xml for posisble replacement -->
+    <!--filter>
+        <filter-name>cross-origin</filter-name>
+        <filter-class>org.eclipse.jetty.servlets.CrossOriginFilter</filter-class>
+        <init-param>
+            <param-name>allowedMethods</param-name>
+            <param-value>GET,POST,PUT,DELETE,OPTIONS,HEAD</param-value>
+        </init-param>
+        <init-param>
+            <param-name>allowedHeaders</param-name>
+            <param-value>X-Requested-With,Content-Type,Accept,Origin,Authorization</param-value>
+        </init-param>
+        <init-param>
+            <param-name>chainPreflight</param-name>
+            <param-value>false</param-value>
+        </init-param>
+    </filter>
+    <filter-mapping>
+        <filter-name>cross-origin</filter-name>
+        <url-pattern>/rest/*</url-pattern>
+    </filter-mapping-->
+</web-app>

--- a/prototype-rest/src/main/webconfig/noauth/web.xml
+++ b/prototype-rest/src/main/webconfig/noauth/web.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source.
+    Copyright 2014 Red Hat, Inc., and individual contributors
+    as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd" version="3.0">
+
+  <!-- try resteasy filter instead of adding jetty dependency
+  https://docs.jboss.org/resteasy/docs/3.0.7.Final/userguide/html/ch30.html
+  http://www.codingpedia.org/ama/how-to-enable-cors-filter-in-resteasy
+
+  or WildFly standalone.xml config
+  https://forum.camunda.org/t/enable-cors-on-wildfly/673/2
+-->
+
+
+  <!--filter>
+      <filter-name>cross-origin</filter-name>
+      <filter-class>org.eclipse.jetty.servlets.CrossOriginFilter</filter-class>
+      <init-param>
+          <param-name>allowedMethods</param-name>
+          <param-value>GET,POST,PUT,DELETE,OPTIONS,HEAD</param-value>
+      </init-param>
+      <init-param>
+          <param-name>allowedHeaders</param-name>
+          <param-value>X-Requested-With,Content-Type,Accept,Origin,Authorization</param-value>
+      </init-param>
+      <init-param>
+          <param-name>chainPreflight</param-name>
+          <param-value>false</param-value>
+      </init-param>
+  </filter>
+  <filter-mapping>
+      <filter-name>cross-origin</filter-name>
+      <url-pattern>/rest/*</url-pattern>
+  </filter-mapping-->
+
+</web-app>


### PR DESCRIPTION
I sketched a prototype for design for the REST refactor. In essence it's refactor of rest and rest-model modules into 4 modules (now prefixed prototype-):

- **rest-model** -  POJO for the REST entities, designed according to the decisions from F2F
  - see [BuildConfigurationRest](https://github.com/project-ncl/pnc/pull/2064/files#diff-ad845808b98e33fe2e1836f0836d82a1) and [BuildConfigurationRef](https://github.com/project-ncl/pnc/pull/2064/files#diff-d81c4cf1616084cbc7335cbbb1d4a4c9) - immutable POJOs with builders
  - it should have as few dependencies as possible
- **rest-api** - interfaces for the REST endpoints
  - see [BuildConfigurationEndpoint](https://github.com/project-ncl/pnc/pull/2064/files#diff-6fbe9162fbc47a43cf18854055e08434) - JAX-RS and swagger annotations goes there
  - it should have as few dependencies as possible
- **rest** - implementation of the rest-api
  - see [BuildConfigurationEndpointImpl](https://github.com/project-ncl/pnc/pull/2064/files#diff-5ddcec581154b733f5361270aba7fcd8)
- **facade** - module where REST and DB meets
   - **mappers** - extracted from rest entity constructors, transforms DB entity to REST entity and vice versa (see [BuildConfigurationMapper](https://github.com/project-ncl/pnc/pull/2064/files#diff-c0f916a063f63f69900475c4b1fc0fef))
  - **providers** - moved from rest module, helps rest implementation with obtaining and manipulating data (see [BuildConfigurationProviderImpl](https://github.com/project-ncl/pnc/pull/2064/files#diff-c10bd27653ec22b2a89b03ce7cfc9336))

I did the example only for the BuildConfiguration entity, deleted the rest also with bunch of other code that was not used by the example. The code should compile, but doesn't actually work. Naming can change!

What do you think? What issues are there? What can we do better?