### PR TITLE
[v1.4] dependen*recordids in buildrecord set to 'text' type

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
@@ -312,12 +312,16 @@ public class BuildRecord implements GenericEntity<Integer> {
      * A collection of buildRecords that depends on this at time this is stored.
      * Dependents are defined based on scheduled state.
      */
+    @Lob
+    @Type(type = "org.hibernate.type.TextType")
     private String dependentBuildRecordIds;
 
     /**
      * A collection of buildRecords that this depends on at time this is stored.
      * Dependencies are defined based on scheduled state.
      */
+    @Lob
+    @Type(type = "org.hibernate.type.TextType")
     private String dependencyBuildRecordIds;
 
     /**

--- a/model/src/main/resources/db-update/00002-from-1.3.0-to-1.4.0.sql
+++ b/model/src/main/resources/db-update/00002-from-1.3.0-to-1.4.0.sql
@@ -1,0 +1,26 @@
+--
+-- JBoss, Home of Professional Open Source.
+-- Copyright 2014 Red Hat, Inc., and individual contributors
+-- as indicated by the @author tags.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- insert npm repositories
+insert into TargetRepository (temporaryRepo, identifier, repositoryPath, repositoryType) values (false, 'indy-npm', '/api/content/npm/group/builds-untested', 'NPM');
+insert into TargetRepository (temporaryRepo, identifier, repositoryPath, repositoryType) values (true, 'indy-npm', '/api/content/npm/group/temporary-builds', 'NPM');
+insert into TargetRepository (temporaryRepo, identifier, repositoryPath, repositoryType) values (false, 'indy-npm', '/api/content/npm/hosted/shared-imports', 'NPM');
+
+-- insert new columns in build record
+alter table buildrecord add column dependencybuildrecordids text;
+alter table buildrecord add column dependentbuildrecordids text;


### PR DESCRIPTION
The SQL schema update file has also been updated to add the extra
columns in buildrecord into the database.