### PR TITLE
[v1.4] Add retries for build env creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - [NCL-4393] Adds pnc service status visualisations to the UI dashboard
 - [NCL-4392] Expose info about number of building and enqueued builds via REST
-
+- Add retries for build environment creation in case of pod creation failures
 
 ### Fixed
 - [NCL-4333] A closed milestone now cannot be set as current via REST API

--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ Finally, to configure the check interval in seconds for the builder pod to start
 
 Note that the system property has precedence over the environment variable if both are defined.
 
-
 ## Database set-up
 
 ### Manually Configuring the Datasource for HSQL DB

--- a/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutor.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutor.java
@@ -436,7 +436,14 @@ public class DefaultBuildExecutor implements BuildExecutor {
             userLog.info("Build execution completed.");
         } catch (Throwable t) {
             userLog.error("Unable to complete execution!", t);
-            buildExecutionSession.setException(new ExecutorException("Unable to recover, see system log for the details."));
+
+            String executorException = "Unable to recover, see system log for the details.";
+
+            if (t.getMessage() != null) {
+                executorException += " " + t.getMessage();
+            }
+
+            buildExecutionSession.setException(new ExecutorException(executorException));
             buildExecutionSession.setEndTime(new Date());
             buildExecutionSession.setStatus(BuildExecutionStatus.SYSTEM_ERROR, true);
             runningExecutions.remove(buildExecutionSession.getId());
@@ -469,7 +476,7 @@ public class DefaultBuildExecutor implements BuildExecutor {
                 destroyableEnvironment.destroyEnvironment();
             }
 
-        } catch (EnvironmentDriverException envE) {
+        } catch (Throwable envE) {
             log.warn("Running environment" + destroyableEnvironment + " couldn't be destroyed!", envE);
         }
     }

--- a/common/src/main/java/org/jboss/pnc/common/monitor/RunningTask.java
+++ b/common/src/main/java/org/jboss/pnc/common/monitor/RunningTask.java
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
  */
