### PR TITLE
dependen*recordids in buildrecord set to 'text' type

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
@@ -312,12 +312,16 @@ public class BuildRecord implements GenericEntity<Integer> {
      * A collection of buildRecords that depends on this at time this is stored.
      * Dependents are defined based on scheduled state.
      */
+    @Lob
+    @Type(type = "org.hibernate.type.TextType")
     private String dependentBuildRecordIds;
 
     /**
      * A collection of buildRecords that this depends on at time this is stored.
      * Dependencies are defined based on scheduled state.
      */
+    @Lob
+    @Type(type = "org.hibernate.type.TextType")
     private String dependencyBuildRecordIds;
 
     /**

--- a/model/src/main/resources/db-update/00002-from-1.3.0-to-1.4.0.sql
+++ b/model/src/main/resources/db-update/00002-from-1.3.0-to-1.4.0.sql
@@ -20,3 +20,7 @@
 insert into TargetRepository (temporaryRepo, identifier, repositoryPath, repositoryType) values (false, 'indy-npm', '/api/content/npm/group/builds-untested', 'NPM');
 insert into TargetRepository (temporaryRepo, identifier, repositoryPath, repositoryType) values (true, 'indy-npm', '/api/content/npm/group/temporary-builds', 'NPM');
 insert into TargetRepository (temporaryRepo, identifier, repositoryPath, repositoryType) values (false, 'indy-npm', '/api/content/npm/hosted/shared-imports', 'NPM');
+
+-- insert new columns in build record
+alter table buildrecord add column dependencybuildrecordids text;
+alter table buildrecord add column dependentbuildrecordids text;


### PR DESCRIPTION
The SQL schema update file has also been updated to add the extra
columns in buildrecord into the database.