### PR TITLE
[v1.7] NCL-4685 - Backport Orch changes to 1.7.0 required to support Gradle …

### DIFF
--- a/bpm/src/main/java/org/jboss/pnc/bpm/task/BpmBuildTask.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/task/BpmBuildTask.java
@@ -33,8 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.Optional;
 
 /**
@@ -91,6 +89,7 @@ public class BpmBuildTask extends BpmTask {
                 buildConfigurationAudited.getBuildEnvironment().getSystemImageId(),
                 buildConfigurationAudited.getBuildEnvironment().getSystemImageRepositoryUrl(),
                 buildConfigurationAudited.getBuildEnvironment().getSystemImageType(),
+                buildConfigurationAudited.getBuildConfiguration().getBuildType(),
                 buildTask.getBuildOptions().isKeepPodOnFailure(),
                 buildConfigurationAudited.getGenericParameters(),
                 buildTask.getBuildOptions().isTemporaryBuild(),

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/local/LocalBuildScheduler.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/local/LocalBuildScheduler.java
@@ -91,6 +91,7 @@ public class LocalBuildScheduler implements BuildScheduler {
                 configuration.getBuildEnvironment().getSystemImageId(),
                 configuration.getBuildEnvironment().getSystemImageRepositoryUrl(),
                 configuration.getBuildEnvironment().getSystemImageType(),
+                configuration.getBuildType(),
                 buildTask.getBuildOptions().isKeepPodOnFailure(),
                 configuration.getGenericParameters(),
                 buildTask.getBuildOptions().isTemporaryBuild(),

--- a/build-executor/src/main/java/org/jboss/pnc/executor/BuildTypeToRepositoryType.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/BuildTypeToRepositoryType.java
@@ -28,9 +28,8 @@ public class BuildTypeToRepositoryType {
     public static TargetRepository.Type getRepositoryType(BuildType buildType) {
         switch (buildType) {
             case MVN:
+            case GRADLE:
                 return TargetRepository.Type.MAVEN;
-            case NPM:
-                return TargetRepository.Type.NPM;
         }
         throw new RuntimeException("Cannot create repository for build type: " + buildType);
     }

--- a/build-executor/src/main/java/org/jboss/pnc/executor/BuildTypeToRepositoryType.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/BuildTypeToRepositoryType.java
@@ -15,19 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.pnc.executor.exceptions;
+package org.jboss.pnc.executor;
+
+import org.jboss.pnc.model.BuildType;
+import org.jboss.pnc.model.TargetRepository;
 
 /**
- * Wraps exception in RuntimeException
- *
- * Created by <a href="mailto:matejonnet@gmail.com">Matej Lazar</a> on 2014-12-23.
+ * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
  */
