### PR TITLE
[v1.4][NCL-4392] Expose info about num of building and enqued builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - [NCL-4393] Adds pnc service status visualisations to the UI dashboard
+- [NCL-4392] Expose info about number of building and enqueued builds via REST
+
 
 ### Fixed
 - [NCL-4333] A closed milestone now cannot be set as current via REST API

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/RunningBuildsCountRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/RunningBuildsCountRest.java
@@ -1,0 +1,31 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.restmodel;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class RunningBuildsCountRest {
+
+    private int running;
+    private int enqueued;
+    private int waitingForDependencies;
+
+}

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/RunningBuildRecordEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/RunningBuildRecordEndpoint.java
@@ -26,6 +26,7 @@ import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.rest.provider.BuildConfigSetRecordProvider;
 import org.jboss.pnc.rest.provider.BuildRecordProvider;
 import org.jboss.pnc.rest.restmodel.BuildRecordRest;
+import org.jboss.pnc.rest.restmodel.RunningBuildsCountRest;
 import org.jboss.pnc.rest.restmodel.response.error.ErrorResponseRest;
 import org.jboss.pnc.rest.swagger.response.BuildRecordPage;
 import org.jboss.pnc.rest.swagger.response.BuildRecordSingleton;
@@ -106,6 +107,19 @@ public class RunningBuildRecordEndpoint extends AbstractEndpoint<BuildRecord, Bu
             @ApiParam(value = SORTING_DESCRIPTION) @QueryParam(SORTING_QUERY_PARAM) String sort,
             @ApiParam(value = SEARCH_DESCRIPTION) @QueryParam(SEARCH_QUERY_PARAM) @DefaultValue(SEARCH_DEFAULT_VALUE) String search) {
         return fromCollection(buildRecordProvider.getAllRunning(pageIndex, pageSize, search, sort));
+    }
+
+    @ApiOperation(value = "Gets count of running, enqueued, and 'awaiting for dependencies' Build Records")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION, response = RunningBuildsCountRest.class),
+            @ApiResponse(code = INVALID_CODE, message = INVALID_DESCRIPTION, response = ErrorResponseRest.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION, response = ErrorResponseRest.class)
+    })
+    @GET
+    @Path("/count")
+    public Response getCount() {
+        return Response.ok(buildRecordProvider.getRunningCount()).build();
+
     }
 
     @ApiOperation(value = "Gets specific running Build Record")


### PR DESCRIPTION
This is done via endpoint: `/running-build-records/count`

REST response is:
```
{
    running: <int>,
    enqueued: <int>,
    waitingForDependencies: <int>
}
```

### Checklist:

* [x] Have you added a note in the CHANGELOG.md for your change if user-facing?
* [ ] Have you added unit tests for your change?
