### PR TITLE
Add @JsonDeserialize to DTOs

### DIFF
--- a/dto/src/main/java/org/jboss/pnc/dto/Artifact.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/Artifact.java
@@ -22,6 +22,7 @@ import org.jboss.pnc.enums.ArtifactQuality;
 import java.time.Instant;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Data;
@@ -31,6 +32,7 @@ import lombok.Data;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @Data
+@JsonDeserialize(builder = Artifact.Builder.class)
 public class Artifact extends ArtifactRef {
 
     private final TargetRepositoryRef targetRepository;

--- a/dto/src/main/java/org/jboss/pnc/dto/ArtifactImportError.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ArtifactImportError.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -28,6 +29,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = ArtifactImportError.Builder.class)
 public class ArtifactImportError {
 
     private final Integer artifactId;

--- a/dto/src/main/java/org/jboss/pnc/dto/ArtifactRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ArtifactRef.java
@@ -26,6 +26,7 @@ import javax.validation.constraints.Null;
 
 import java.time.Instant;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -37,6 +38,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder", builderMethodName = "refBuilder")
+@JsonDeserialize(builder = ArtifactRef.Builder.class)
 public class ArtifactRef implements DTOEntity {
 
     @NotNull(groups = WhenUpdating.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/Build.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/Build.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Data;
@@ -32,6 +33,7 @@ import lombok.Data;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @Data
+@JsonDeserialize(builder = Build.Builder.class)
 public class Build extends BuildRef {
 
     private final ProjectRef project;

--- a/dto/src/main/java/org/jboss/pnc/dto/BuildConfiguration.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/BuildConfiguration.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Data;
@@ -35,6 +36,7 @@ import lombok.Data;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @Data
+@JsonDeserialize(builder = BuildConfiguration.Builder.class)
 public class BuildConfiguration extends BuildConfigurationRef {
 
     @RefHasId(groups = {WhenCreatingNew.class, WhenUpdating.class})

--- a/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationRef.java
@@ -27,6 +27,7 @@ import javax.validation.constraints.Pattern;
 
 import java.time.Instant;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -38,6 +39,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder", builderMethodName = "refBuilder")
+@JsonDeserialize(builder = BuildConfigurationRef.Builder.class)
 public class BuildConfigurationRef implements DTOEntity {
 
     @NotNull(groups = WhenUpdating.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationRevision.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationRevision.java
@@ -22,6 +22,7 @@ import org.jboss.pnc.enums.BuildType;
 import java.time.Instant;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Data;
 
@@ -30,6 +31,7 @@ import lombok.Data;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @Data
+@JsonDeserialize(builder = BuildConfigurationRevision.Builder.class)
 public class BuildConfigurationRevision extends BuildConfigurationRevisionRef {
 
     private final SCMRepository repository;

--- a/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationRevisionRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationRevisionRef.java
@@ -26,6 +26,7 @@ import javax.validation.constraints.Null;
 
 import java.time.Instant;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -37,6 +38,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder", builderMethodName = "refBuilder")
+@JsonDeserialize(builder = BuildConfigurationRevisionRef.Builder.class)
 public class BuildConfigurationRevisionRef implements DTOEntity {
 
     @NotNull(groups = WhenUpdating.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/BuildEnvironment.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/BuildEnvironment.java
@@ -26,6 +26,7 @@ import javax.validation.constraints.Null;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -37,6 +38,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = BuildEnvironment.Builder.class)
 public class BuildEnvironment implements DTOEntity {
 
     @NotNull(groups = WhenUpdating.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/BuildPushResult.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/BuildPushResult.java
@@ -26,6 +26,7 @@ import javax.validation.constraints.Null;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -37,6 +38,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = BuildPushResult.Builder.class)
 public class BuildPushResult implements DTOEntity {
 
     @NotNull(groups = WhenUpdating.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/BuildRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/BuildRef.java
@@ -26,6 +26,7 @@ import javax.validation.constraints.Null;
 
 import java.time.Instant;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -37,6 +38,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder", builderMethodName = "refBuilder")
+@JsonDeserialize(builder = BuildRef.Builder.class)
 public class BuildRef implements DTOEntity {
 
     @NotNull(groups = WhenUpdating.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/GroupBuild.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/GroupBuild.java
@@ -22,6 +22,7 @@ import org.jboss.pnc.enums.BuildStatus;
 import java.time.Instant;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Data;
 
@@ -30,6 +31,7 @@ import lombok.Data;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @Data
+@JsonDeserialize(builder = GroupBuild.Builder.class)
 public class GroupBuild extends GroupBuildRef {
 
     private final GroupConfigurationRef groupConfig;

--- a/dto/src/main/java/org/jboss/pnc/dto/GroupBuildRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/GroupBuildRef.java
@@ -26,6 +26,7 @@ import javax.validation.constraints.Null;
 
 import java.time.Instant;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -37,6 +38,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder", builderMethodName = "refBuilder")
+@JsonDeserialize(builder = GroupBuildRef.Builder.class)
 public class GroupBuildRef implements DTOEntity {
 
     @NotNull(groups = WhenUpdating.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/GroupConfiguration.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/GroupConfiguration.java
@@ -23,6 +23,7 @@ import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Data;
 
@@ -31,6 +32,7 @@ import lombok.Data;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @Data
+@JsonDeserialize(builder = GroupConfiguration.Builder.class)
 public class GroupConfiguration extends GroupConfigurationRef {
 
     @RefHasId(groups = {WhenCreatingNew.class, WhenUpdating.class}, optional = true)

--- a/dto/src/main/java/org/jboss/pnc/dto/GroupConfigurationRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/GroupConfigurationRef.java
@@ -23,6 +23,7 @@ import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -34,6 +35,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder", builderMethodName = "refBuilder")
+@JsonDeserialize(builder = GroupConfigurationRef.Builder.class)
 public class GroupConfigurationRef implements DTOEntity {
 
     @NotNull(groups = WhenUpdating.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/Product.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/Product.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.dto;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Data;
@@ -30,6 +31,7 @@ import lombok.Setter;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @Data
+@JsonDeserialize(builder = Product.Builder.class)
 public class Product extends ProductRef {
 
     @Getter

--- a/dto/src/main/java/org/jboss/pnc/dto/ProductMilestone.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ProductMilestone.java
@@ -23,6 +23,7 @@ import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import java.time.Instant;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Data;
@@ -32,6 +33,7 @@ import lombok.Data;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @Data
+@JsonDeserialize(builder = ProductMilestone.Builder.class)
 public class ProductMilestone extends ProductMilestoneRef {
 
     @RefHasId(groups = {WhenCreatingNew.class})

--- a/dto/src/main/java/org/jboss/pnc/dto/ProductMilestoneRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ProductMilestoneRef.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
@@ -37,6 +38,7 @@ import java.time.Instant;
  */
 @Data
 @Builder(builderClassName = "Builder", builderMethodName = "refBuilder")
+@JsonDeserialize(builder = ProductMilestoneRef.Builder.class)
 public class ProductMilestoneRef implements DTOEntity {
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/ProductMilestoneRelease.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ProductMilestoneRelease.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
@@ -36,6 +37,7 @@ import java.time.Instant;
  */
 @Data
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = ProductMilestoneRelease.Builder.class)
 public class ProductMilestoneRelease implements DTOEntity {
 
     @NotNull(groups = WhenUpdating.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/ProductRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ProductRef.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
@@ -35,6 +36,7 @@ import javax.validation.constraints.Pattern;
  */
 @Data
 @Builder(builderClassName = "Builder", builderMethodName = "refBuilder")
+@JsonDeserialize(builder = ProductRef.Builder.class)
 public class ProductRef implements DTOEntity {
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/ProductRelease.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ProductRelease.java
@@ -24,6 +24,7 @@ import org.jboss.pnc.enums.SupportLevel;
 
 import java.time.Instant;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Data;
@@ -33,6 +34,7 @@ import lombok.Data;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @Data
+@JsonDeserialize(builder = ProductRelease.Builder.class)
 public class ProductRelease extends ProductReleaseRef {
 
     @RefHasId(groups = {WhenCreatingNew.class, WhenUpdating.class})

--- a/dto/src/main/java/org/jboss/pnc/dto/ProductReleaseRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ProductReleaseRef.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
@@ -36,6 +37,7 @@ import java.time.Instant;
  */
 @Data
 @Builder(builderClassName = "Builder", builderMethodName = "refBuilder")
+@JsonDeserialize(builder = ProductReleaseRef.Builder.class)
 public class ProductReleaseRef implements DTOEntity {
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/ProductVersion.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ProductVersion.java
@@ -22,6 +22,7 @@ import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Data;
@@ -31,6 +32,7 @@ import lombok.Data;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @Data
+@JsonDeserialize(builder = ProductVersion.Builder.class)
 public class ProductVersion extends ProductVersionRef {
 
     @RefHasId(groups = {WhenCreatingNew.class})

--- a/dto/src/main/java/org/jboss/pnc/dto/ProductVersionRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ProductVersionRef.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
@@ -38,6 +39,7 @@ import java.util.Map;
  */
 @Data
 @Builder(builderClassName = "Builder", builderMethodName = "refBuilder")
+@JsonDeserialize(builder = ProductVersionRef.Builder.class)
 public class ProductVersionRef implements DTOEntity {
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/Project.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/Project.java
@@ -23,6 +23,7 @@ import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Data;
@@ -32,6 +33,7 @@ import lombok.Data;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @Data
+@JsonDeserialize(builder = Project.Builder.class)
 public class Project extends ProjectRef {
 
     private final List<BuildConfigurationRef> buildConfigurations;

--- a/dto/src/main/java/org/jboss/pnc/dto/ProjectRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ProjectRef.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
@@ -32,6 +33,7 @@ import javax.validation.constraints.Null;
  */
 @Data
 @Builder(builderClassName = "Builder", builderMethodName = "refBuilder")
+@JsonDeserialize(builder = ProjectRef.Builder.class)
 public class ProjectRef implements DTOEntity {
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/SCMRepository.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/SCMRepository.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
@@ -36,6 +37,7 @@ import org.jboss.pnc.dto.validation.constraints.SCMUrl;
  */
 @Data
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = SCMRepository.Builder.class)
 public class SCMRepository implements DTOEntity {
 
     @NotNull(groups = WhenUpdating.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/TargetRepository.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/TargetRepository.java
@@ -21,6 +21,7 @@ import org.jboss.pnc.enums.RepositoryType;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Data;
@@ -30,6 +31,7 @@ import lombok.Data;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @Data
+@JsonDeserialize(builder = TargetRepository.Builder.class)
 public class TargetRepository extends TargetRepositoryRef {
 
     private final Set<Integer> artifactIds;

--- a/dto/src/main/java/org/jboss/pnc/dto/TargetRepositoryRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/TargetRepositoryRef.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
@@ -34,6 +35,7 @@ import javax.validation.constraints.Null;
  */
 @Data
 @Builder(builderClassName = "Builder", builderMethodName = "refBuilder")
+@JsonDeserialize(builder = TargetRepositoryRef.Builder.class)
 public class TargetRepositoryRef implements DTOEntity {
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/User.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/User.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
@@ -32,6 +33,7 @@ import javax.validation.constraints.Null;
  */
 @Data
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = User.Builder.class)
 public class User implements DTOEntity {
 
     @NotNull(groups = WhenUpdating.class)

--- a/dto/src/main/java/org/jboss/pnc/dto/internal/ArtifactRepository.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/internal/ArtifactRepository.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.dto.internal;
 
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -29,6 +30,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = ArtifactRepository.Builder.class)
 public class ArtifactRepository {
 
     private final Integer id;

--- a/dto/src/main/java/org/jboss/pnc/dto/internal/BuildDriverResult.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/internal/BuildDriverResult.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.dto.internal;
 
 import org.jboss.pnc.enums.BuildStatus;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -30,6 +31,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = BuildDriverResult.Builder.class)
 public class BuildDriverResult {
 
     private final String buildLog;

--- a/dto/src/main/java/org/jboss/pnc/dto/internal/BuildExecutionConfiguration.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/internal/BuildExecutionConfiguration.java
@@ -24,6 +24,7 @@ import org.jboss.pnc.enums.SystemImageType;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -35,6 +36,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = BuildExecutionConfiguration.Builder.class)
 public class BuildExecutionConfiguration {
 
     private final Integer id;

--- a/dto/src/main/java/org/jboss/pnc/dto/internal/bpm/BPMTask.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/internal/bpm/BPMTask.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.dto.internal.bpm;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -32,6 +33,7 @@ import lombok.Setter;
  */
 @Data
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = BPMTask.Builder.class)
 public class BPMTask {
 
     /**

--- a/dto/src/main/java/org/jboss/pnc/dto/internal/bpm/ProcessProgressUpdate.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/internal/bpm/ProcessProgressUpdate.java
@@ -20,6 +20,7 @@ package org.jboss.pnc.dto.internal.bpm;
 import org.jboss.pnc.enums.BPMTaskStatus;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Data;
@@ -30,6 +31,7 @@ import lombok.Data;
  */
 @Data
 @JsonTypeName(value = ProcessProgressUpdate.PROCESS_PROGRESS_UPDATE)
+@JsonDeserialize(builder = ProcessProgressUpdate.Builder.class)
 public class ProcessProgressUpdate extends BPMNotification {
     static final String PROCESS_PROGRESS_UPDATE = "PROCESS_PROGRESS_UPDATE";
 

--- a/dto/src/main/java/org/jboss/pnc/dto/requests/BuildConfigWithSCMRequest.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/requests/BuildConfigWithSCMRequest.java
@@ -22,6 +22,7 @@ import org.jboss.pnc.dto.BuildConfiguration;
 
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -35,6 +36,7 @@ import lombok.Setter;
  */
 @Data
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = BuildConfigWithSCMRequest.Builder.class)
 public class BuildConfigWithSCMRequest {
 
     @NotBlank

--- a/dto/src/main/java/org/jboss/pnc/dto/requests/BuildPushRequest.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/requests/BuildPushRequest.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.dto.requests;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -30,6 +31,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = BuildPushRequest.Builder.class)
 public class BuildPushRequest {
 
     private final String tagPrefix;

--- a/dto/src/main/java/org/jboss/pnc/dto/requests/CreateAndSyncSCMRequest.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/requests/CreateAndSyncSCMRequest.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.dto.requests;
 
 import org.hibernate.validator.constraints.NotBlank;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -30,6 +31,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = CreateAndSyncSCMRequest.Builder.class)
 public class CreateAndSyncSCMRequest {
 
     @NotBlank

--- a/dto/src/main/java/org/jboss/pnc/dto/requests/GroupBuildPushRequest.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/requests/GroupBuildPushRequest.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.dto.requests;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -30,6 +31,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = GroupBuildPushRequest.Builder.class)
 public class GroupBuildPushRequest {
 
     private final String tagPrefix;

--- a/dto/src/main/java/org/jboss/pnc/dto/response/ErrorResponse.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/response/ErrorResponse.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.AllArgsConstructor;
@@ -30,6 +31,7 @@ import lombok.Data;
 @Data
 @Builder(builderClassName = "Builder")
 @AllArgsConstructor()
+@JsonDeserialize(builder = ErrorResponse.Builder.class)
 public class ErrorResponse {
 
     private final String errorType;

--- a/dto/src/main/java/org/jboss/pnc/dto/response/Parameter.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/response/Parameter.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,6 +30,7 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = Parameter.Builder.class)
 public class Parameter {
 
     public final String name;

--- a/dto/src/main/java/org/jboss/pnc/dto/response/SSHCredentials.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/response/SSHCredentials.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,6 +30,7 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = SSHCredentials.Builder.class)
 public class SSHCredentials {
 
     private final String command;

--- a/dto/src/main/java/org/jboss/pnc/dto/response/SupportLevel.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/response/SupportLevel.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,6 +30,7 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = SupportLevel.Builder.class)
 public class SupportLevel {
 
     public final String name;

--- a/dto/src/main/java/org/jboss/pnc/dto/response/TaskResponse.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/response/TaskResponse.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
@@ -28,6 +29,7 @@ import lombok.Data;
  */
 @Data
 @Builder(builderClassName = "Builder")
+@JsonDeserialize(builder = TaskResponse.Builder.class)
 public class TaskResponse {
 
     public int taskId;


### PR DESCRIPTION
To let Jackson know which Builder class to use to deserialize JSON back to
its DTO, we need to add `@JsonDeserialize` annotation to the class and
specify which Builder class to use

The existing `@JsonPOJOBuilder` annotation is used to tell Jackson how
to call the Builder class (which methods, setter method prefix to use)

Reference: https://stackoverflow.com/a/21624629/2907906

### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing?
* [ ] Have you added unit tests for your change?
