### PR TITLE
[NCL-4568] Stop env monitor on error

### DIFF
--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -107,10 +107,6 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
      */
     private static final String BUILDER_POD_MEMORY = "BUILDER_POD_MEMORY";
 
-    private boolean serviceCreated = false;
-    private boolean podCreated = false;
-    private boolean routeCreated = false;
-
     private final IClient client;
     private final RepositorySession repositorySession;
     private final OpenshiftBuildAgentConfig openshiftBuildAgentConfig;
@@ -228,7 +224,6 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         Runnable createPod = () -> {
             try {
                 client.create(pod, pod.getNamespace());
-                podCreated = true;
             } catch (Throwable e) {
                 logger.error("Cannot create pod.", e);
                 throw e;
@@ -243,7 +238,6 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         Runnable createService = () -> {
             try {
                 client.create(service, service.getNamespace());
-                serviceCreated = true;
             } catch (Throwable e) {
                 logger.error("Cannot create service.", e);
                 throw e;
@@ -259,7 +253,6 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
             Runnable createRoute = () -> {
                 try {
                     client.create(route, route.getNamespace());
-                    routeCreated = true;
                 } catch (Throwable e) {
                     logger.error("Cannot create route.", e);
                     throw e;
@@ -417,24 +410,28 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
 
         cancelHook = () -> onComplete.accept(null);
 
-        addMonitors(
-                pullingMonitor.monitor(onEnvironmentInitComplete(onCompleteInternal, Selector.POD),
-                        (t) -> this.retryPod(t, onComplete, onError, retries), this::isPodRunning));
+        creatingPod.ifPresent((f) -> f.thenRunAsync(() -> {
+            addMonitors(
+                    pullingMonitor.monitor(onEnvironmentInitComplete(onCompleteInternal, Selector.POD),
+                            (t) -> this.retryPod(t, onComplete, onError, retries), this::isPodRunning));
+        }));
 
-        addMonitors(pullingMonitor.monitor(
-                onEnvironmentInitComplete(onCompleteInternal, Selector.SERVICE),
-                onErrorInternal,
-                this::isServiceRunning));
+        creatingService.ifPresent((f) -> f.thenRunAsync(() -> {
+            addMonitors(pullingMonitor.monitor(
+                    onEnvironmentInitComplete(onCompleteInternal, Selector.SERVICE),
+                    onErrorInternal,
+                    this::isServiceRunning));
+        }));
 
         logger.info("Waiting to initialize environment. Pod [{}]; Service [{}].", pod.getName(), service.getName());
 
-        if (createRoute) {
+        creatingRoute.ifPresent((f) -> f.thenRunAsync(() -> {
             addMonitors(pullingMonitor.monitor(
-                            onEnvironmentInitComplete(onCompleteInternal, Selector.ROUTE),
-                            onErrorInternal,
-                            this::isRouteRunning));
+                    onEnvironmentInitComplete(onCompleteInternal, Selector.ROUTE),
+                    onErrorInternal,
+                    this::isRouteRunning));
             logger.info("Route [{}].", route.getName());
-        }
+        }));
 
         // monitor creation errors after all other monitors to make sure we cancel all of them on failure
         addMonitors(pullingMonitor.monitor(
@@ -549,9 +546,6 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
      * @return boolean: is pod running?
      */
     private boolean isPodRunning() {
-        if (!podCreated) { //avoid Caused by: java.io.FileNotFoundException: https://<host>:8443/api/v1/namespaces/project-ncl/services/pnc-ba-pod-552c
-            return false;
-        }
 
         pod = client.get(pod.getKind(), pod.getName(), environmentConfiguration.getPncNamespace());
 
@@ -572,9 +566,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
     }
 
     private boolean isServiceRunning() {
-        if (!serviceCreated) { //avoid Caused by: java.io.FileNotFoundException: https://<host>:8443/api/v1/namespaces/project-ncl/services/pnc-ba-service-552c
-            return false;
-        }
+
         service = client.get(service.getKind(), service.getName(), environmentConfiguration.getPncNamespace());
         boolean isRunning = service.getPods().size() > 0;
         if (isRunning) {
@@ -585,9 +577,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
     }
 
     private boolean isRouteRunning() {
-        if (!routeCreated) {
-            return false;
-        }
+
         try {
             if (connectToPingUrl(new URL(getPublicEndpointUrl()))) {
                 route = client.get(route.getKind(), route.getName(), environmentConfiguration.getPncNamespace());


### PR DESCRIPTION
Note: this is a backport of #2430 for master branch

Sometimes object pod creation fails because of quota limits. In those
cases, an exception is thrown on pod creation indicating we are above
quota. Unfortunately we do not capture the exception and deal with it
properly.

This commit attempts to capture the exception and calls the 'onError'
callback when an exception is thrown. This is done by:

- Using CompletableFuture instead of Future

  This is done to:
  * be able to capture any exceptions raised in the runnables
  * combine CompletableFutures together

- Adding an additional monitor to check if the Openshift
  object creation CompletableFutures are finished and without
  exceptions. If with exceptions, it is wrapped as a
  PodFailedStartedException and thrown (and caught by the
  PollingMonitor).

  If the CompletableFutures are not finished yet, then we just return
  false, to indicate that it's not ready yet.

- Add all the monitors into the monitors list to be able to cancel them
  on failure

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
