### PR TITLE
[NCL-4716] Resolve HV000152 on group-configuration

### DIFF
--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/GroupConfigurationEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/GroupConfigurationEndpoint.java
@@ -134,8 +134,7 @@ public interface GroupConfigurationEndpoint{
     @PUT
     @Path("/{id}")
     void update(
-            @Parameter(description = GC_ID) @PathParam("id") int id,
-            @NotNull GroupConfiguration groupConfiguration);
+            @Parameter(description = GC_ID) @PathParam("id") int id, GroupConfiguration groupConfiguration);
 
     @Operation(summary = "Removes a specific group config.",
             responses = {


### PR DESCRIPTION
[NCL-4716] Resolve HV000152 on group-configuration

This happened because 'GroupConfigurationEndpointImpl' implements
'GroupConfigurationEndpoint' and 'GroupConfigurationEndpoint' in some
sort of way implements 'AbstractEndpoint#update' method.
'GroupConfigurationEndpoint' is imposing additional contraint on the
`update` method with `@NotNull` (with AbstractEndpoint), violating the
Liskov substitution.

https://beanvalidation.org/1.1/spec/#constraintdeclarationvalidationprocess-methodlevelconstraints-inheritance

I also made sure that we are not using `@NotNull` in our Endpoint
interfaces that implements `AbstractEndpoint`.

Futher work is planned to properly add `@NotNull` constraint in our
endpoints without violating the Liskov substitution (See NCL-4767)

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
