### PR TITLE
[NCL-4767] Use EndpointHelper instead of AbstractEndpoint

### DIFF
--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ArtifactEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ArtifactEndpoint.java
@@ -30,6 +30,7 @@ import org.jboss.pnc.processor.annotation.Client;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.ArtifactPage;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -105,7 +106,7 @@ public interface ArtifactEndpoint {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @POST
-    Artifact create(Artifact artifactRest);
+    Artifact create(@NotNull Artifact artifactRest);
 
     @Operation(summary = "[role:admin] Updates an existing Artifact",
             tags = "internal",
@@ -120,5 +121,5 @@ public interface ArtifactEndpoint {
             })
     @PUT
     @Path("/{id}")
-    void update(@PathParam("id") Integer id, Artifact artifact);
+    void update(@PathParam("id") Integer id, @NotNull Artifact artifact);
 }

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/BuildConfigurationEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/BuildConfigurationEndpoint.java
@@ -43,6 +43,7 @@ import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.BuildConfigRevisionP
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.BuildPage;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.GroupConfigPage;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -110,7 +111,7 @@ public interface BuildConfigurationEndpoint {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
-    BuildConfiguration createNew(BuildConfiguration buildConfiguration);
+    BuildConfiguration createNew(@NotNull BuildConfiguration buildConfiguration);
 
     @Operation(summary = "Gets a specific build config.",
             responses = {
@@ -137,7 +138,7 @@ public interface BuildConfigurationEndpoint {
     @PUT
     @Path("/{id}")
     void update(@Parameter(description = BC_ID) @PathParam("id") int id,
-            BuildConfiguration buildConfiguration);
+                @NotNull BuildConfiguration buildConfiguration);
 
     @Operation(summary = "Removes a specific build config.",
             responses = {

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/BuildEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/BuildEndpoint.java
@@ -42,6 +42,7 @@ import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.ArtifactPage;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.BuildPage;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.BuildPushResultPage;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -152,7 +153,7 @@ public interface BuildEndpoint{
             })
     @PUT
     @Path("/{id}")
-    void update(@Parameter(description = B_ID) @PathParam("id") int id, Build build);
+    void update(@Parameter(description = B_ID) @PathParam("id") int id, @NotNull Build build);
 
     @Operation(summary = "Gets artifacts built in a specific build.",
             responses = {

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/GroupConfigurationEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/GroupConfigurationEndpoint.java
@@ -133,7 +133,7 @@ public interface GroupConfigurationEndpoint{
     @PUT
     @Path("/{id}")
     void update(
-            @Parameter(description = GC_ID) @PathParam("id") int id, GroupConfiguration groupConfiguration);
+            @Parameter(description = GC_ID) @PathParam("id") int id, @NotNull GroupConfiguration groupConfiguration);
 
     @Operation(summary = "Removes a specific group config.",
             responses = {

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductEndpoint.java
@@ -34,6 +34,7 @@ import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.BuildConfigPage;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.ProductPage;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.ProductVersionPage;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -91,7 +92,7 @@ public interface ProductEndpoint {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
-    Product createNew(Product product);
+    Product createNew(@NotNull Product product);
 
     @Operation(summary = "Gets a specific product.",
             responses = {
@@ -119,7 +120,7 @@ public interface ProductEndpoint {
     @Path("/{id}")
     void update(
             @Parameter(description = P_ID) @PathParam("id") int id,
-            Product product);
+            @NotNull Product product);
 
     @Operation(summary = "Get all versions for a specific product.",
             responses = {

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductMilestoneEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductMilestoneEndpoint.java
@@ -31,6 +31,7 @@ import org.jboss.pnc.processor.annotation.Client;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.BuildPage;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -79,7 +80,7 @@ public interface ProductMilestoneEndpoint{
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
-    ProductMilestone createNew(ProductMilestone productMilestone);
+    ProductMilestone createNew(@NotNull ProductMilestone productMilestone);
 
     @Operation(summary = "Gets a specific product milestone.",
             responses = {
@@ -107,7 +108,7 @@ public interface ProductMilestoneEndpoint{
     @Path("/{id}")
     void update(
             @Parameter(description = PM_ID) @PathParam("id") int id,
-            ProductMilestone productMilestone);
+            @NotNull ProductMilestone productMilestone);
 
     @Operation(summary = "Gets builds performed during a product milestone cycle.",
             responses = {

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductReleaseEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductReleaseEndpoint.java
@@ -29,6 +29,7 @@ import org.jboss.pnc.dto.response.ErrorResponse;
 import org.jboss.pnc.enums.SupportLevel;
 import org.jboss.pnc.processor.annotation.Client;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -75,7 +76,7 @@ public interface ProductReleaseEndpoint{
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
-    ProductRelease createNew(ProductRelease productRelease);
+    ProductRelease createNew(@NotNull ProductRelease productRelease);
 
     @Operation(summary = "Gets a specific product release.",
             responses = {
@@ -103,7 +104,7 @@ public interface ProductReleaseEndpoint{
     @Path("/{id}")
     void update(
             @Parameter(description = PR_ID) @PathParam("id") int id,
-            ProductRelease productRelease);
+            @NotNull ProductRelease productRelease);
 
     @Operation(summary = "Gets all product releases support levels.",
             responses = {

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductVersionEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductVersionEndpoint.java
@@ -38,6 +38,7 @@ import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.GroupConfigPage;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.ProductMilestonePage;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.ProductReleasePage;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -83,7 +84,7 @@ public interface ProductVersionEndpoint{
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @POST
-    ProductVersion createNewProductVersion(ProductVersion productVersion);
+    ProductVersion createNewProductVersion(@NotNull ProductVersion productVersion);
 
     @Operation(summary = "Gets a specific product version.",
             responses = {
@@ -111,7 +112,7 @@ public interface ProductVersionEndpoint{
     @Path("/{id}")
     void update(
             @Parameter(description = PV_ID) @PathParam("id") int id,
-            ProductVersion productVersion);
+            @NotNull ProductVersion productVersion);
 
     @Operation(summary = "Gets all build configs in a specific product version.",
             responses = {

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProjectEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProjectEndpoint.java
@@ -35,6 +35,7 @@ import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.BuildConfigPage;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.BuildPage;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.ProjectPage;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -96,7 +97,7 @@ public interface ProjectEndpoint{
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
-    Project createNew(Project project);
+    Project createNew(@NotNull Project project);
 
     @Operation(summary = "Gets a specific project.",
             responses = {
@@ -124,7 +125,7 @@ public interface ProjectEndpoint{
     @Path("/{id}")
     void update(
             @Parameter(description = P_ID) @PathParam("id") int id,
-            Project project);
+            @NotNull Project project);
 
     @Operation(summary = "Removes a specific project and associated build configs.",
             responses = {

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/SCMRepositoryEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/SCMRepositoryEndpoint.java
@@ -33,6 +33,7 @@ import org.jboss.pnc.processor.annotation.Client;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.SCMRepositoryPage;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -115,7 +116,7 @@ public interface SCMRepositoryEndpoint{
     @Path("/{id}")
     void update(
             @Parameter(description = SCM_ID) @PathParam("id") int id,
-            SCMRepository repositoryConfiguration);
+            @NotNull SCMRepository repositoryConfiguration);
 
     @Operation(summary = "Creates a new SCM repository.",
             description = "If the given URL is external, it does create the repository in the scm server.",
@@ -131,5 +132,5 @@ public interface SCMRepositoryEndpoint{
     })
     @POST
     @Path("/create-and-sync")
-    RepositoryCreationResponse createNew(CreateAndSyncSCMRequest request);
+    RepositoryCreationResponse createNew(@NotNull CreateAndSyncSCMRequest request);
 }

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/ArtifactEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/ArtifactEndpointImpl.java
@@ -26,25 +26,24 @@ import org.jboss.pnc.rest.api.parameters.PageParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.PostConstruct;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import java.util.Optional;
 
 @Stateless
-public class ArtifactEndpointImpl extends AbstractEndpoint<Artifact, ArtifactRef> implements ArtifactEndpoint {
+public class ArtifactEndpointImpl implements ArtifactEndpoint {
 
     private static final Logger logger = LoggerFactory.getLogger(ArtifactEndpointImpl.class);
+
+    private EndpointHelper<Artifact, ArtifactRef> endpointHelper;
     
     @Inject
     private ArtifactProvider artifactProvider;
 
-    public ArtifactEndpointImpl(){
-        super(Artifact.class);
-    }
-
-    @Override
-    protected ArtifactProvider provider() {
-        return artifactProvider;
+    @PostConstruct
+    public void init() {
+        endpointHelper = new EndpointHelper<>(Artifact.class, artifactProvider);
     }
 
     @Override
@@ -62,16 +61,16 @@ public class ArtifactEndpointImpl extends AbstractEndpoint<Artifact, ArtifactRef
 
     @Override
     public Artifact getSpecific(int id) {
-        return super.getSpecific(id);
+        return endpointHelper.getSpecific(id);
     }
 
     @Override
     public Artifact create(Artifact artifact) {
-        return super.create(artifact);
+        return endpointHelper.create(artifact);
     }
 
     @Override
     public void update(Integer id, Artifact artifact){
-        super.update(id, artifact);
+        endpointHelper.update(id, artifact);
     }
 }

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/BuildConfigurationEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/BuildConfigurationEndpointImpl.java
@@ -35,6 +35,7 @@ import org.jboss.pnc.rest.api.parameters.BuildParameters;
 import org.jboss.pnc.rest.api.parameters.BuildsFilterParameters;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -51,7 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ApplicationScoped
-public class BuildConfigurationEndpointImpl extends AbstractEndpoint<BuildConfiguration, BuildConfigurationRef> implements BuildConfigurationEndpoint {
+public class BuildConfigurationEndpointImpl implements BuildConfigurationEndpoint {
 
     private static final Logger logger = LoggerFactory.getLogger(BuildConfigurationEndpointImpl.class);
 
@@ -70,38 +71,36 @@ public class BuildConfigurationEndpointImpl extends AbstractEndpoint<BuildConfig
     @Inject
     private BuildTriggerer buildTriggerer;
 
-    public BuildConfigurationEndpointImpl() {
-        super(BuildConfiguration.class);
-    }
+    private EndpointHelper<BuildConfiguration, BuildConfigurationRef> endpointHelper;
 
-    @Override
-    protected BuildConfigurationProvider provider() {
-        return buildConfigurationProvider;
+    @PostConstruct
+    public void init() {
+        endpointHelper = new EndpointHelper<>(BuildConfiguration.class, buildConfigurationProvider);
     }
 
     @Override
     public Page<BuildConfiguration> getAll(PageParameters pageParams) {
-        return super.getAll(pageParams);
+        return endpointHelper.getAll(pageParams);
     }
 
     @Override
     public BuildConfiguration createNew(BuildConfiguration buildConfiguration) {
-        return super.create(buildConfiguration);
+        return endpointHelper.create(buildConfiguration);
     }
 
     @Override
     public BuildConfiguration getSpecific(int id) {
-        return super.getSpecific(id);
+        return endpointHelper.getSpecific(id);
     }
 
     @Override
     public void update(int id, BuildConfiguration buildConfiguration) {
-        super.update(id, buildConfiguration);
+        endpointHelper.update(id, buildConfiguration);
     }
 
     @Override
     public void deleteSpecific(int id) {
-        super.delete(id);
+        endpointHelper.delete(id);
     }
 
     @Override

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/BuildEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/BuildEndpointImpl.java
@@ -37,6 +37,7 @@ import org.jboss.pnc.rest.api.parameters.PageParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.core.Response;
@@ -49,7 +50,7 @@ import java.util.List;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @ApplicationScoped
-public class BuildEndpointImpl extends AbstractEndpoint<Build, BuildRef> implements BuildEndpoint {
+public class BuildEndpointImpl implements BuildEndpoint {
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -63,13 +64,11 @@ public class BuildEndpointImpl extends AbstractEndpoint<Build, BuildRef> impleme
     @Inject
     private ArtifactProvider artifactProvider;
 
-    public BuildEndpointImpl() {
-        super(Build.class);
-    }
+    private EndpointHelper<Build, BuildRef> endpointHelper;
 
-    @Override
-    protected BuildProvider provider() {
-        return provider;
+    @PostConstruct
+    public void init() {
+        endpointHelper = new EndpointHelper<>(Build.class, provider);
     }
 
     @Override
@@ -85,17 +84,17 @@ public class BuildEndpointImpl extends AbstractEndpoint<Build, BuildRef> impleme
 
     @Override
     public Build getSpecific(int id) {
-        return super.getSpecific(id);
+        return endpointHelper.getSpecific(id);
     }
 
     @Override
     public void delete(int id) {
-        super.delete(id);
+        endpointHelper.delete(id);
     }
 
     @Override
     public void update(int id, Build build) {
-        super.update(id, build);
+        endpointHelper.update(id, build);
     }
 
     @Override

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/EndpointHelper.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/EndpointHelper.java
@@ -18,39 +18,36 @@
 package org.jboss.pnc.rest.endpoints;
 
 import org.jboss.pnc.dto.DTOEntity;
-
 import org.jboss.pnc.dto.response.Page;
 import org.jboss.pnc.facade.providers.api.Provider;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 import javax.ws.rs.NotFoundException;
 
-public abstract class AbstractEndpoint<DTO extends REF, REF extends DTOEntity> {
+public class EndpointHelper<DTO extends REF, REF extends DTOEntity> {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final Class<DTO> dtoClass;
+    private final Provider<?, DTO, REF> provider;
 
-    protected AbstractEndpoint(Class<DTO> dtoClass){
+    protected EndpointHelper(Class<DTO> dtoClass, Provider<?, DTO, REF> provider){
         this.dtoClass = dtoClass;
+        this.provider = provider;
     }
-
-    protected abstract Provider<?, DTO, REF> provider();
 
     protected DTO create(DTO dto) {
         logger.debug("Creating an entity with body: " + dto);
-        dto = provider().store(dto);
+        dto = provider.store(dto);
         logger.debug("Entity with id: " + dto.getId() + " successfully created");
         return dto;
     }
 
     protected DTO getSpecific(int id) {
         logger.debug("Getting " + dtoClass.getSimpleName() + " with id: " + id);
-        DTO dto = provider().getSpecific(id);
+        DTO dto = provider.getSpecific(id);
         if (dto == null) {
             logger.debug("Entity of type " + dtoClass.getSimpleName() + " with id: " + id + " not found.");
             throw new NotFoundException("Entity of type " + dtoClass.getSimpleName() + " with id: " + id + " not found.");
@@ -61,17 +58,17 @@ public abstract class AbstractEndpoint<DTO extends REF, REF extends DTOEntity> {
 
     protected Page<DTO> getAll(PageParameters pageParameters) {
         logger.debug("Retrieving " + dtoClass.getSimpleName() + "s with these " + pageParameters);
-        return provider().getAll(pageParameters.getPageIndex(), pageParameters.getPageSize(), pageParameters.getSort(), pageParameters.getQ());
+        return provider.getAll(pageParameters.getPageIndex(), pageParameters.getPageSize(), pageParameters.getSort(), pageParameters.getQ());
     };
 
     protected void update(int id, DTO dto) {
         logger.debug("Updating " + dtoClass.getSimpleName() + " with id: " + id);
-        provider().update(id, dto);
+        provider.update(id, dto);
     }
 
     protected void delete(int id) {
         logger.debug("Deleting " + dtoClass.getSimpleName() + " with id: " + id);
-        provider().delete(id);
+        provider.delete(id);
         logger.debug("Deletion of " + dtoClass.getSimpleName() + " with id: " + id + " was successful");
     }
 }

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/EnvironmentEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/EnvironmentEndpointImpl.java
@@ -24,33 +24,30 @@ import org.jboss.pnc.facade.providers.api.Provider;
 import org.jboss.pnc.rest.api.endpoints.EnvironmentEndpoint;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 
+import javax.annotation.PostConstruct;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 
 @Stateless
-public class EnvironmentEndpointImpl
-        extends AbstractEndpoint<Environment, Environment>
-        implements EnvironmentEndpoint {
+public class EnvironmentEndpointImpl implements EnvironmentEndpoint {
 
     @Inject
     private EnvironmentProvider environmentProvider;
 
-    public EnvironmentEndpointImpl() {
-        super(Environment.class);
-    }
+    private EndpointHelper<Environment, Environment> endpointHelper;
 
-    @Override
-    protected Provider<?, Environment, Environment> provider() {
-        return environmentProvider;
+    @PostConstruct
+    public void init() {
+        endpointHelper = new EndpointHelper<>(Environment.class, environmentProvider);
     }
 
     @Override
     public Page<Environment> getAll(PageParameters pageParameters) {
-        return super.getAll(pageParameters);
+        return endpointHelper.getAll(pageParameters);
     }
 
     @Override
     public Environment getSpecific(int id) {
-        return super.getSpecific(id);
+        return endpointHelper.getSpecific(id);
     }
 }

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/GroupBuildEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/GroupBuildEndpointImpl.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.rest.endpoints;
 
 import java.lang.invoke.MethodHandles;
 
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.jboss.pnc.rest.api.parameters.BuildsFilterParameters;
@@ -47,7 +48,7 @@ import javax.ws.rs.NotFoundException;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @ApplicationScoped
-public class GroupBuildEndpointImpl extends AbstractEndpoint<GroupBuild, GroupBuildRef> implements GroupBuildEndpoint {
+public class GroupBuildEndpointImpl implements GroupBuildEndpoint {
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -63,28 +64,26 @@ public class GroupBuildEndpointImpl extends AbstractEndpoint<GroupBuild, GroupBu
     @Inject
     private BrewPusher brewPusher;
 
-    public GroupBuildEndpointImpl() {
-        super(GroupBuild.class);
-    }
+    private EndpointHelper<GroupBuild, GroupBuildRef> endpointHelper;
 
-    @Override
-    protected GroupBuildProvider provider() {
-        return provider;
+    @PostConstruct
+    public void init() {
+        endpointHelper = new EndpointHelper<>(GroupBuild.class, provider);
     }
 
     @Override
     public Page<GroupBuild> getAll(PageParameters pageParameters) {
-        return super.getAll(pageParameters);
+        return endpointHelper.getAll(pageParameters);
     }
 
     @Override
     public GroupBuild getSpecific(int id) {
-        return super.getSpecific(id);
+        return endpointHelper.getSpecific(id);
     }
 
     @Override
     public void delete(int id) {
-        super.delete(id);
+        endpointHelper.delete(id);
     }
 
     @Override

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/GroupConfigurationEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/GroupConfigurationEndpointImpl.java
@@ -20,6 +20,7 @@ package org.jboss.pnc.rest.endpoints;
 import java.lang.invoke.MethodHandles;
 import java.util.Optional;
 
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.jboss.pnc.dto.Build;
@@ -55,7 +56,7 @@ import org.jboss.pnc.spi.exception.CoreException;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @ApplicationScoped
-public class GroupConfigurationEndpointImpl extends AbstractEndpoint<GroupConfiguration, GroupConfigurationRef> implements GroupConfigurationEndpoint{
+public class GroupConfigurationEndpointImpl implements GroupConfigurationEndpoint {
     
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     
@@ -74,38 +75,36 @@ public class GroupConfigurationEndpointImpl extends AbstractEndpoint<GroupConfig
     @Inject
     private BuildTriggerer buildTriggerer;
 
-    public GroupConfigurationEndpointImpl() {
-        super(GroupConfiguration.class);
-    }
+    private EndpointHelper<GroupConfiguration, GroupConfigurationRef> endpointHelper;
 
-    @Override
-    protected GroupConfigurationProvider provider() {
-        return provider;
+    @PostConstruct
+    public void init() {
+        endpointHelper = new EndpointHelper<>(GroupConfiguration.class, provider);
     }
 
     @Override
     public Page<GroupConfiguration> getAll(PageParameters pageParams) {
-        return super.getAll(pageParams);
+        return endpointHelper.getAll(pageParams);
     }
 
     @Override
     public GroupConfiguration createNew(GroupConfiguration groupConfiguration) {
-        return super.create(groupConfiguration);
+        return endpointHelper.create(groupConfiguration);
     }
 
     @Override
     public GroupConfiguration getSpecific(int id) {
-        return super.getSpecific(id);
+        return endpointHelper.getSpecific(id);
     }
 
     @Override
     public void update(int id, GroupConfiguration buildConfigurationSet) {
-        super.update(id, buildConfigurationSet);
+        endpointHelper.update(id, buildConfigurationSet);
     }
 
     @Override
     public void deleteSpecific(int id) {
-        super.delete(id);
+        endpointHelper.delete(id);
     }
 
     @Override

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/ProductEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/ProductEndpointImpl.java
@@ -26,11 +26,12 @@ import org.jboss.pnc.facade.providers.api.ProductVersionProvider;
 import org.jboss.pnc.rest.api.endpoints.ProductEndpoint;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 
+import javax.annotation.PostConstruct;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 
 @Stateless
-public class ProductEndpointImpl extends AbstractEndpoint<Product, ProductRef> implements ProductEndpoint {
+public class ProductEndpointImpl implements ProductEndpoint {
 
     @Inject
     private ProductProvider productProvider;
@@ -38,13 +39,11 @@ public class ProductEndpointImpl extends AbstractEndpoint<Product, ProductRef> i
     @Inject
     private ProductVersionProvider productVersionProvider;
 
-    public ProductEndpointImpl() {
-        super(Product.class);
-    }
+    private EndpointHelper<Product, ProductRef> endpointHelper;
 
-    @Override
-    protected ProductProvider provider() {
-        return productProvider;
+    @PostConstruct
+    public void init() {
+        endpointHelper = new EndpointHelper<>(Product.class, productProvider);
     }
 
     @Override
@@ -54,22 +53,21 @@ public class ProductEndpointImpl extends AbstractEndpoint<Product, ProductRef> i
                 pageParameters.getPageSize(),
                 pageParameters.getSort(),
                 pageParameters.getQ());
-
     }
 
     @Override
     public Product createNew(Product product) {
-        return super.create(product);
+        return endpointHelper.create(product);
     }
 
     @Override
     public Product getSpecific(int id) {
-        return super.getSpecific(id);
+        return endpointHelper.getSpecific(id);
     }
 
     @Override
     public void update(int id, Product product) {
-        super.update(id, product);
+        endpointHelper.update(id, product);
     }
 
     @Override

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/ProductMilestoneEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/ProductMilestoneEndpointImpl.java
@@ -28,15 +28,14 @@ import org.jboss.pnc.facade.providers.api.ProductMilestoneProvider;
 import org.jboss.pnc.rest.api.endpoints.ProductMilestoneEndpoint;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 
+import javax.annotation.PostConstruct;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Context;
 
 @Stateless
-public class ProductMilestoneEndpointImpl
-        extends AbstractEndpoint<ProductMilestone, ProductMilestoneRef>
-        implements ProductMilestoneEndpoint {
+public class ProductMilestoneEndpointImpl implements ProductMilestoneEndpoint {
 
     @Inject
     private ProductMilestoneProvider productMilestoneProvider;
@@ -50,28 +49,26 @@ public class ProductMilestoneEndpointImpl
     @Context
     private HttpServletRequest httpServletRequest;
 
-    public ProductMilestoneEndpointImpl() {
-        super(ProductMilestone.class);
-    }
+    private EndpointHelper<ProductMilestone, ProductMilestoneRef> endpointHelper;
 
-    @Override
-    protected ProductMilestoneProvider provider() {
-        return productMilestoneProvider;
+    @PostConstruct
+    public void init() {
+        endpointHelper = new EndpointHelper<>(ProductMilestone.class, productMilestoneProvider);
     }
 
     @Override
     public ProductMilestone createNew(ProductMilestone productMilestone) {
-        return super.create(productMilestone);
+        return endpointHelper.create(productMilestone);
     }
 
     @Override
     public ProductMilestone getSpecific(int id) {
-        return super.getSpecific(id);
+        return endpointHelper.getSpecific(id);
     }
 
     @Override
     public void update(int id, ProductMilestone productMilestone) {
-        super.update(id, productMilestone);
+        endpointHelper.update(id, productMilestone);
     }
 
     @Override

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/ProductReleaseEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/ProductReleaseEndpointImpl.java
@@ -23,6 +23,7 @@ import org.jboss.pnc.enums.SupportLevel;
 import org.jboss.pnc.facade.providers.api.ProductReleaseProvider;
 import org.jboss.pnc.rest.api.endpoints.ProductReleaseEndpoint;
 
+import javax.annotation.PostConstruct;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import java.util.Arrays;
@@ -31,35 +32,31 @@ import java.util.List;
 import java.util.Set;
 
 @Stateless
-public class ProductReleaseEndpointImpl
-        extends AbstractEndpoint<ProductRelease, ProductReleaseRef>
-        implements ProductReleaseEndpoint {
+public class ProductReleaseEndpointImpl implements ProductReleaseEndpoint {
 
     @Inject
     private ProductReleaseProvider productReleaseProvider;
 
-    public ProductReleaseEndpointImpl() {
-        super(ProductRelease.class);
-    }
+    private EndpointHelper<ProductRelease, ProductReleaseRef> endpointHelper;
 
-    @Override
-    protected ProductReleaseProvider provider() {
-        return productReleaseProvider;
+    @PostConstruct
+    public void init() {
+        endpointHelper = new EndpointHelper<>(ProductRelease.class, productReleaseProvider);
     }
 
     @Override
     public ProductRelease createNew(ProductRelease productRelease) {
-        return super.create(productRelease);
+        return endpointHelper.create(productRelease);
     }
 
     @Override
     public ProductRelease getSpecific(int id) {
-        return super.getSpecific(id);
+        return endpointHelper.getSpecific(id);
     }
 
     @Override
     public void update(int id, ProductRelease productRelease) {
-        super.update(id, productRelease);
+        endpointHelper.update(id, productRelease);
     }
 
     @Override

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/ProductVersionEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/ProductVersionEndpointImpl.java
@@ -32,13 +32,12 @@ import org.jboss.pnc.facade.providers.api.ProductVersionProvider;
 import org.jboss.pnc.rest.api.endpoints.ProductVersionEndpoint;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 
+import javax.annotation.PostConstruct;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 
 @Stateless
-public class ProductVersionEndpointImpl
-        extends AbstractEndpoint<ProductVersion, ProductVersionRef>
-        implements ProductVersionEndpoint {
+public class ProductVersionEndpointImpl implements ProductVersionEndpoint {
 
     @Inject
     private ProductVersionProvider productVersionProvider;
@@ -55,28 +54,26 @@ public class ProductVersionEndpointImpl
     @Inject
     private ProductReleaseProvider productReleaseProvider;
 
-    public ProductVersionEndpointImpl() {
-        super(ProductVersion.class);
-    }
+    private EndpointHelper<ProductVersion, ProductVersionRef> endpointHelper;
 
-    @Override
-    protected ProductVersionProvider provider() {
-        return productVersionProvider;
+    @PostConstruct
+    public void init() {
+        endpointHelper = new EndpointHelper<>(ProductVersion.class, productVersionProvider);
     }
 
     @Override
     public ProductVersion createNewProductVersion(ProductVersion productVersion) {
-        return super.create(productVersion);
+        return endpointHelper.create(productVersion);
     }
 
     @Override
     public ProductVersion getSpecific(int id) {
-        return super.getSpecific(id);
+        return endpointHelper.getSpecific(id);
     }
 
     @Override
     public void update(int id, ProductVersion productVersion) {
-        super.update(id, productVersion);
+        endpointHelper.update(id, productVersion);
     }
 
     @Override

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/ProjectEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/ProjectEndpointImpl.java
@@ -29,13 +29,12 @@ import org.jboss.pnc.rest.api.endpoints.ProjectEndpoint;
 import org.jboss.pnc.rest.api.parameters.BuildsFilterParameters;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 
+import javax.annotation.PostConstruct;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 
 @Stateless
-public class ProjectEndpointImpl
-        extends AbstractEndpoint<Project, ProjectRef>
-        implements ProjectEndpoint {
+public class ProjectEndpointImpl implements ProjectEndpoint {
 
     @Inject
     private ProjectProvider projectProvider;
@@ -46,38 +45,36 @@ public class ProjectEndpointImpl
     @Inject
     private BuildProvider buildProvider;
 
-    public ProjectEndpointImpl() {
-        super(Project.class);
-    }
+    private EndpointHelper<Project, ProjectRef> endpointHelper;
 
-    @Override
-    protected ProjectProvider provider() {
-        return projectProvider;
+    @PostConstruct
+    public void init() {
+        endpointHelper = new EndpointHelper<>(Project.class, projectProvider);
     }
 
     @Override
     public Page<Project> getAll(PageParameters pageParameters) {
-        return super.getAll(pageParameters);
+        return endpointHelper.getAll(pageParameters);
     }
 
     @Override
     public Project createNew(Project project) {
-        return super.create(project);
+        return endpointHelper.create(project);
     }
 
     @Override
     public Project getSpecific(int id) {
-        return super.getSpecific(id);
+        return endpointHelper.getSpecific(id);
     }
 
     @Override
     public void update(int id, Project project) {
-        super.update(id, project);
+        endpointHelper.update(id, project);
     }
 
     @Override
     public void deleteSpecific(int id) {
-        super.delete(id);
+        endpointHelper.delete(id);
     }
 
     @Override

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/SCMRepositoryEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/SCMRepositoryEndpointImpl.java
@@ -27,24 +27,21 @@ import org.jboss.pnc.facade.validation.ValidationBuilder;
 import org.jboss.pnc.rest.api.endpoints.SCMRepositoryEndpoint;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 @ApplicationScoped
-public class SCMRepositoryEndpointImpl
-        extends AbstractEndpoint<SCMRepository, SCMRepository>
-        implements SCMRepositoryEndpoint {
+public class SCMRepositoryEndpointImpl implements SCMRepositoryEndpoint {
 
     @Inject
     private SCMRepositoryProvider scmRepositoryProvider;
 
-    public SCMRepositoryEndpointImpl() {
-        super(SCMRepository.class);
-    }
+    private EndpointHelper<SCMRepository, SCMRepository> endpointHelper;
 
-    @Override
-    protected SCMRepositoryProvider provider() {
-        return scmRepositoryProvider;
+    @PostConstruct
+    public void init() {
+        endpointHelper = new EndpointHelper<>(SCMRepository.class, scmRepositoryProvider);
     }
 
     @Override
@@ -61,12 +58,12 @@ public class SCMRepositoryEndpointImpl
 
     @Override
     public SCMRepository getSpecific(int id) {
-        return super.getSpecific(id);
+        return endpointHelper.getSpecific(id);
     }
 
     @Override
     public void update(int id, SCMRepository repositoryConfiguration) {
-        super.update(id, repositoryConfiguration);
+        endpointHelper.update(id, repositoryConfiguration);
     }
 
     @Override

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/UserEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/UserEndpointImpl.java
@@ -33,9 +33,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Context;
 
 @Stateless
-public class UserEndpointImpl
-        extends AbstractEndpoint<User, User>
-        implements UserEndpoint {
+public class UserEndpointImpl implements UserEndpoint {
 
     @Context
     private HttpServletRequest httpServletRequest;
@@ -48,15 +46,6 @@ public class UserEndpointImpl
 
     @Inject
     private BuildProvider buildProvider;
-
-    public UserEndpointImpl() {
-        super(User.class);
-    }
-
-    @Override
-    protected UserProvider provider() {
-        return userProvider;
-    }
 
     @Override
     public User getCurrentUser() {


### PR DESCRIPTION
It is a bit confusing from the `*EndpointImpl` the order of inheritance
between the `AbstractEndpoint` and the Endpoint interface. This hits us
with the HV000152 errors we were getting when `@NotNull` is used in
either the interface or `AbstractEndpoint` methods (See NCL-4716).

To help make things clearer, this commit makes `AbstractEndpoint` a
non-abstract class, that we can use inside our `*EndpointImpl` as a
regular object. As such, we moved `AbstractEndpoint` from inheritance to
composition (and renamed it to `EndpointHelper` to avoid confusion).

This is part 1 of the work for NCL-4767. I wanted to get this reviewed first
before I continue with it.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
