### PR TITLE
[v1.4] Add metrics to track failed/success/attempts for creation of pod

### DIFF
--- a/openshift-environment-driver/pom.xml
+++ b/openshift-environment-driver/pom.xml
@@ -54,6 +54,10 @@
       <groupId>org.jboss.pnc</groupId>
       <artifactId>spi</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.pnc.metrics</groupId>
+      <artifactId>pncmetrics</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.jboss</groupId>

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriver.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriver.java
@@ -28,6 +28,7 @@ import org.jboss.pnc.common.json.moduleprovider.PncConfigProvider;
 import org.jboss.pnc.common.monitor.PullingMonitor;
 import org.jboss.pnc.common.util.StringUtils;
 import org.jboss.pnc.model.SystemImageType;
+import org.jboss.pnc.pncmetrics.MetricsConfiguration;
 import org.jboss.pnc.spi.builddriver.DebugData;
 import org.jboss.pnc.spi.environment.EnvironmentDriver;
 import org.jboss.pnc.spi.environment.StartedEnvironment;
@@ -60,13 +61,14 @@ public class OpenshiftEnvironmentDriver implements EnvironmentDriver {
     private OpenshiftEnvironmentDriverModuleConfig openshiftEnvironmentDriverModuleConfig;
     private OpenshiftBuildAgentConfig openshiftBuildAgentConfig;
     private PullingMonitor pullingMonitor;
+    private MetricsConfiguration metricsConfig;
 
     @Deprecated //CDI workaround
     public OpenshiftEnvironmentDriver() {
     }
 
     @Inject
-    public OpenshiftEnvironmentDriver(Configuration configuration, PullingMonitor pullingMonitor) throws ConfigurationParseException {
+    public OpenshiftEnvironmentDriver(Configuration configuration, PullingMonitor pullingMonitor, MetricsConfiguration metricsConfig) throws ConfigurationParseException {
 
         int executorThreadPoolSize = DEFAULT_EXECUTOR_THREAD_POOL_SIZE;
         this.pullingMonitor = pullingMonitor;
@@ -84,6 +86,7 @@ public class OpenshiftEnvironmentDriver implements EnvironmentDriver {
             executorThreadPoolSize = Integer.parseInt(executorThreadPoolSizeStr);
         }
         executor = MDCExecutors.newFixedThreadPool(executorThreadPoolSize, new NamedThreadFactory("openshift-environment-driver"));
+        this.metricsConfig = metricsConfig;
 
         logger.info("Is OpenShift environment driver disabled: {}", openshiftEnvironmentDriverModuleConfig.isDisabled());
     }
@@ -108,7 +111,8 @@ public class OpenshiftEnvironmentDriver implements EnvironmentDriver {
                 repositorySession,
                 buildImageId,
                 debugData,
-                accessToken);
+                accessToken,
+                metricsConfig);
     }
 
     @Override

--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.environment.openshift;
 
+import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,6 +39,7 @@ import org.jboss.pnc.common.monitor.RunningTask;
 import org.jboss.pnc.common.util.RandomUtils;
 import org.jboss.pnc.common.util.StringUtils;
 import org.jboss.pnc.environment.openshift.exceptions.PodFailedStartException;
+import org.jboss.pnc.pncmetrics.MetricsConfiguration;
 import org.jboss.pnc.spi.builddriver.DebugData;
 import org.jboss.pnc.spi.environment.RunningEnvironment;
 import org.jboss.pnc.spi.environment.StartedEnvironment;
@@ -76,6 +78,11 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
     private static final String OSE_API_VERSION = "v1";
     private static final Pattern SECURE_LOG_PATTERN = Pattern.compile("\"name\":\\s*\"accessToken\",\\s*\"value\":\\s*\"\\p{Print}+\"");
 
+    private static final String METRICS_POD_STARTED_KEY = "openshift-environment-driver.started.pod";
+    private static final String METRICS_POD_STARTED_ATTEMPTED_KEY = METRICS_POD_STARTED_KEY + ".attempts";
+    private static final String METRICS_POD_STARTED_SUCCESS_KEY = METRICS_POD_STARTED_KEY + ".success";
+    private static final String METRICS_POD_STARTED_FAILED_KEY = METRICS_POD_STARTED_KEY + ".failed";
+
     private static final int DEFAULT_CREATION_POD_RETRY = 1;
 
     private int creationPodRetry;
@@ -106,6 +113,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
     private final Map<String, String> runtimeProperties;
 
     private final ExecutorService executor;
+    private Optional<MetricRegistry> metricRegistry = Optional.empty();
 
     private Pod pod;
     private Service service;
@@ -134,7 +142,8 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
             RepositorySession repositorySession,
             String systemImageId,
             DebugData debugData,
-            String accessToken) {
+            String accessToken,
+            MetricsConfiguration metricsConfiguration) {
 
         creationPodRetry = DEFAULT_CREATION_POD_RETRY;
 
@@ -155,6 +164,9 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         this.repositorySession = repositorySession;
         this.imageId = systemImageId == null ? environmentConfiguration.getImageId() : systemImageId;
         this.debugData = debugData;
+        if (metricsConfiguration != null) {
+            this.metricRegistry = Optional.of(metricsConfiguration.getMetricRegistry());
+        }
 
         createRoute = environmentConfiguration.getExposeBuildAgentOnPublicUrl();
 
@@ -231,6 +243,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
             };
             creatingRoute = Optional.of(executor.submit(createRoute));
         }
+        metricRegistry.ifPresent(m -> m.meter(METRICS_POD_STARTED_ATTEMPTED_KEY).mark());
     }
 
     static String secureLog(String message) {
@@ -271,6 +284,8 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
      * @param retries how many times will we retry starting the build environment
      */
     private void retryPod(Exception e, Consumer<RunningEnvironment> onComplete, Consumer<Exception> onError, int retries) {
+
+        metricRegistry.ifPresent(m -> m.meter(METRICS_POD_STARTED_FAILED_KEY).mark());
 
         logger.debug("Cancelling existing monitors for this build environment");
         cancelAndClearMonitors();
@@ -428,6 +443,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
                     debugData
             );
 
+            metricRegistry.ifPresent(m -> m.meter(METRICS_POD_STARTED_SUCCESS_KEY).mark());
             onComplete.accept(runningEnvironment);
         };
     }

--- a/openshift-environment-driver/src/test/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriverRemoteTest.java
+++ b/openshift-environment-driver/src/test/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriverRemoteTest.java
@@ -72,7 +72,7 @@ public class OpenshiftEnvironmentDriverRemoteTest {
 
         configurationService = new Configuration();
 
-        environmentDriver = new OpenshiftEnvironmentDriver(configurationService, new PullingMonitor());
+        environmentDriver = new OpenshiftEnvironmentDriver(configurationService, new PullingMonitor(), null);
     }
 
     @Test


### PR DESCRIPTION
We use Optional for the `metricRegistry` and check if
`metricsConfiguration` is null in `OpenshiftStartedEnvironment`. This is
done to facilate testing in `OpenshiftEnvironmentDriverRemoteTest`. With
those changes we can set the 'metricsConfiguration' parameter in
`OpenshiftStartedEnvironment` to null, and make metrics optional.

### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing?
* [ ] Have you added unit tests for your change?
