### PR TITLE
Fetch BuildConfigAudited info in BuildProvider

### DIFF
--- a/facade/src/main/java/org/jboss/pnc/facade/providers/BuildProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/BuildProviderImpl.java
@@ -65,8 +65,10 @@ import static org.jboss.pnc.spi.datastore.predicates.BuildRecordPredicates.withU
 @Stateless
 public class BuildProviderImpl extends AbstractProvider<BuildRecord, Build, BuildRef> implements BuildProvider {
 
+    private BuildRecordRepository buildRecordRepository;
     private BuildConfigurationRepository buildConfigurationRepository;
     private BuildConfigurationAuditedRepository buildConfigurationAuditedRepository;
+
     private Gerrit gerrit;
     private BuildConfigurationRevisionMapper buildConfigurationRevisionMapper;
     private BuildMapper buildMapper;
@@ -83,6 +85,7 @@ public class BuildProviderImpl extends AbstractProvider<BuildRecord, Build, Buil
                              BuildCoordinator buildCoordinator) {
         super(repository, mapper, BuildRecord.class);
 
+        this.buildRecordRepository = repository;
         this.buildConfigurationRepository = buildConfigurationRepository;
         this.buildConfigurationAuditedRepository = buildConfigurationAuditedRepository;
         this.gerrit = gerrit;
@@ -257,7 +260,8 @@ public class BuildProviderImpl extends AbstractProvider<BuildRecord, Build, Buil
 
         // if build not in runningBuilds, check the database
         if (build == null) {
-            build = super.getSpecific(id);
+            // use findByIdFetchProperties instead of super.getSpecific to get 'BuildConfigurationAudited' object
+            build = mapper.toDTO(buildRecordRepository.findByIdFetchProperties(id));
         }
 
         return build;


### PR DESCRIPTION
This commit fixes a bug where the BuildConfigurationAudited object is
not fetched on the 'BuildRecord' object by default. This causes the
`mapper.toDTO` method to not be able to properly convert most of the
stuff:

```
{
    "id": 57,
    "submitTime": "2019-06-12T21:26:41.379Z",
    "startTime": "2019-06-12T21:26:41.383Z",
    "endTime": "2019-06-12T21:28:22.460Z",
    "status": "DONE",
    "buildContentId": "build-57",
    "temporaryBuild": false,
    "project": null,
    "repository": null,
    "environment": null,
    "attributes": {},
    "user": {
        "id": 102,
        "username": "dcheung"
    },
    "buildConfigurationRevision": null,
    "dependentBuildIds": [],
    "dependencyBuildIds": []
}
```

The project, repository, environment, and buildConfigurationRevision
fields are all obtained from the `BuildConfigurationAudited` object.

This commit tries to fetch the BuildConfigurationAudited object inside
the BuildRecord by calling `buildRecordRepository.findByIdFetchProperties(id)`

We can't use the default 'mapper' object since it is cast to
`Repository` and it doesn't define the method `findByIdFetchProperties`,
which is why we have to define a `BuildRecordRepository` field instead.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