-class RunningTask {
+public class RunningTask {
 
     private ScheduledFuture<?> future;
     Instant deadline;

--- a/common/src/main/java/org/jboss/pnc/common/util/ReadEnvProperty.java
+++ b/common/src/main/java/org/jboss/pnc/common/util/ReadEnvProperty.java
@@ -1,0 +1,57 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.common.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReadEnvProperty {
+
+    private static final Logger log = LoggerFactory.getLogger(ReadEnvProperty.class);
+    /**
+     * If propertyName has no value (either specified in system property or environment property), then just return
+     * the default value. System property value has priority over environment property value.
+     *
+     * If value can't be parsed, just return the default value.
+     *
+     * @param propertyName property name to check the value
+     * @param defaultValue default value to use
+     *
+     * @return value from property, or default value
+     */
+    public int getIntValueFromPropertyOrDefault(String propertyName, int defaultValue) {
+
+        int value = defaultValue;
+
+        String valueEnv = System.getenv(propertyName);
+        String valueSys = System.getProperty(propertyName);
+
+        try {
+            if (valueSys != null) {
+                value = Integer.parseInt(valueSys);
+            } else if (valueEnv != null) {
+                value = Integer.parseInt(valueEnv);
+            }
+            return value;
+        } catch (NumberFormatException e) {
+            log.warn("Could not parse the '" + propertyName +
+                    "' system property. Using default value: " + defaultValue);
+            return value;
+        }
+    }
+}

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftEnvironmentDriverModuleConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/OpenshiftEnvironmentDriverModuleConfig.java
@@ -47,6 +47,8 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
     private boolean keepBuildAgentInstance;
     private boolean exposeBuildAgentOnPublicUrl;
 
+    private String creationPodRetry;
+
     public OpenshiftEnvironmentDriverModuleConfig(@JsonProperty("restEndpointUrl") String restEndpointUrl,
                                                   @JsonProperty("buildAgentHost") String buildAgentHost,
                                                   @JsonProperty("imageId") String imageId,
@@ -63,7 +65,8 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
                                                   @JsonProperty("workingDirectory") String workingDirectory,
                                                   @JsonProperty("disabled") Boolean disabled,
                                                   @JsonProperty("keepBuildAgentInstance") Boolean keepBuildAgentInstance,
-                                                  @JsonProperty("exposeBuildAgentOnPublicUrl") Boolean exposeBuildAgentOnPublicUrl) {
+                                                  @JsonProperty("exposeBuildAgentOnPublicUrl") Boolean exposeBuildAgentOnPublicUrl,
+                                                  @JsonProperty("creationPodRetry") String creationPodRetry) {
         super(imageId, firewallAllowedDestinations, allowedHttpOutgoingDestinations, proxyServer, proxyPort, nonProxyHosts,workingDirectory, disabled);
 
         this.restEndpointUrl = restEndpointUrl;
@@ -75,6 +78,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
         this.containerPort = containerPort;
         this.keepBuildAgentInstance = keepBuildAgentInstance != null ? keepBuildAgentInstance: false;
         this.exposeBuildAgentOnPublicUrl = exposeBuildAgentOnPublicUrl != null ? exposeBuildAgentOnPublicUrl: false;
+        this.creationPodRetry = creationPodRetry;
 
         log.debug("Created new instance {}", toString());
     }
@@ -115,6 +119,10 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
         return exposeBuildAgentOnPublicUrl;
     }
 
+    public String getCreationPodRetry() {
+        return creationPodRetry;
+    }
+
     @Override
     public String toString() {
         return "OpenshiftEnvironmentDriverModuleConfig{" +
@@ -134,6 +142,7 @@ public class OpenshiftEnvironmentDriverModuleConfig extends EnvironmentDriverMod
                 ", disabled='" + disabled + '\'' +
                 ", keepBuildAgentInstance='" + keepBuildAgentInstance + '\'' +
                 ", exposeBuildAgentOnPublicUrl='" + exposeBuildAgentOnPublicUrl + '\'' +
+                ", creationPodRetry='" + creationPodRetry + '\'' +
                 '}';
     }
 

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -32,13 +32,16 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.pnc.common.json.moduleconfig.OpenshiftBuildAgentConfig;
 import org.jboss.pnc.common.json.moduleconfig.OpenshiftEnvironmentDriverModuleConfig;
 import org.jboss.pnc.common.monitor.PullingMonitor;
+import org.jboss.pnc.common.monitor.RunningTask;
 import org.jboss.pnc.common.util.RandomUtils;
 import org.jboss.pnc.common.util.StringUtils;
+import org.jboss.pnc.environment.openshift.exceptions.PodFailedStartException;
 import org.jboss.pnc.spi.builddriver.DebugData;
 import org.jboss.pnc.spi.environment.RunningEnvironment;
 import org.jboss.pnc.spi.environment.StartedEnvironment;
 import org.jboss.pnc.spi.repositorymanager.model.RepositorySession;
 import org.jboss.util.StringPropertyReplacer;
+import org.jboss.util.collection.ConcurrentSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,6 +74,20 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
     private static final String OSE_API_VERSION = "v1";
     private static final Pattern SECURE_LOG_PATTERN = Pattern.compile("\"name\":\\s*\"accessToken\",\\s*\"value\":\\s*\"\\p{Print}+\"");
 
+    private static final int DEFAULT_CREATION_POD_RETRY = 1;
+
+    private int creationPodRetry;
+
+    /**
+     * From: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
+     *
+     * ErrImagePull and ImagePullBackOff added to that list. The pod.getStatus() call will return the *reason* of failure,
+     * and if the reason is not available, then it'll return the regular status (as mentioned in the link)
+     *
+     * For pod creation, the failure reason we expect when docker registry is not behaving is 'ErrImagePull' or 'ImagePullBackOff'
+     */
+    private static final String[] POD_FAILED_STATUSES = {"Failed", "Unknown", "CrashLoopBackOff", "ErrImagePull", "ImagePullBackOff"};
+
 
     private boolean serviceCreated = false;
     private boolean podCreated = false;
@@ -86,21 +103,26 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
     private final Set<Selector> initialized = new HashSet<>();
     private final Map<String, String> runtimeProperties;
 
+    private final ExecutorService executor;
+
     private Pod pod;
     private Service service;
     private Route route;
     private Service sshService;
 
-    private final String buildAgentContextPath;
+    private ConcurrentSet<RunningTask> runningTaskMonitors = new ConcurrentSet<>();
+
+    private String buildAgentContextPath;
 
     private final boolean createRoute;
 
     private Runnable cancelHook;
     private boolean cancelRequested = false;
 
-    Optional<Future> creatingPod = Optional.empty();
-    Optional<Future> creatingService = Optional.empty();
-    Optional<Future> creatingRoute = Optional.empty();
+    private Optional<Future> creatingPod = Optional.empty();
+    private Optional<Future> creatingService = Optional.empty();
+    private Optional<Future> creatingRoute = Optional.empty();
+
 
     public OpenshiftStartedEnvironment(
             ExecutorService executor,
@@ -112,8 +134,19 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
             DebugData debugData,
             String accessToken) {
 
+        creationPodRetry = DEFAULT_CREATION_POD_RETRY;
+
+        if (environmentConfiguration.getCreationPodRetry() != null) {
+            try {
+                creationPodRetry = Integer.parseInt(environmentConfiguration.getCreationPodRetry());
+            } catch (NumberFormatException e) {
+                logger.error("Couldn't parse the value of creation pod retry from the configuration. Using default");
+            }
+        }
+
         logger.info("Creating new build environment using image id: " + environmentConfiguration.getImageId());
 
+        this.executor = executor;
         this.openshiftBuildAgentConfig = openshiftBuildAgentConfig;
         this.environmentConfiguration = environmentConfiguration;
         this.pullingMonitor = pullingMonitor;
@@ -129,21 +162,30 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         client.getServerReadyStatus(); // make sure client is connected
 
         runtimeProperties = new HashMap<>();
-        String randString = RandomUtils.randString(6);//note the 24 char limit
-        buildAgentContextPath = "pnc-ba-" + randString;
 
         final String buildAgentHost = environmentConfiguration.getBuildAgentHost();
 
         runtimeProperties.put("build-agent-host", buildAgentHost);
+        runtimeProperties.put("containerPort", environmentConfiguration.getContainerPort());
+        runtimeProperties.put("buildContentId", repositorySession.getBuildRepositoryId());
+        runtimeProperties.put("accessToken", accessToken);
+
+        createEnvironment();
+    }
+
+    private void createEnvironment() {
+
+
+        String randString = RandomUtils.randString(6);//note the 24 char limit
+        buildAgentContextPath = "pnc-ba-" + randString;
+
+
         runtimeProperties.put("pod-name", "pnc-ba-pod-" + randString);
         runtimeProperties.put("service-name", "pnc-ba-service-" + randString);
         runtimeProperties.put("ssh-service-name", "pnc-ba-ssh-" + randString);
         runtimeProperties.put("route-name", "pnc-ba-route-" + randString);
         runtimeProperties.put("route-path", "/" + buildAgentContextPath);
         runtimeProperties.put("buildAgentContextPath", "/" + buildAgentContextPath);
-        runtimeProperties.put("containerPort", environmentConfiguration.getContainerPort());
-        runtimeProperties.put("accessToken", accessToken);
-        runtimeProperties.put("buildContentId", repositorySession.getBuildRepositoryId());
 
         initDebug();
 
@@ -218,8 +260,85 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         return ModelNode.fromJSONString(definition);
     }
 
+    /**
+     * Method to retry creating the whole Openshift environment in case of failure
+     *
+     * @param e exception thrown
+     * @param onComplete consumer to call if successful
+     * @param onError consumer to call if no more retries
+     * @param retries how many times will we retry starting the build environment
+     */
+    private void retryPod(Exception e, Consumer<RunningEnvironment> onComplete, Consumer<Exception> onError, int retries) {
+
+        logger.debug("Cancelling existing monitors for this build environment");
+        cancelAndClearMonitors();
+
+        // no more retries, execute the onError consumer
+        if (retries == 0) {
+            onError.accept(e);
+
+        } else {
+            logger.error("Creating build environment failed! Retrying...");
+
+            // since deletion runs in an executor, it might run *after* the createEnvironment() is finished.
+            // createEnvironment()  will overwrite the Openshift object fields. So we need to capture the existing
+            // openshift objects to delete before they get overwritten by createEnvironment()
+            Route routeToDestroy = route;
+            Service serviceToDestroy = service;
+            Service sshServiceToDestroy = sshService;
+            Pod podToDestroy = pod;
+
+            executor.submit(() -> {
+                try {
+                    logger.debug("Destroying old build environment");
+                    destroyEnvironment(routeToDestroy, serviceToDestroy, sshServiceToDestroy, podToDestroy,true);
+                } catch (Exception ex) {
+                    logger.error("Error deleting previous environment", ex);
+                }
+            });
+
+            logger.debug("Creating new build environment");
+            createEnvironment();
+
+            // restart the process again
+            monitorInitialization(onComplete, onError, retries - 1);
+            // at this point the running task running this is finished. New ones are created to monitor pod /service/route creation
+        }
+
+    }
+
+    /**
+     * Call stack:
+     *   monitorInitialization:
+     *       -> setup monitors, track them and return
+     *
+     * -> pullingMonitor.monitor(<pod>) [in background]
+     *    -> Success: signal via executing onComplete consumer
+     *                finish
+     *    -> Failure: call retryPod consumer
+     *       -> if retries == 0: call onError consumer. no more retries
+     *       -> else: cancel and clear monitors,
+     *                delete existing build environment (if any),
+     *                recreate build environment,
+     *                call monitorInitialization again with retries decremented
+     *                finish
+     *
+     *  While the call stack may appear recursive, it's not in fact recursive due to the fact that we are using RunningTask
+     *  to figure out if the pod / route /service are online or not and they run in the background
+     */
     @Override
     public void monitorInitialization(Consumer<RunningEnvironment> onComplete, Consumer<Exception> onError) {
+        monitorInitialization(onComplete, onError, creationPodRetry);
+    }
+
+    /**
+     * retries is decremented in retryPod in case of pod failing to start
+     *
+     * @param onComplete
+     * @param onError
+     * @param retries
+     */
+    private void monitorInitialization(Consumer<RunningEnvironment> onComplete, Consumer<Exception> onError, int retries) {
 
         Consumer<RunningEnvironment> onCompleteInternal = (runningEnvironment) -> {
             logger.info("New build environment available on internal url: {}", getInternalEndpointUrl());
@@ -228,7 +347,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
                 Runnable onUrlAvailable = () -> onComplete.accept(runningEnvironment);
 
                 URL url = new URL(getInternalEndpointUrl());
-                pullingMonitor.monitor(onUrlAvailable, onError, () -> isServletAvailable(url));
+                addMonitors(pullingMonitor.monitor(onUrlAvailable, onError, () -> isServletAvailable(url)));
             } catch (IOException e) {
                 onError.accept(e);
             }
@@ -236,17 +355,35 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
 
         cancelHook = () -> onComplete.accept(null);
 
-        pullingMonitor.monitor(onEnvironmentInitComplete(onCompleteInternal, Selector.POD), onError, this::isPodRunning);
-        pullingMonitor.monitor(onEnvironmentInitComplete(onCompleteInternal, Selector.SERVICE), onError, this::isServiceRunning);
+        pullingMonitor.monitor(onEnvironmentInitComplete(onCompleteInternal, Selector.POD),
+                (t) -> this.retryPod(t, onComplete, onError, retries),
+                this::isPodRunning);
+
+        addMonitors(pullingMonitor.monitor(
+                onEnvironmentInitComplete(onCompleteInternal, Selector.SERVICE),
+                onError,
+                this::isServiceRunning));
 
         logger.info("Waiting to initialize environment. Pod [{}]; Service [{}].", pod.getName(), service.getName());
 
         if (createRoute) {
-            pullingMonitor.monitor(onEnvironmentInitComplete(onCompleteInternal, Selector.ROUTE), onError, this::isRouteRunning);
+            addMonitors(pullingMonitor.monitor(
+                            onEnvironmentInitComplete(onCompleteInternal, Selector.ROUTE),
+                            onError,
+                            this::isRouteRunning));
             logger.info("Route [{}].", route.getName());
         }
 
         //logger.info("Waiting to start a pod [{}], service [{}].", pod.getName(), service.getName());
+    }
+
+    private void addMonitors(RunningTask task) {
+        runningTaskMonitors.add(task);
+    }
+
+    private void cancelAndClearMonitors() {
+        runningTaskMonitors.stream().forEach(pullingMonitor::cancelRunningTask);
+        runningTaskMonitors.clear();
     }
 
     private boolean isServletAvailable(URL servletUrl) {
@@ -305,11 +442,26 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         return "http://" + service.getClusterIP() + "/" + buildAgentContextPath + "/" + environmentConfiguration.getBuildAgentBindPath();
     }
 
+    /**
+     * Check if pod is in running state.
+     * If pod is in one of the failure statuses (as specified in POD_FAILED_STATUSES, PodFailedStartException is thrown
+     *
+     * @return boolean: is pod running?
+     */
     private boolean isPodRunning() {
         if (!podCreated) { //avoid Caused by: java.io.FileNotFoundException: https://<host>:8443/api/v1/namespaces/project-ncl/services/pnc-ba-pod-552c
             return false;
         }
+
         pod = client.get(pod.getKind(), pod.getName(), environmentConfiguration.getPncNamespace());
+
+        String podStatus = pod.getStatus();
+        logger.debug("Pod {} status: {}", pod.getName(), podStatus);
+
+        if (Arrays.asList(POD_FAILED_STATUSES).contains(podStatus)) {
+            throw new PodFailedStartException("Pod failed with status: " + podStatus);
+        }
+
         boolean isRunning = "Running".equals(pod.getStatus());
         if (isRunning) {
             logger.debug("Pod {} running.", pod.getName());
@@ -372,16 +524,22 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
 
     @Override
     public void destroyEnvironment() {
-        if (!debugData.isDebugEnabled()) {
+        destroyEnvironment(route, service, sshService, pod, false);
+    }
+
+    private void destroyEnvironment(Route routeLocal, Service serviceLocal, Service sshServiceLocal,
+                                    Pod podLocal, boolean force) {
+
+        if (!debugData.isDebugEnabled() || force) {
             if (!environmentConfiguration.getKeepBuildAgentInstance()) {
                 if (createRoute) {
-                    client.delete(route);
+                    client.delete(routeLocal);
                 }
-                client.delete(service);
+                client.delete(serviceLocal);
                 if (sshService != null) {
-                    client.delete(sshService);
+                    client.delete(sshServiceLocal);
                 }
-                client.delete(pod);
+                client.delete(podLocal);
             }
         }
     }

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -26,7 +26,9 @@ import com.openshift.internal.restclient.model.Service;
 import com.openshift.internal.restclient.model.properties.ResourcePropertiesRegistry;
 import com.openshift.restclient.ClientBuilder;
 import com.openshift.restclient.IClient;
+import com.openshift.restclient.NotFoundException;
 import com.openshift.restclient.ResourceKind;
+import com.openshift.restclient.model.IResource;
 import org.apache.commons.lang.RandomStringUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.pnc.common.json.moduleconfig.OpenshiftBuildAgentConfig;
@@ -533,14 +535,29 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         if (!debugData.isDebugEnabled() || force) {
             if (!environmentConfiguration.getKeepBuildAgentInstance()) {
                 if (createRoute) {
-                    client.delete(routeLocal);
+                    tryOpenshiftDeleteResource(routeLocal);
                 }
-                client.delete(serviceLocal);
+                tryOpenshiftDeleteResource(serviceLocal);
                 if (sshService != null) {
-                    client.delete(sshServiceLocal);
+                    tryOpenshiftDeleteResource(sshServiceLocal);
                 }
-                client.delete(podLocal);
+                tryOpenshiftDeleteResource(podLocal);
             }
+        }
+    }
+
+    /**
+     * Try to delete an openshift resource. If it doesn't exist, it's fine
+     *
+     * @param resource Openshift resource to delete
+     * @param <T>
+     */
+    private <T extends IResource> void tryOpenshiftDeleteResource(T resource) {
+
+        try {
+            client.delete(resource);
+        } catch (NotFoundException e) {
+            logger.warn("Couldn't delete the Openshift resource since it does not exist", e);
         }
     }
 

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/exceptions/PodFailedStartException.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/exceptions/PodFailedStartException.java
@@ -1,0 +1,28 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.environment.openshift.exceptions;
+
+/**
+ * Exception to indicate that a pod failed to start
+ */
+public class PodFailedStartException extends RuntimeException {
+
+    public PodFailedStartException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
This commit adds retries for build env creation. The number of retries
is configurable by setting 'creationPodRetry' value in the
pnc-config.json

We do the retry by identifying when the pod creation failed by checking
its status periodically in monitors (or RunningTasks). The
monitors are setup in `monitorInitialization`. Once the monitors are
setup, they run in the background and `monitorInitialization` returns.

If the pod creation failed, we throw an exception that is ultimately
captured in `retryPod`. The latter will check the current number of
retries allowed. If 0: we call the `onError` consumer to end the
creation attempt. If greater than 0, we cancel and clear the existing
monitors, destroy any existing build environment Openshift objects,
recreate new build environment Openshift objects, and call
`monitorInitialization` again, with the number of retries decremented.

If the pod creation succeeded, we just call the `onComplete` consumer to
signal that pod creation is done.

This loop will continue until either the environment is created
successfully, or there is a failure and the number of retries is 0.

The side benefit of this commit is that instead of waiting for the pod to be
in state 'Running', we now identify if the pod failed and take action
based on this instead. This reduces the time we have to wait to take
alternate actions.

Note that in the case where pod creation fails with 'grpc connection
unavailable', we cannot capture that error on the pod status (it remains
on 'ContainerCreating' for some reason). However after <timeout> seconds
the creation will timeout, and another retry will be attempted.

Special thanks to @matejonnet for his review!

### Checklist:

* [x] Have you added a note in the CHANGELOG.md for your change if user-facing?
* [ ] Have you added unit tests for your change?
