### PR TITLE
Add generic internal-repo pattern list, support for generic-http in isExternalOrigin()

### DIFF
--- a/indy-repository-manager/src/main/java/org/jboss/pnc/indyrepositorymanager/IndyRepositorySession.java
+++ b/indy-repository-manager/src/main/java/org/jboss/pnc/indyrepositorymanager/IndyRepositorySession.java
@@ -669,7 +669,7 @@ public class IndyRepositorySession implements RepositorySession {
                 suffixes = ignoredPathSuffixes.getNpmWithShared();
                 break;
             case GENERIC_PKG_KEY:
-                suffixes = ignoredPathSuffixes.getGenericWithShared();
+                suffixes = ignoredPathSuffixes.getShared();
                 break;
             default:
                 throw new IllegalArgumentException("Package type " + packageType

--- a/indy-repository-manager/src/main/java/org/jboss/pnc/indyrepositorymanager/IndyRepositorySession.java
+++ b/indy-repository-manager/src/main/java/org/jboss/pnc/indyrepositorymanager/IndyRepositorySession.java
@@ -377,6 +377,9 @@ public class IndyRepositorySession implements RepositorySession {
             case NPM_PKG_KEY:
                 patterns = internalRepoPatterns.getNpm();
                 break;
+            case GENERIC_PKG_KEY:
+                patterns = internalRepoPatterns.getGeneric();
+                break;
             default:
                 throw new IllegalArgumentException("Package type " + storeKey.getPackageType()
                         + " is not supported by Indy repository manager driver.");

--- a/indy-repository-manager/src/main/java/org/jboss/pnc/indyrepositorymanager/IndyRepositorySession.java
+++ b/indy-repository-manager/src/main/java/org/jboss/pnc/indyrepositorymanager/IndyRepositorySession.java
@@ -669,7 +669,7 @@ public class IndyRepositorySession implements RepositorySession {
                 suffixes = ignoredPathSuffixes.getNpmWithShared();
                 break;
             case GENERIC_PKG_KEY:
-                suffixes = ignoredPathSuffixes.getShared();
+                suffixes = ignoredPathSuffixes.getGenericWithShared();
                 break;
             default:
                 throw new IllegalArgumentException("Package type " + packageType

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/IndyRepoDriverModuleConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/IndyRepoDriverModuleConfig.java
@@ -292,13 +292,6 @@ public class IndyRepoDriverModuleConfig extends AbstractModuleConfig{
             return npmWithShared;
         }
 
-        @JsonIgnore
-        public List<String> getGenericWithShared() {
-            List<String> genericWithShared = (generic == null ? new ArrayList<>() : new ArrayList<>(generic));
-            genericWithShared.addAll(getShared());
-            return genericWithShared;
-        }
-
         /**
          * Gets the list of ignored path suffixes shared among all package types.
          * @return the list of shared strings or empty list if no value is set (never {@code null})

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/IndyRepoDriverModuleConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/IndyRepoDriverModuleConfig.java
@@ -186,6 +186,11 @@ public class IndyRepoDriverModuleConfig extends AbstractModuleConfig{
         @JsonInclude(Include.NON_EMPTY)
         protected List<String> npm;
 
+        @Setter
+        @JsonProperty("generic")
+        @JsonInclude(Include.NON_EMPTY)
+        protected List<String> generic;
+
         /**
          * Gets the list of Maven strings.
          * @return the list of Maven strings or empty list if no value is set (never {@code null})

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/IndyRepoDriverModuleConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/IndyRepoDriverModuleConfig.java
@@ -239,6 +239,28 @@ public class IndyRepoDriverModuleConfig extends AbstractModuleConfig{
             }
         }
 
+        /**
+         * Gets the list of Generic-http strings.
+         * @return the list of Generic-http strings or empty list if no value is set (never {@code null})
+         */
+        public List<String> getGeneric() {
+            return generic == null ? Collections.emptyList() : generic;
+        }
+
+        /**
+         * Adds extra members to the list of Generic-http strings.
+         * @param addition added strings
+         */
+        public void addGeneric(List<String> addition) {
+            if (addition != null) {
+                if (generic == null) {
+                    generic = new ArrayList<>(addition);
+                } else {
+                    npm.addAll(addition);
+                }
+            }
+        }
+
     }
 
 
@@ -268,6 +290,13 @@ public class IndyRepoDriverModuleConfig extends AbstractModuleConfig{
             List<String> npmWithShared = (npm == null ? new ArrayList<>() : new ArrayList<>(npm));
             npmWithShared.addAll(getShared());
             return npmWithShared;
+        }
+
+        @JsonIgnore
+        public List<String> getGenericWithShared() {
+            List<String> genericWithShared = (generic == null ? new ArrayList<>() : new ArrayList<>(generic));
+            genericWithShared.addAll(getShared());
+            return genericWithShared;
         }
 
         /**


### PR DESCRIPTION
I'm adding handling logic for generic-http to deal with IllegalArgumentException when trying to sort out whether tracking record entries are from an external origin. I've also added better support for generic-http in the ignored path suffixes, to be consistent.

I couldn't find a place to add unit tests for these. Please advise if you need more WRT that.

### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing? (N/A)
* [ ] Have you added unit tests for your change? (No)
