### PR TITLE
[NCL-4395] Partial implementation of BpmEndpoint

### DIFF
--- a/facade/src/main/java/org/jboss/pnc/facade/BpmController.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/BpmController.java
@@ -1,0 +1,28 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.facade;
+
+import org.jboss.pnc.dto.internal.bpm.BPMTask;
+import org.jboss.pnc.dto.response.Page;
+
+public interface BpmController {
+
+    Page<BPMTask> getBPMTasks(int pageIndex, int pageSize);
+
+    BPMTask getBPMTaskById(int taskId);
+}

--- a/facade/src/main/java/org/jboss/pnc/facade/impl/BpmControllerImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/impl/BpmControllerImpl.java
@@ -1,0 +1,65 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.facade.impl;
+
+import org.jboss.pnc.bpm.BpmManager;
+import org.jboss.pnc.bpm.BpmTask;
+import org.jboss.pnc.dto.internal.bpm.BPMTask;
+import org.jboss.pnc.dto.response.Page;
+import org.jboss.pnc.facade.BpmController;
+import org.jboss.pnc.mapper.api.BPMTaskMapper;
+
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Stateless
+public class BpmControllerImpl implements BpmController {
+
+    @Inject
+    private BpmManager bpmManager;
+
+    @Inject
+    private BPMTaskMapper bpmTaskMapper;
+
+    public Page<BPMTask> getBPMTasks(int pageIndex, int pageSize) {
+
+        Collection<BpmTask> tasks = bpmManager.getActiveTasks();
+
+        int totalHits = tasks.size();
+        int totalPages = (totalHits + pageSize - 1) / pageSize;
+
+        List<BPMTask> pagedTasks = tasks.stream()
+                .sorted()
+                .skip(pageIndex * pageSize)
+                .limit(pageSize)
+                .map(bpmTaskMapper::toDTO)
+                .collect(Collectors.toList());
+
+        return new Page<>(pageIndex, pageSize, totalPages, totalHits, pagedTasks);
+    }
+
+    public BPMTask getBPMTaskById(int taskId) {
+
+        Optional<BpmTask> task = bpmManager.getTaskById(taskId);
+        return bpmTaskMapper.toDTO(task.orElse(null));
+    }
+}

--- a/mapper/pom.xml
+++ b/mapper/pom.xml
@@ -41,6 +41,10 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
+            <artifactId>bpm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.pnc</groupId>
             <artifactId>moduleconfig</artifactId>
         </dependency>
         <dependency>

--- a/mapper/src/main/java/org/jboss/pnc/mapper/api/BPMTaskMapper.java
+++ b/mapper/src/main/java/org/jboss/pnc/mapper/api/BPMTaskMapper.java
@@ -1,0 +1,31 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.mapper.api;
+
+import org.jboss.pnc.bpm.BpmTask;
+import org.jboss.pnc.dto.internal.bpm.BPMTask;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(config = MapperCentralConfig.class)
+public interface BPMTaskMapper {
+
+    // TODO: ignoring events for now: waiting for NCL-4253
+    @Mapping(target = "events", ignore = true)
+    BPMTask toDTO(BpmTask task);
+}

--- a/rest-new/src/main/java/org/jboss/pnc/rest/JaxRsActivatorNew.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/JaxRsActivatorNew.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.rest;
 
 import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
 import org.jboss.pnc.rest.endpoints.ArtifactEndpointImpl;
+import org.jboss.pnc.rest.endpoints.BpmEndpointImpl;
 import org.jboss.pnc.rest.endpoints.BuildConfigurationEndpointImpl;
 import org.jboss.pnc.rest.endpoints.BuildEndpointImpl;
 import org.jboss.pnc.rest.endpoints.EnvironmentEndpointImpl;
@@ -90,6 +91,8 @@ public class JaxRsActivatorNew extends Application {
 
     private void addEndpoints(Set<Class<?>> resources) {
         resources.add(ArtifactEndpointImpl.class);
+
+        resources.add(BpmEndpointImpl.class);
 
         resources.add(BuildEndpointImpl.class);
 

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/BpmEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/BpmEndpointImpl.java
@@ -1,0 +1,49 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.endpoints;
+
+import org.jboss.pnc.dto.internal.bpm.BPMTask;
+import org.jboss.pnc.dto.response.Page;
+import org.jboss.pnc.facade.BpmController;
+import org.jboss.pnc.rest.api.endpoints.BpmEndpoint;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class BpmEndpointImpl implements BpmEndpoint {
+
+    @Inject
+    private BpmController bpmController;
+
+    @Override
+    public void notifyTask(int taskId) {
+        // NCL-4395
+        throw new UnsupportedOperationException("Not implemented yet!");
+    }
+
+    @Override
+    public Page<BPMTask> getBPMTasks(int pageIndex, int pageSize) {
+        return bpmController.getBPMTasks(pageIndex, pageSize);
+    }
+
+    @Override
+    public BPMTask getBPMTaskById(int taskId) {
+        return bpmController.getBPMTaskById(taskId);
+    }
+}


### PR DESCRIPTION
The 'notify' part is not yet implemented; waiting for NCL-4253.

The 'get all' and 'get specific' bpm tasks are implemented.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
