### PR TITLE
[v1.6][NCL-4568] Stop env monitor on error

### DIFF
--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -53,16 +53,19 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 /**
@@ -134,9 +137,12 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
     private Runnable cancelHook;
     private boolean cancelRequested = false;
 
-    private Optional<Future> creatingPod = Optional.empty();
-    private Optional<Future> creatingService = Optional.empty();
-    private Optional<Future> creatingRoute = Optional.empty();
+    private Optional<CompletableFuture<Void>> creatingPod = Optional.empty();
+    private Optional<CompletableFuture<Void>> creatingService = Optional.empty();
+    private Optional<CompletableFuture<Void>> creatingRoute = Optional.empty();
+
+    // Used to track whether all the futures for creation are completed, or failed with an exception
+    private CompletableFuture<Void> creationCompletableFutures;
 
 
     public OpenshiftStartedEnvironment(
@@ -196,6 +202,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
 
     private void createEnvironment() {
 
+        List<CompletableFuture<Void>> trackCreationFutures = new ArrayList<>();
 
         String randString = RandomUtils.randString(6);//note the 24 char limit
         buildAgentContextPath = "pnc-ba-" + randString;
@@ -219,9 +226,11 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
                 podCreated = true;
             } catch (Throwable e) {
                 logger.error("Cannot create pod.", e);
+                throw e;
             }
         };
-        creatingPod = Optional.of(executor.submit(createPod));
+        creatingPod = Optional.of(CompletableFuture.runAsync(createPod, executor));
+        trackCreationFutures.add(creatingPod.get());
 
         ModelNode serviceConfigurationNode = createModelNode(Configurations.getContentAsString(Resource.PNC_BUILDER_SERVICE, openshiftBuildAgentConfig), runtimeProperties);
         service = new Service(serviceConfigurationNode, client, ResourcePropertiesRegistry.getInstance().get(OSE_API_VERSION, ResourceKind.SERVICE));
@@ -232,9 +241,11 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
                 serviceCreated = true;
             } catch (Throwable e) {
                 logger.error("Cannot create service.", e);
+                throw e;
             }
         };
-        creatingService = Optional.of(executor.submit(createService));
+        creatingService = Optional.of(CompletableFuture.runAsync(createService, executor));
+        trackCreationFutures.add(creatingService.get());
 
         if (createRoute) {
             ModelNode routeConfigurationNode = createModelNode(Configurations.getContentAsString(Resource.PNC_BUILDER_ROUTE, openshiftBuildAgentConfig), runtimeProperties);
@@ -246,10 +257,14 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
                     routeCreated = true;
                 } catch (Throwable e) {
                     logger.error("Cannot create route.", e);
+                    throw e;
                 }
             };
-            creatingRoute = Optional.of(executor.submit(createRoute));
+            creatingRoute = Optional.of(CompletableFuture.runAsync(createRoute, executor));
+            trackCreationFutures.add(creatingRoute.get());
         }
+
+        creationCompletableFutures = CompletableFuture.allOf(trackCreationFutures.toArray(new CompletableFuture[0]));
         gaugeMetric.ifPresent(g -> g.incrementMetric(METRICS_POD_STARTED_ATTEMPTED_KEY));
     }
 
@@ -392,26 +407,38 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
             }
         };
 
+        Consumer<Exception> onErrorInternal = (exception) -> {
+            cancelAndClearMonitors();
+            onError.accept(exception);
+        };
+
         cancelHook = () -> onComplete.accept(null);
 
-        pullingMonitor.monitor(onEnvironmentInitComplete(onCompleteInternal, Selector.POD),
-                (t) -> this.retryPod(t, onComplete, onError, retries),
-                this::isPodRunning);
+        addMonitors(
+                pullingMonitor.monitor(onEnvironmentInitComplete(onCompleteInternal, Selector.POD),
+                        (t) -> this.retryPod(t, onComplete, onError, retries), this::isPodRunning));
 
         addMonitors(pullingMonitor.monitor(
                 onEnvironmentInitComplete(onCompleteInternal, Selector.SERVICE),
-                onError,
+                onErrorInternal,
                 this::isServiceRunning));
+
 
         logger.info("Waiting to initialize environment. Pod [{}]; Service [{}].", pod.getName(), service.getName());
 
         if (createRoute) {
             addMonitors(pullingMonitor.monitor(
                             onEnvironmentInitComplete(onCompleteInternal, Selector.ROUTE),
-                            onError,
+                            onErrorInternal,
                             this::isRouteRunning));
             logger.info("Route [{}].", route.getName());
         }
+
+        // monitor creation errors after all other monitors to make sure we cancel all of them on failure
+        addMonitors(pullingMonitor.monitor(
+                () -> {},
+                onErrorInternal,
+                this::checkOpenshiftObjectCreation));
 
         //logger.info("Waiting to start a pod [{}], service [{}].", pod.getName(), service.getName());
     }
@@ -480,6 +507,39 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
 
     private String getInternalEndpointUrl() {
         return "http://" + service.getClusterIP() + "/" + buildAgentContextPath + "/" + environmentConfiguration.getBuildAgentBindPath();
+    }
+
+    /**
+     * check if the Openshift object futures are completed successfully.
+     *
+     * If completed successfully, return true
+     * If completed, but not successfully, the exception in the future is thrown.
+     * If not completed, return false
+     *
+     * @return boolean
+     */
+    private boolean checkOpenshiftObjectCreation() {
+
+
+        if (!creationCompletableFutures.isDone()) {
+            logger.debug("All openshift creating completable futures not done yet!");
+            return false;
+        } else {
+
+            // creation futures are done. Check if there was an exception or not
+            if (creationCompletableFutures.isCompletedExceptionally()) {
+                // capturing the exception
+                try {
+                    creationCompletableFutures.join();
+                } catch (Exception e) {
+                    logger.debug("Exception in one of the openshift creating completable future", e);
+                    throw new PodFailedStartException(e.getMessage());
+                }
+                return false;
+            } else {
+                return true;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Sometimes object pod creation fails because of quota limits. In those
cases, an exception is thrown on pod creation indicating we are above
quota. Unfortunately we do not capture the exception and deal with it
properly.

This commit attempts to capture the exception and calls the 'onError'
callback when an exception is thrown. This is done by:

- Using CompletableFuture instead of Future

  This is done to:
  * be able to capture any exceptions raised in the runnables
  * combine CompletableFutures together

- Adding an additional monitor to check if the Openshift
  object creation CompletableFutures are finished and without
  exceptions. If with exceptions, it is wrapped as a
  PodFailedStartedException and thrown (and caught by the
  PollingMonitor).

  If the CompletableFutures are not finished yet, then we just return
  false, to indicate that it's not ready yet.

- Add all the monitors into the monitors list to be able to cancel them
  on failure

### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing?
* [ ] Have you added unit tests for your change?
