### PR TITLE
Remove duplicate of logback-classic from dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -950,12 +950,6 @@
         <version>1.5.0</version>
       </dependency>
 
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>1.2.3</version>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
The first occurence starts on line 615.