-public class ExecutionExceptionWrapper extends RuntimeException {
-    public ExecutionExceptionWrapper(String message) {
-        super(message);
-    }
+public class BuildTypeToRepositoryType {
 
-    public ExecutionExceptionWrapper(Throwable cause) {
-        super(cause);
+    public static TargetRepository.Type getRepositoryType(BuildType buildType) {
+        switch (buildType) {
+            case MVN:
+                return TargetRepository.Type.MAVEN;
+            case NPM:
+                return TargetRepository.Type.NPM;
+        }
+        throw new RuntimeException("Cannot create repository for build type: " + buildType);
     }
 }

--- a/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionConfiguration.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionConfiguration.java
@@ -18,6 +18,7 @@
 
 package org.jboss.pnc.executor;
 
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.SystemImageType;
 import org.jboss.pnc.spi.executor.BuildExecutionConfiguration;
 import org.jboss.pnc.spi.repositorymanager.ArtifactRepository;
@@ -40,6 +41,7 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
     private final String scmTag;
     private final String originRepoURL;
     private final boolean preBuildSyncEnabled;
+    private final BuildType buildType;
     private final String systemImageId;
     private final String systemImageRepositoryUrl;
     private final SystemImageType systemImageType;
@@ -60,6 +62,7 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
             String scmTag,
             String originRepoURL,
             boolean preBuildSyncEnabled,
+            BuildType buildType,
             String systemImageId,
             String systemImageRepositoryUrl,
             SystemImageType systemImageType,
@@ -79,6 +82,7 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
         this.scmTag = scmTag;
         this.originRepoURL = originRepoURL;
         this.preBuildSyncEnabled = preBuildSyncEnabled;
+        this.buildType = buildType;
         this.systemImageId = systemImageId;
         this.systemImageRepositoryUrl = systemImageRepositoryUrl;
         this.systemImageType = systemImageType;
@@ -137,6 +141,11 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
     @Override
     public boolean isPreBuildSyncEnabled() {
         return preBuildSyncEnabled;
+    }
+
+    @Override
+    public BuildType getBuildType() {
+        return buildType;
     }
 
     @Override

--- a/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutor.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutor.java
@@ -31,6 +31,7 @@ import org.jboss.pnc.executor.servicefactories.BuildDriverFactory;
 import org.jboss.pnc.executor.servicefactories.EnvironmentDriverFactory;
 import org.jboss.pnc.executor.servicefactories.RepositoryManagerFactory;
 import org.jboss.pnc.model.BuildStatus;
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.TargetRepository;
 import org.jboss.pnc.spi.BuildExecutionStatus;
 import org.jboss.pnc.spi.builddriver.BuildDriver;
@@ -194,6 +195,14 @@ public class DefaultBuildExecutor implements BuildExecutor {
         }
         userLog.info("Setting up repository...");
         buildExecutionSession.setStatus(BuildExecutionStatus.REPO_SETTING_UP);
+
+        BuildType buildType = buildExecutionSession.getBuildExecutionConfiguration().getBuildType();
+        if (buildType == null) {
+            throw new BuildProcessException("Missing required value buildExecutionConfiguration.buildType");
+        }
+        TargetRepository.Type repositoryType = BuildTypeToRepositoryType.getRepositoryType(buildType);
+        //TODO use repositoryType
+        
         try {
             RepositoryManager repositoryManager = repositoryManagerFactory.getRepositoryManager(TargetRepository.Type.MAVEN);
             BuildExecution buildExecution = buildExecutionSession.getBuildExecutionConfiguration();

--- a/build-executor/src/main/java/org/jboss/pnc/executor/exceptions/BuildProcessException.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/exceptions/BuildProcessException.java
@@ -29,7 +29,11 @@ import org.jboss.pnc.spi.environment.DestroyableEnvironment;
 public class BuildProcessException extends ExecutionExceptionWrapper {
     
     private DestroyableEnvironment destroyableEnvironment;
-    
+
+    public BuildProcessException(String message) {
+        super(message);
+    }
+
     public BuildProcessException(Throwable cause) {
         super(cause);
     }

--- a/build-executor/src/test/java/org/jboss/pnc/executor/BuildEnvironmentTest.java
+++ b/build-executor/src/test/java/org/jboss/pnc/executor/BuildEnvironmentTest.java
@@ -157,6 +157,7 @@ public class BuildEnvironmentTest {
                 null,
                 buildConfiguration.getRepositoryConfiguration().getExternalUrl(),
                 buildConfiguration.getRepositoryConfiguration().isPreBuildSyncEnabled(),
+                buildConfiguration.getBuildType(),
                 buildConfiguration.getBuildEnvironment().getSystemImageId(),
                 buildConfiguration.getBuildEnvironment().getSystemImageRepositoryUrl(),
                 buildConfiguration.getBuildEnvironment().getSystemImageType(),

--- a/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
+++ b/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
@@ -155,6 +155,7 @@ class BuildExecutionBase {
                 null,
                 buildConfiguration.getRepositoryConfiguration().getExternalUrl(),
                 buildConfiguration.getRepositoryConfiguration().isPreBuildSyncEnabled(),
+                buildConfiguration.getBuildType(),
                 buildConfiguration.getBuildEnvironment().getSystemImageId(),
                 buildConfiguration.getBuildEnvironment().getSystemImageRepositoryUrl(),
                 buildConfiguration.getBuildEnvironment().getSystemImageType(),

--- a/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
+++ b/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
@@ -28,6 +28,7 @@ import org.jboss.pnc.model.BuildConfigurationSet;
 import org.jboss.pnc.model.BuildEnvironment;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.BuildStatus;
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.IdRev;
 import org.jboss.pnc.model.Product;
 import org.jboss.pnc.model.ProductMilestone;
@@ -354,6 +355,7 @@ public class DatabaseDataInitializer {
                 .name(PNC_PROJECT_BUILD_CFG_ID)
                 .project(project1)
                 .description("Test build config for project newcastle")
+                .buildType(BuildType.MVN)
                 .buildEnvironment(environment1)
                 .buildScript("mvn deploy -DskipTests=true")
                 .repositoryConfiguration(repositoryConfiguration1)
@@ -367,6 +369,7 @@ public class DatabaseDataInitializer {
                 .name("termd")
                 .project(project2)
                 .description("Test configueration for Termd.")
+                .buildType(BuildType.MVN)
                 .buildEnvironment(environment1)
                 .buildScript("mvn deploy -DskipTests=true")
                 .productVersion(productVersion1)
@@ -379,6 +382,7 @@ public class DatabaseDataInitializer {
                 .name("pnc-build-agent-0.4")
                 .project(project3)
                 .description("Test config for Pnc Build Agent.")
+                .buildType(BuildType.MVN)
                 .buildEnvironment(environment1)
                 .buildScript("mvn deploy -DskipTests=true")
                 .productVersion(productVersion2)
@@ -390,6 +394,7 @@ public class DatabaseDataInitializer {
         BuildConfiguration buildConfiguration4 = BuildConfiguration.Builder.newBuilder()
                 .name("dependency-analysis-1.3")
                 .project(project4).description("Test config for Dependency Analysis.")
+                .buildType(BuildType.MVN)
                 .buildEnvironment(environment1)
                 .buildScript("mvn deploy -DskipTests=true")
                 .repositoryConfiguration(repositoryConfiguration4)
@@ -400,6 +405,7 @@ public class DatabaseDataInitializer {
         BuildConfiguration buildConfiguration5 = BuildConfiguration.Builder.newBuilder()
                 .name("maven-plugin-test")
                 .project(project5).description("Test build for Plugins with external downloads")
+                .buildType(BuildType.MVN)
                 .buildEnvironment(environment1)
                 .buildScript("mvn clean deploy")
                 .repositoryConfiguration(repositoryConfiguration5)

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildConfigurationRestTest.java
@@ -31,6 +31,7 @@ import org.jboss.pnc.integration.client.util.RestResponse;
 import org.jboss.pnc.integration.deployments.Deployments;
 import org.jboss.pnc.integration.matchers.JsonMatcher;
 import org.jboss.pnc.integration.template.JsonTemplateBuilder;
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.rest.endpoint.BuildConfigurationEndpoint;
 import org.jboss.pnc.rest.provider.BuildConfigurationProvider;
 import org.jboss.pnc.rest.restmodel.BuildConfigurationRest;
@@ -447,12 +448,14 @@ public class BuildConfigurationRestTest extends AbstractTest {
         BuildConfigurationRest buildConfiguration = new BuildConfigurationRest();
         buildConfiguration.setName(UUID.randomUUID().toString());
         buildConfiguration.setProject(projectRestClient.getValue());
+        buildConfiguration.setBuildType(BuildType.MVN);
         buildConfiguration.setEnvironment(environmentRestClient.getValue());
         buildConfiguration.setRepositoryConfiguration(repositoryConfigurationRest);
 
         BuildConfigurationRest dependencyBuildConfiguration = new BuildConfigurationRest();
         dependencyBuildConfiguration.setName(UUID.randomUUID().toString());
         dependencyBuildConfiguration.setProject(projectRestClient.getValue());
+        dependencyBuildConfiguration.setBuildType(BuildType.MVN);
         dependencyBuildConfiguration.setEnvironment(environmentRestClient.getValue());
         dependencyBuildConfiguration.setRepositoryConfiguration(repositoryConfigurationRest);
 

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildTasksRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildTasksRestTest.java
@@ -99,6 +99,7 @@ public class BuildTasksRestTest extends AbstractTest{
                 "jboss-modules",
                 "scm-url",
                 "master",
+                "1.0.0.redhat-1",
                 "origin-scm-url",
                 false,
                 "dummy-docker-image-id",

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildTasksRestTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildTasksRestTest.java
@@ -33,6 +33,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.pnc.AbstractTest;
 import org.jboss.pnc.common.util.HttpUtils;
 import org.jboss.pnc.integration.deployments.Deployments;
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.SystemImageType;
 import org.jboss.pnc.rest.endpoint.BuildTaskEndpoint;
 import org.jboss.pnc.rest.restmodel.BuildExecutionConfigurationRest;
@@ -91,9 +92,24 @@ public class BuildTasksRestTest extends AbstractTest{
         request.addHeader(getAuthenticationHeaderApache());
 
         BuildExecutionConfiguration buildExecutionConfig = BuildExecutionConfiguration.build(
-                1, "test-content-id", 1, "mvn clean install", "jboss-modules", "scm-url", "f18de64523d5054395d82e24d4e28473a05a3880",
-                "1.0.0.redhat-1", "origin-scm-url", false, "dummy-docker-image-id", "dummy.repo.url/repo", SystemImageType.DOCKER_IMAGE, false, null, new HashMap<>(),
-                false, null);
+                1,
+                "test-content-id",
+                1,
+                "mvn clean install",
+                "jboss-modules",
+                "scm-url",
+                "master",
+                "origin-scm-url",
+                false,
+                "dummy-docker-image-id",
+                "dummy.repo.url/repo",
+                SystemImageType.DOCKER_IMAGE,
+                BuildType.MVN,
+                false,
+                null,
+                new HashMap<>(),
+                false,
+                null);
 
         BuildExecutionConfigurationRest buildExecutionConfigurationRest = new BuildExecutionConfigurationRest(buildExecutionConfig);
 

--- a/integration-test/src/test/resources/buildConfiguration_WithEmptyCreateDate_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_WithEmptyCreateDate_template.json
@@ -6,6 +6,7 @@
     "project": {
       "id": ${_projectId}
     },
+    "buildType" : "MVN",
     "environment": {
       "id": ${_environmentId}
     }

--- a/integration-test/src/test/resources/buildConfiguration_create_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_create_template.json
@@ -9,6 +9,7 @@
     "project": {
       "id": ${_projectId}
     },
+    "buildType" : "MVN",
     "environment": {
       "id": ${_environmentId}
     },

--- a/integration-test/src/test/resources/buildConfiguration_update_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_update_template.json
@@ -9,6 +9,7 @@
     "project": {
       "id": ${_projectId}
     },
+    "buildType" : "MVN",
     "environment": {
       "id": ${_environmentId}
     },

--- a/integration-test/src/test/resources/buildConfiguration_with_id_template.json
+++ b/integration-test/src/test/resources/buildConfiguration_with_id_template.json
@@ -9,6 +9,7 @@
     "project": {
       "id": ${_projectId}
     },
+    "buildType" : "MVN",
     "environment": {
       "id": ${_environmentId}
     }

--- a/model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
@@ -29,6 +29,8 @@ import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -127,6 +129,9 @@ public class BuildConfiguration implements GenericEntity<Integer>, Cloneable {
     @ForeignKey(name = "fk_buildconfiguration_project")
     @Index(name="idx_buildconfiguration_project")
     private Project project;
+
+    @Enumerated(EnumType.STRING)
+    private BuildType buildType;
 
     @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
     @NotNull
@@ -265,6 +270,14 @@ public class BuildConfiguration implements GenericEntity<Integer>, Cloneable {
 
     public void setProject(Project project) {
         this.project = project;
+    }
+
+    public BuildType getBuildType() {
+        return buildType;
+    }
+
+    public void setBuildType(BuildType buildType) {
+        this.buildType = buildType;
     }
 
     /**
@@ -668,6 +681,8 @@ public class BuildConfiguration implements GenericEntity<Integer>, Cloneable {
 
         private Project project;
 
+        private BuildType buildType;
+
         private BuildEnvironment buildEnvironment;
 
         private ProductVersion productVersion;
@@ -710,7 +725,7 @@ public class BuildConfiguration implements GenericEntity<Integer>, Cloneable {
                 project.addBuildConfiguration(buildConfiguration);
             }
             buildConfiguration.setProject(project);
-
+            buildConfiguration.setBuildType(buildType);
             buildConfiguration.setBuildEnvironment(buildEnvironment);
             buildConfiguration.setCreationTime(creationTime);
             buildConfiguration.setLastModificationTime(lastModificationTime);
@@ -772,6 +787,11 @@ public class BuildConfiguration implements GenericEntity<Integer>, Cloneable {
 
         public Builder project(Project project) {
             this.project = project;
+            return this;
+        }
+
+        public Builder buildType(BuildType buildType) {
+            this.buildType = buildType;
             return this;
         }
 

--- a/model/src/main/java/org/jboss/pnc/model/BuildConfigurationAudited.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildConfigurationAudited.java
@@ -58,6 +58,8 @@ public class BuildConfigurationAudited {
 
     private Project project;
 
+    private BuildType buildType;
+
     private BuildEnvironment buildEnvironment;
 
     private Set<BuildRecord> buildRecords;
@@ -144,6 +146,14 @@ public class BuildConfigurationAudited {
         this.project = project;
     }
 
+    public BuildType getBuildType() {
+        return buildType;
+    }
+
+    public void setBuildType(BuildType buildType) {
+        this.buildType = buildType;
+    }
+
     public BuildEnvironment getBuildEnvironment() {
         return buildEnvironment;
     }
@@ -221,6 +231,7 @@ public class BuildConfigurationAudited {
             configurationAudited.setScmRevision(buildConfiguration.getScmRevision());
             configurationAudited.setGenericParameters(buildConfiguration.getGenericParameters());
             configurationAudited.setProject(buildConfiguration.getProject());
+            configurationAudited.setBuildType(buildConfiguration.getBuildType());
             configurationAudited.setRepositoryConfiguration(buildConfiguration.getRepositoryConfiguration());
             configurationAudited.setBuildRecords(buildRecords);
             configurationAudited.buildConfiguration = buildConfiguration;

--- a/model/src/main/java/org/jboss/pnc/model/BuildType.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildType.java
@@ -15,19 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.pnc.executor.exceptions;
+package org.jboss.pnc.model;
 
 /**
- * Wraps exception in RuntimeException
+ * BuildType is used to define pre-build operations and to set proper repository.
  *
- * Created by <a href="mailto:matejonnet@gmail.com">Matej Lazar</a> on 2014-12-23.
+ * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
  */
-public class ExecutionExceptionWrapper extends RuntimeException {
-    public ExecutionExceptionWrapper(String message) {
-        super(message);
-    }
-
-    public ExecutionExceptionWrapper(Throwable cause) {
-        super(cause);
-    }
+public enum BuildType {
+    MVN,
+    NPM
 }

--- a/model/src/main/java/org/jboss/pnc/model/BuildType.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildType.java
@@ -24,5 +24,5 @@ package org.jboss.pnc.model;
  */
 public enum BuildType {
     MVN,
-    NPM
+    GRADLE
 }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionConfigurationMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionConfigurationMock.java
@@ -18,7 +18,7 @@
 
 package org.jboss.pnc.mock.executor;
 
-import jdk.nashorn.internal.objects.annotations.Setter;
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.SystemImageType;
 import org.jboss.pnc.spi.executor.BuildExecutionConfiguration;
 import org.jboss.pnc.spi.repositorymanager.ArtifactRepository;
@@ -42,6 +42,7 @@ public class BuildExecutionConfigurationMock implements BuildExecutionConfigurat
     private String scmTag;
     private String originRepoURL;
     private boolean preBuildSyncEnabled;
+    private BuildType buildType;
     private String systemImageId;
     private String systemImageRepositoryUrl;
     private SystemImageType systemImageType;
@@ -58,6 +59,7 @@ public class BuildExecutionConfigurationMock implements BuildExecutionConfigurat
         mock.setScmRevision("f18de64523d5054395d82e24d4e28473a05a3880");
         mock.setScmTag("1.0.0.redhat-1");
         mock.setPreBuildSyncEnabled(false);
+        mock.setBuildType(BuildType.MVN);
         mock.setSystemImageId("abcd1234");
         mock.setSystemImageRepositoryUrl("image.repo.url/repo");
         mock.setSystemImageType(SystemImageType.DOCKER_IMAGE);
@@ -156,6 +158,15 @@ public class BuildExecutionConfigurationMock implements BuildExecutionConfigurat
 
     public void setPreBuildSyncEnabled(boolean preBuildSyncEnabled) {
         this.preBuildSyncEnabled = preBuildSyncEnabled;
+    }
+
+    public void setBuildType(BuildType buildType) {
+        this.buildType = buildType;
+    }
+
+    @Override
+    public BuildType getBuildType() {
+        return buildType;
     }
 
     @Override

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/model/builders/TestProjectConfigurationBuilder.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/model/builders/TestProjectConfigurationBuilder.java
@@ -21,6 +21,7 @@ import org.jboss.pnc.mock.datastore.DatastoreMock;
 import org.jboss.pnc.model.BuildConfiguration;
 import org.jboss.pnc.model.BuildConfigurationSet;
 import org.jboss.pnc.model.BuildEnvironment;
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.Project;
 import org.jboss.pnc.model.RepositoryConfiguration;
 
@@ -135,6 +136,7 @@ public class TestProjectConfigurationBuilder {
         buildConfiguration.setBuildScript(PASS);
         buildConfiguration.setName(id + "");
         buildConfiguration.setRepositoryConfiguration(repositoryConfiguration);
+        buildConfiguration.setBuildType(BuildType.MVN);
         buildConfiguration.setBuildEnvironment(javaBuildEnvironment);
         buildConfiguration.setProject(project);
         buildConfiguration.setProject(project);

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/spi/BuildExecutionConfigurationMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/spi/BuildExecutionConfigurationMock.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.mock.spi;
 
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.SystemImageType;
 import org.jboss.pnc.spi.executor.BuildExecutionConfiguration;
 
@@ -44,6 +45,7 @@ public class BuildExecutionConfigurationMock {
                 DEFAULT_SYSTEM_IMAGE_ID,
                 "image.repo.url/repo",
                 SystemImageType.DOCKER_IMAGE,
+                BuildType.MVN,
                 false,
                 null,
                 new HashMap<>(),

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigurationRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildConfigurationRest.java
@@ -20,6 +20,7 @@ package org.jboss.pnc.rest.restmodel;
 import lombok.Getter;
 import lombok.Setter;
 import org.jboss.pnc.model.BuildConfiguration;
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.ProductVersion;
 import org.jboss.pnc.rest.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.rest.validation.groups.WhenUpdating;
@@ -69,6 +70,11 @@ public class BuildConfigurationRest implements GenericRestEntity<Integer> {
     private ProjectRest project;
 
     @NotNull(groups = { WhenCreatingNew.class, WhenUpdating.class })
+    @Getter
+    @Setter
+    private BuildType buildType;
+
+    @NotNull(groups = { WhenCreatingNew.class, WhenUpdating.class })
     private BuildEnvironmentRest environment;
 
     private Set<Integer> dependencyIds;
@@ -113,6 +119,7 @@ public class BuildConfigurationRest implements GenericRestEntity<Integer> {
                 .map(dependencyConfig -> dependencyConfig.getId()).collect(Collectors.toSet());
         performIfNotNull(buildConfiguration.getProductVersion(),
                 () -> this.productVersionId = buildConfiguration.getProductVersion().getId());
+        this.buildType = buildConfiguration.getBuildType();
     }
 
     @Override
@@ -229,7 +236,8 @@ public class BuildConfigurationRest implements GenericRestEntity<Integer> {
                 .buildScript(this.getBuildScript())
                 .scmRevision(this.getScmRevision())
                 .archived(this.isArchived())
-                .genericParameters(this.getGenericParameters());
+                .genericParameters(this.getGenericParameters())
+                .buildType(this.getBuildType());
 
         performIfNotNull(this.getRepositoryConfiguration(), () -> builder.repositoryConfiguration(this.getRepositoryConfiguration().toDBEntityBuilder().build()));
         performIfNotNull(this.getProject(), () -> builder.project(this.getProject().toDBEntityBuilder().build()));

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.SystemImageType;
 import org.jboss.pnc.common.json.JsonOutputConverterMapper;
 import org.jboss.pnc.spi.executor.BuildExecutionConfiguration;
@@ -53,6 +54,7 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
     private String originRepoURL;
     private boolean preBuildSyncEnabled;
 
+    private BuildType buildType;
     private String systemImageId;
     private String systemImageRepositoryUrl;
     private SystemImageType systemImageType;
@@ -90,6 +92,7 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
         scmTag = buildExecutionConfiguration.getScmTag();
         originRepoURL = buildExecutionConfiguration.getOriginRepoURL();
         preBuildSyncEnabled = buildExecutionConfiguration.isPreBuildSyncEnabled();
+        buildType = buildExecutionConfiguration.getBuildType();
         systemImageId = buildExecutionConfiguration.getSystemImageId();
         systemImageRepositoryUrl = buildExecutionConfiguration.getSystemImageRepositoryUrl();
         systemImageType = buildExecutionConfiguration.getSystemImageType();
@@ -122,6 +125,7 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
                 systemImageId,
                 systemImageRepositoryUrl,
                 systemImageType,
+                buildType,
                 podKeptOnFailure,
                 artifactRepositories,
                 genericParameters,
@@ -228,12 +232,8 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
         return preBuildSyncEnabled;
     }
 
-    /**
-     * This is no longer used so it returns an empty string, for more info see NCL-1778
-     */
-    @Deprecated
-    public String getBuildType() {
-        return "";
+    public BuildType getBuildType() {
+        return buildType;
     }
 
     public UserRest getUser() {

--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/mock/RepositoryCreationUrlAutoRestMockBuilder.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/mock/RepositoryCreationUrlAutoRestMockBuilder.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.rest.restmodel.mock;
 
 import org.jboss.pnc.model.BuildEnvironment;
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.rest.restmodel.BuildConfigurationRest;
 import org.jboss.pnc.rest.restmodel.BuildEnvironmentRest;
 import org.jboss.pnc.rest.restmodel.ProjectRest;
@@ -49,6 +50,7 @@ public class RepositoryCreationUrlAutoRestMockBuilder {
         BuildEnvironment buildEnvironment = BuildEnvironment.Builder.newBuilder()
                 .id(1)
                 .build();
+        buildConfiguration.setBuildType(BuildType.MVN);
         buildConfiguration.setEnvironment(new BuildEnvironmentRest(buildEnvironment));
 
         ProjectRest projectRest = new ProjectRest();

--- a/rest-model/src/test/java/org/jboss/pnc/restmodel/serialization/BuildExecutionConfigurationTest.java
+++ b/rest-model/src/test/java/org/jboss/pnc/restmodel/serialization/BuildExecutionConfigurationTest.java
@@ -18,6 +18,7 @@
 
 package org.jboss.pnc.restmodel.serialization;
 
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.SystemImageType;
 import org.jboss.pnc.rest.restmodel.BuildExecutionConfigurationRest;
 import org.jboss.pnc.spi.builddriver.exception.BuildDriverException;
@@ -53,6 +54,7 @@ public class BuildExecutionConfigurationTest {
                 "abcd1234",
                 "image.repo.url/repo",
                 SystemImageType.DOCKER_IMAGE,
+                BuildType.MVN,
                 false,
                 null,
                 new HashMap<>(),

--- a/rest/src/test/java/org/jboss/pnc/rest/endpoint/BuildRecordEndpointTest.java
+++ b/rest/src/test/java/org/jboss/pnc/rest/endpoint/BuildRecordEndpointTest.java
@@ -21,6 +21,7 @@ import org.jboss.pnc.coordinator.maintenance.TemporaryBuildsCleanerAsyncInvoker;
 import org.jboss.pnc.executor.DefaultBuildExecutionConfiguration;
 import org.jboss.pnc.executor.DefaultBuildExecutionSession;
 import org.jboss.pnc.model.BuildRecord;
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.SystemImageType;
 import org.jboss.pnc.model.User;
 import org.jboss.pnc.rest.notifications.websockets.DefaultNotifier;
@@ -153,6 +154,7 @@ public class BuildRecordEndpointTest {
                 "",
                 "",
                 false,
+                BuildType.MVN,
                 "",
                 "",
                 SystemImageType.DOCKER_IMAGE,

--- a/rest/src/test/java/org/jboss/pnc/rest/provider/BuildConfigurationProviderTest.java
+++ b/rest/src/test/java/org/jboss/pnc/rest/provider/BuildConfigurationProviderTest.java
@@ -22,6 +22,7 @@ import org.jboss.pnc.common.json.moduleconfig.ScmModuleConfig;
 import org.jboss.pnc.model.BuildConfiguration;
 import org.jboss.pnc.model.BuildConfigurationAudited;
 import org.jboss.pnc.model.BuildEnvironment;
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.IdRev;
 import org.jboss.pnc.model.Project;
 import org.jboss.pnc.model.RepositoryConfiguration;
@@ -179,6 +180,7 @@ public class BuildConfigurationProviderTest {
         configuration.setDescription(null);
         configuration.setScmRevision(SCM_REVISION);
         configuration.setRepositoryConfiguration(REPOSITORY);
+        configuration.setBuildType(BuildType.MVN);
         configuration.setEnvironment(ENVIRONMENT);
         configuration.setBuildScript(BUILD_SCRIPT);
         return configuration;

--- a/rest/src/test/java/org/jboss/pnc/rest/serialization/BuildExecutionConfigurationTest.java
+++ b/rest/src/test/java/org/jboss/pnc/rest/serialization/BuildExecutionConfigurationTest.java
@@ -20,6 +20,7 @@ package org.jboss.pnc.rest.serialization;
 
 import org.jboss.pnc.common.json.JsonOutputConverterMapper;
 import org.jboss.pnc.executor.DefaultBuildExecutionConfiguration;
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.SystemImageType;
 import org.jboss.pnc.rest.restmodel.BuildExecutionConfigurationRest;
 import org.jboss.pnc.spi.builddriver.exception.BuildDriverException;
@@ -82,6 +83,7 @@ public class BuildExecutionConfigurationTest {
                     "1.0.0.redhat-1",
                     "https://pathToOriginRepo.git",
                     false,
+                    BuildType.MVN,
                     "abcd1234",
                     "image.repo.url/repo",
                     SystemImageType.DOCKER_IMAGE,

--- a/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionConfiguration.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionConfiguration.java
@@ -18,6 +18,7 @@
 
 package org.jboss.pnc.spi.executor;
 
+import org.jboss.pnc.model.BuildType;
 import org.jboss.pnc.model.SystemImageType;
 import org.jboss.pnc.spi.repositorymanager.ArtifactRepository;
 import org.jboss.pnc.spi.repositorymanager.BuildExecution;
@@ -56,6 +57,8 @@ public interface BuildExecutionConfiguration extends BuildExecution {
 
     SystemImageType getSystemImageType();
 
+    BuildType getBuildType();
+
     boolean isPodKeptOnFailure();
 
     Map<String, String> getGenericParameters();
@@ -74,12 +77,13 @@ public interface BuildExecutionConfiguration extends BuildExecution {
             String systemImageId,
             String systemImageRepositoryUrl,
             SystemImageType systemImageType,
+            BuildType buildType,
             boolean podKeptAfterFailure,
             Map<String, String> genericParameters,
             boolean tempBuild,
             String tempBuildTimestamp) {
         return build(id, buildContentId, userId, buildScript, name, scmRepoURL, scmRevision, scmTag, originRepoURL, preBuildSyncEnabled,
-                systemImageId, systemImageRepositoryUrl, systemImageType, podKeptAfterFailure, null, genericParameters,
+                systemImageId, systemImageRepositoryUrl, systemImageType, buildType, podKeptAfterFailure, null, genericParameters,
                 tempBuild, tempBuildTimestamp);
     }
 
@@ -97,6 +101,7 @@ public interface BuildExecutionConfiguration extends BuildExecution {
             String systemImageId,
             String systemImageRepositoryUrl,
             SystemImageType systemImageType,
+            BuildType buildType,
             boolean podKeptAfterFailure,
             List<ArtifactRepository> artifactRepositories,
             Map<String, String> genericParameters,
@@ -169,6 +174,11 @@ public interface BuildExecutionConfiguration extends BuildExecution {
             @Override
             public String getSystemImageId() {
                 return systemImageId;
+            }
+
+            @Override
+            public BuildType getBuildType() {
+                return buildType;
             }
 
             @Override


### PR DESCRIPTION
Backport Orch changes to 1.7.0 required to support Gradle manipulator
The following PR have been cherry picked from master: 

- PR#2124 - the commit "Add buildType field to BCAudited"
- PR#1782

### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing?
* [ ] Have you added unit tests for your change?
