### PR TITLE
[v1.7] Enable setter for buildtype

### DIFF
--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BuildExecutionConfigurationRest.java
@@ -244,11 +244,8 @@ public class BuildExecutionConfigurationRest implements BuildExecutionConfigurat
         this.user = user;
     }
 
-    /**
-     * This is no longer used so it does nothing, for more info see NCL-1778
-     */
-    @Deprecated
-    public void setBuildType(String buildType) {
+    public void setBuildType(BuildType buildType) {
+        this.buildType = buildType;
     }
 
     @Override


### PR DESCRIPTION
I believe Jackson will use the setter method to set the buildtype. Since
it doesn't do anything, buildtype is never set. This commit fixes this
situation by actually setting the buildtype field in the setter method

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
