### PR TITLE
[NCL-4189] Execute debug scripts if debug mode on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- [NCL-4189] Call scripts at the beginning and end of a build run in debug mode. The script will launch tools such as `tcpdump` in the background to capture packets. If the build fails, the packet capture can be collected and then analyzed
+
 ### Changed
 - [NCL-3886] Relax milestone version restrictions to support Continuous Delivery
 

--- a/termd-build-driver/src/main/java/org/jboss/pnc/termdbuilddriver/TermdBuildDriver.java
+++ b/termd-build-driver/src/main/java/org/jboss/pnc/termdbuilddriver/TermdBuildDriver.java
@@ -238,6 +238,28 @@ public class TermdBuildDriver implements BuildDriver { //TODO rename class
         }
     }
 
+    /**
+     * When the build fails, run the stopDebugTools.sh script to shutdown any debug tools that might have been running
+     * in the background
+     *
+     * Related: NCL-4189
+     *
+     * @param maybeClient
+     */
+    private void shutdownDebug(Optional<BuildAgentClient> maybeClient) {
+
+        if (maybeClient.isPresent()) {
+            BuildAgentClient client = maybeClient.get();
+            try {
+                client.executeCommand("/usr/local/bin/stopDebugTools.sh");
+            } catch (BuildAgentClientException e) {
+                logger.error("Failed to stop debug env tools", e);
+            }
+        } else {
+            logger.error("No build agent client present to stop debug tools");
+        }
+    }
+
     private Void createBuildAgentClient(
             RemoteInvocation remoteInvocation,
             RunningEnvironment runningEnvironment,
@@ -329,7 +351,13 @@ public class TermdBuildDriver implements BuildDriver { //TODO rename class
 
         String workingDirectory = termdRunningBuild.getRunningEnvironment().getWorkingDirectory().toAbsolutePath().toString();
         String name = termdRunningBuild.getName();
+
         if (debugData.isEnableDebugOnFailure()) {
+
+            // NCL-4189: start debug tools to use for debugging before the build
+            buildScript.append("/usr/local/bin/startDebugTools.sh");
+
+            // This is so that we are in the correct directory when we ssh into the pod
             String projectDirectory = (workingDirectory.endsWith("/") ? workingDirectory : workingDirectory + "/") + name;
             String enterProjectDirCommand = "echo 'cd " + projectDirectory + "' >> /home/worker/.bashrc";
             buildScript.append(enterProjectDirCommand).append("\n");


### PR DESCRIPTION
When debug mode is on (or keep pod alive is on), we now execute a script
(startDebugTools.sh) before the build script runs, and another script
(stopDebugTools.sh) if the build script fails.

In the case the build script passes, the pod will die and will
automatically kill any debug tools still running. (the build script
typically runs the Maven command)

The usecase for the scripts right now is to start running `tcpdump` in
the background to capture packet going in/out of the pod (inside
`startDebugTools.sh`). If the build script fails, we can then stop the
`tcpdump` capture by running `stopDebugTools.sh`. The tcpdump capture is
then accessible to the user to analyze since the pod stays alive if the
build script fails.

The idea behind running scripts instead of running the 'tcpdump'
directly is that it gives us flexibility to run other debug commands in
the future.