### PR TITLE
[v1.4] Remove duplicate of logback-classic from dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -944,12 +944,6 @@
         <artifactId>commons-validator</artifactId>
         <version>1.5.0</version>
       </dependency>
-
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>1.2.3</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
The first occurence starts on line 615.