### PR TITLE
[v1.4][NCL-4089] Add EXECUTION_ROOT_NAME generic param

### DIFF
--- a/rest/src/main/resources/buildConfigurationSupportedGenericParameters.properties
+++ b/rest/src/main/resources/buildConfigurationSupportedGenericParameters.properties
@@ -17,3 +17,4 @@
 #
 
 CUSTOM_PME_PARAMETERS=Additional parameters, which will be passed to the PME CLI executable during the alignment before the build. The format is as you would enter them on a command line, and each MUST start with a dash.
+EXECUTION_ROOT_NAME=Specify the execution root name of the build configuration. This is used to override the default value, and can be useful for builds that disable PME. Format is '<groupid>:<artifactid>'


### PR DESCRIPTION
Specify the execution root name of the build configuration. This is used
to override the default value, and can be useful for builds that disable
PME. Format is '<groupid>:<artifactid>'