### PR TITLE
Add retries for build env creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ Finally, to configure the check interval in seconds for the builder pod to start
 
 Note that the system property has precedence over the environment variable if both are defined.
 
-
 ## Database set-up
 
 ### Manually Configuring the Datasource for HSQL DB

--- a/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutor.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutor.java
@@ -450,7 +450,14 @@ public class DefaultBuildExecutor implements BuildExecutor {
             userLog.info("Build execution completed.");
         } catch (Throwable t) {
             userLog.error("Unable to complete execution!", t);
-            buildExecutionSession.setException(new ExecutorException("Unable to recover, see system log for the details."));
+
+            String executorException = "Unable to recover, see system log for the details.";
+
+            if (t.getMessage() != null) {
+                executorException += " " + t.getMessage();
+            }
+
+            buildExecutionSession.setException(new ExecutorException(executorException));
             buildExecutionSession.setEndTime(new Date());
             buildExecutionSession.setStatus(BuildExecutionStatus.SYSTEM_ERROR, true);
             runningExecutions.remove(buildExecutionSession.getId());
@@ -482,7 +489,7 @@ public class DefaultBuildExecutor implements BuildExecutor {
             if (destroyableEnvironment != null) {
                 destroyableEnvironment.destroyEnvironment();
             }
-        } catch (EnvironmentDriverException envE) {
+        } catch (Throwable envE) {
             log.warn("Running environment" + destroyableEnvironment + " couldn't be destroyed!", envE);
         }
     }

--- a/common/src/main/java/org/jboss/pnc/common/monitor/RunningTask.java
+++ b/common/src/main/java/org/jboss/pnc/common/monitor/RunningTask.java
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
  */
-class RunningTask {
+public class RunningTask {
 
     private ScheduledFuture<?> future;
     Instant deadline;

--- a/common/src/main/java/org/jboss/pnc/common/util/ReadEnvProperty.java
+++ b/common/src/main/java/org/jboss/pnc/common/util/ReadEnvProperty.java
@@ -1,0 +1,57 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.common.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReadEnvProperty {
+
+    private static final Logger log = LoggerFactory.getLogger(ReadEnvProperty.class);
+    /**
+     * If propertyName has no value (either specified in system property or environment property), then just return
+     * the default value. System property value has priority over environment property value.
+     *
+     * If value can't be parsed, just return the default value.
+     *
+     * @param propertyName property name to check the value
+     * @param defaultValue default value to use
+     *
+     * @return value from property, or default value
+     */
+    public int getIntValueFromPropertyOrDefault(String propertyName, int defaultValue) {
+
+        int value = defaultValue;
+
+        String valueEnv = System.getenv(propertyName);
+        String valueSys = System.getProperty(propertyName);
+
+        try {
+            if (valueSys != null) {
+                value = Integer.parseInt(valueSys);
+            } else if (valueEnv != null) {
+                value = Integer.parseInt(valueEnv);
+            }
+            return value;
+        } catch (NumberFormatException e) {
+            log.warn("Could not parse the '" + propertyName +
+                    "' system property. Using default value: " + defaultValue);
+            return value;
+        }
+    }
+}

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftEnvironmentDriverModuleConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftEnvironmentDriverModuleConfig.java
@@ -47,6 +47,8 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
     private boolean keepBuildAgentInstance;
     private boolean exposeBuildAgentOnPublicUrl;
 
+    private String creationPodRetry;
+
     public OpenshiftEnvironmentDriverModuleConfig(@JsonProperty("restEndpointUrl") String restEndpointUrl,
                                                   @JsonProperty("buildAgentHost") String buildAgentHost,
                                                   @JsonProperty("imageId") String imageId,
@@ -63,7 +65,8 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
                                                   @JsonProperty("workingDirectory") String workingDirectory,
                                                   @JsonProperty("disabled") Boolean disabled,
                                                   @JsonProperty("keepBuildAgentInstance") Boolean keepBuildAgentInstance,
-                                                  @JsonProperty("exposeBuildAgentOnPublicUrl") Boolean exposeBuildAgentOnPublicUrl) {
+                                                  @JsonProperty("exposeBuildAgentOnPublicUrl") Boolean exposeBuildAgentOnPublicUrl,
+                                                  @JsonProperty("creationPodRetry") String creationPodRetry) {
         super(imageId, firewallAllowedDestinations, allowedHttpOutgoingDestinations, proxyServer, proxyPort, nonProxyHosts,workingDirectory, disabled);
 
         this.restEndpointUrl = restEndpointUrl;
@@ -75,6 +78,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
         this.containerPort = containerPort;
         this.keepBuildAgentInstance = keepBuildAgentInstance != null ? keepBuildAgentInstance: false;
         this.exposeBuildAgentOnPublicUrl = exposeBuildAgentOnPublicUrl != null ? exposeBuildAgentOnPublicUrl: false;
+        this.creationPodRetry = creationPodRetry;
 
         log.debug("Created new instance {}", toString());
     }
@@ -115,6 +119,10 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
         return exposeBuildAgentOnPublicUrl;
     }
 
+    public String getCreationPodRetry() {
+        return creationPodRetry;
+    }
+
     @Override
     public String toString() {
         return "OpenshiftEnvironmentDriverModuleConfig{" +
@@ -134,6 +142,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
                 ", disabled='" + disabled + '\'' +
                 ", keepBuildAgentInstance='" + keepBuildAgentInstance + '\'' +
                 ", exposeBuildAgentOnPublicUrl='" + exposeBuildAgentOnPublicUrl + '\'' +
+                ", creationPodRetry='" + creationPodRetry + '\'' +
                 '}';
     }
 

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/exceptions/PodFailedStartException.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/exceptions/PodFailedStartException.java
@@ -1,0 +1,28 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.environment.openshift.exceptions;
+
+/**
+ * Exception to indicate that a pod failed to start
+ */
+public class PodFailedStartException extends RuntimeException {
+
+    public PodFailedStartException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
This commit adds retries for build env creation. The number of retries
is configurable by setting 'creationPodRetry' in pnc-config.json

We do the retry by identifying when the pod creation failed by checking
its status periodically in monitors (or RunningTasks). The
monitors are setup in `monitorInitialization`. Once the monitors are
setup, they run in the background and `monitorInitialization` returns.

If the pod creation failed, we throw an exception that is ultimately
captured in `retryPod`. The latter will check the current number of
retries allowed. If 0: we call the `onError` consumer to end the
creation attempt. If greater than 0, we cancel and clear the existing
monitors, destroy any existing build environment Openshift objects,
recreate new build environment Openshift objects, and call
`monitorInitialization` again, with the number of retries decremented.

If the pod creation succeeded, we just call the `onComplete` consumer to
signal that pod creation is done.

This loop will continue until either the environment is created
successfully, or there is a failure and the number of retries is 0.

The side benefit of this commit is that instead of waiting for the pod to be
in state 'Running', we now identify if the pod failed and take action
based on this instead. This reduces the time we have to wait to take
alternate actions.

Note that in the case where pod creation fails with 'grpc connection
unavailable', we cannot capture that error on the pod status (it remains
on 'ContainerCreating' for some reason). However after \<timeout\> seconds
the creation will timeout, and another retry will be attempted.


### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing?
* [ ] Have you added unit tests for your change?
