### PR TITLE
[NCL-4701] Store scm info on build failure if possible

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/datastore/DatastoreAdapter.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/datastore/DatastoreAdapter.java
@@ -263,6 +263,15 @@ public class DatastoreAdapter {
                     errorLog.append(r.getLog());
                     errorLog.append("\n---- End Environment Driver Log ----\n");
             });
+
+            // store scm information of failed build if present
+            result.getBuildExecutionConfiguration().ifPresent(
+                r -> {
+                    buildRecordBuilder.scmRepoURL(r.getScmRepoURL());
+                    buildRecordBuilder.scmRevision(r.getScmRevision());
+                    buildRecordBuilder.scmTag(r.getScmTag());
+
+                });
         });
 
         errorLog.append("Build status: ").append(getBuildStatus(buildResult)).append("\n");


### PR DESCRIPTION
This commit adds the scm information of a build in case of failure. This is useful when a build has already finished alignment, and is either in the process of starting the build or building, and a failure occurs.

![ncl-4701-before](https://user-images.githubusercontent.com/630746/58660918-8cf4df00-82f4-11e9-96e2-b1916cde0706.png)
From the picture above, you can see that the scm revision and scm tag are not stored. This is useful information that the builder might want to see to debug her builds locally (to see for e.g the alignment done)

With this commit, the scm revision and scm tag are stored (if available).
![ncl-4701-after](https://user-images.githubusercontent.com/630746/58661187-3e941000-82f5-11e9-8d0c-e2a979522087.png)

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
