### PR TITLE
Add jackson-datatype-jdk8 on rest-new

### DIFF
--- a/rest-new/pom.xml
+++ b/rest-new/pom.xml
@@ -91,6 +91,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <!-- Enterprise dependencies -->
         <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>


### PR DESCRIPTION
It is added so that Jackson knows how to deserialize Instant-type
objects

### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing?
* [ ] Have you added unit tests for your change?
