### PR TITLE
[NCL-4965] JAX-RS method to specify alt HTTP code

### DIFF
--- a/rest-api/src/main/java/org/jboss/pnc/rest/annotation/RespondWithStatus.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/annotation/RespondWithStatus.java
@@ -1,0 +1,29 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.annotation;
+
+import javax.ws.rs.NameBinding;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@NameBinding
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RespondWithStatus {
+
+    String value();
+}

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ArtifactEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ArtifactEndpoint.java
@@ -27,6 +27,7 @@ import org.jboss.pnc.dto.Artifact;
 import org.jboss.pnc.dto.response.ErrorResponse;
 import org.jboss.pnc.dto.response.Page;
 import org.jboss.pnc.processor.annotation.Client;
+import org.jboss.pnc.rest.annotation.RespondWithStatus;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.ArtifactPage;
 
@@ -106,6 +107,7 @@ public interface ArtifactEndpoint {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @POST
+    @RespondWithStatus(ENTITY_CREATED_CODE)
     Artifact create(@NotNull Artifact artifactRest);
 
     @Operation(summary = "[role:admin] Updates an existing Artifact",

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/BuildConfigurationEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/BuildConfigurationEndpoint.java
@@ -34,6 +34,7 @@ import org.jboss.pnc.dto.response.BuildConfigCreationResponse;
 import org.jboss.pnc.dto.response.ErrorResponse;
 import org.jboss.pnc.dto.response.Page;
 import org.jboss.pnc.processor.annotation.Client;
+import org.jboss.pnc.rest.annotation.RespondWithStatus;
 import org.jboss.pnc.rest.api.parameters.BuildParameters;
 import org.jboss.pnc.rest.api.parameters.BuildsFilterParameters;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
@@ -110,6 +111,7 @@ public interface BuildConfigurationEndpoint {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ENTITY_CREATED_CODE)
     BuildConfiguration createNew(@NotNull BuildConfiguration buildConfiguration);
 
     @Operation(summary = "Gets a specific build config.",
@@ -180,6 +182,7 @@ public interface BuildConfigurationEndpoint {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ACCEPTED_CODE)
     @Path("/{id}/build")
     Build trigger(
             @Parameter(description = BC_ID) @PathParam("id") int id,
@@ -210,6 +213,7 @@ public interface BuildConfigurationEndpoint {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ENTITY_CREATED_CODE)
     @Path("/{id}/clone")
     BuildConfiguration clone(@Parameter(description = BC_ID) @PathParam("id") int id);
 
@@ -298,6 +302,7 @@ public interface BuildConfigurationEndpoint {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ENTITY_CREATED_CODE)
     @Path("/{id}/revisions")
     BuildConfigurationRevision createRevision(
             @Parameter(description = BC_ID) @PathParam("id") int id,
@@ -329,6 +334,7 @@ public interface BuildConfigurationEndpoint {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ACCEPTED_CODE)
     @Path("/{id}/revisions/{rev}/build")
     Build triggerRevision(
             @Parameter(description = BC_ID) @PathParam("id") int id,
@@ -364,6 +370,7 @@ public interface BuildConfigurationEndpoint {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ACCEPTED_CODE)
     @Path("/create-with-scm")
     BuildConfigCreationResponse createWithSCM(BuildConfigWithSCMRequest request);
 

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/BuildEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/BuildEndpoint.java
@@ -34,6 +34,7 @@ import org.jboss.pnc.dto.response.Page;
 import org.jboss.pnc.dto.response.SSHCredentials;
 import org.jboss.pnc.enums.BuildStatus;
 import org.jboss.pnc.processor.annotation.Client;
+import org.jboss.pnc.rest.annotation.RespondWithStatus;
 import org.jboss.pnc.rest.api.parameters.BuildAttributeParameters;
 import org.jboss.pnc.rest.api.parameters.BuildsFilterParameters;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
@@ -233,6 +234,7 @@ public interface BuildEndpoint{
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ENTITY_CREATED_CODE)
     @Path("/{id}/attributes")
     void addAttribute(
             @Parameter(description = B_ID) @PathParam("id") int id,
@@ -277,6 +279,7 @@ public interface BuildEndpoint{
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ACCEPTED_CODE)
     @Path("/{id}/brew-push")
     BuildPushResult push(BuildPushRequest buildPushRequest);
 
@@ -304,6 +307,7 @@ public interface BuildEndpoint{
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ENTITY_CREATED_CODE)
     @Path("/{id}/brew-push/complete")
     BuildPushResult completePush(
             @Parameter(description = B_ID) @PathParam("id") int id,

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/GroupConfigurationEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/GroupConfigurationEndpoint.java
@@ -33,6 +33,7 @@ import org.jboss.pnc.dto.requests.GroupBuildRequest;
 import org.jboss.pnc.dto.response.ErrorResponse;
 import org.jboss.pnc.dto.response.Page;
 import org.jboss.pnc.processor.annotation.Client;
+import org.jboss.pnc.rest.annotation.RespondWithStatus;
 import org.jboss.pnc.rest.api.parameters.BuildsFilterParameters;
 import org.jboss.pnc.rest.api.parameters.GroupBuildParameters;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
@@ -107,6 +108,7 @@ public interface GroupConfigurationEndpoint{
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ENTITY_CREATED_CODE)
     GroupConfiguration createNew(@NotNull GroupConfiguration buildConfigurationSet);
 
     @Operation(summary = "Gets a specific group config.",
@@ -176,6 +178,7 @@ public interface GroupConfigurationEndpoint{
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ACCEPTED_CODE)
     @Path("/{id}/build")
     @Consumes(MediaType.APPLICATION_JSON)
     GroupBuild trigger(

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductEndpoint.java
@@ -28,6 +28,7 @@ import org.jboss.pnc.dto.ProductVersion;
 import org.jboss.pnc.dto.response.ErrorResponse;
 import org.jboss.pnc.dto.response.Page;
 import org.jboss.pnc.processor.annotation.Client;
+import org.jboss.pnc.rest.annotation.RespondWithStatus;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.ProductPage;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.ProductVersionPage;
@@ -91,6 +92,7 @@ public interface ProductEndpoint {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ENTITY_CREATED_CODE)
     Product createNew(@NotNull Product product);
 
     @Operation(summary = "Gets a specific product.",

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductMilestoneEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductMilestoneEndpoint.java
@@ -29,6 +29,7 @@ import org.jboss.pnc.dto.ProductMilestone;
 import org.jboss.pnc.dto.response.ErrorResponse;
 import org.jboss.pnc.dto.response.Page;
 import org.jboss.pnc.processor.annotation.Client;
+import org.jboss.pnc.rest.annotation.RespondWithStatus;
 import org.jboss.pnc.rest.api.parameters.BuildsFilterParameters;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.BuildPage;
@@ -83,6 +84,7 @@ public interface ProductMilestoneEndpoint{
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ENTITY_CREATED_CODE)
     ProductMilestone createNew(@NotNull ProductMilestone productMilestone);
 
     @Operation(summary = "Gets a specific product milestone.",

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductReleaseEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductReleaseEndpoint.java
@@ -28,6 +28,7 @@ import org.jboss.pnc.dto.ProductRelease;
 import org.jboss.pnc.dto.response.ErrorResponse;
 import org.jboss.pnc.enums.SupportLevel;
 import org.jboss.pnc.processor.annotation.Client;
+import org.jboss.pnc.rest.annotation.RespondWithStatus;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -77,6 +78,7 @@ public interface ProductReleaseEndpoint{
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ENTITY_CREATED_CODE)
     ProductRelease createNew(@NotNull ProductRelease productRelease);
 
     @Operation(summary = "Gets a specific product release.",

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductVersionEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductVersionEndpoint.java
@@ -31,6 +31,7 @@ import org.jboss.pnc.dto.ProductVersion;
 import org.jboss.pnc.dto.response.ErrorResponse;
 import org.jboss.pnc.dto.response.Page;
 import org.jboss.pnc.processor.annotation.Client;
+import org.jboss.pnc.rest.annotation.RespondWithStatus;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.BuildConfigPage;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.GroupConfigPage;
@@ -84,6 +85,7 @@ public interface ProductVersionEndpoint{
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @POST
+    @RespondWithStatus(ENTITY_CREATED_CODE)
     ProductVersion createNewProductVersion(@NotNull ProductVersion productVersion);
 
     @Operation(summary = "Gets a specific product version.",

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProjectEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProjectEndpoint.java
@@ -29,6 +29,7 @@ import org.jboss.pnc.dto.Project;
 import org.jboss.pnc.dto.response.ErrorResponse;
 import org.jboss.pnc.dto.response.Page;
 import org.jboss.pnc.processor.annotation.Client;
+import org.jboss.pnc.rest.annotation.RespondWithStatus;
 import org.jboss.pnc.rest.api.parameters.BuildsFilterParameters;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.BuildConfigPage;
@@ -98,6 +99,7 @@ public interface ProjectEndpoint{
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ENTITY_CREATED_CODE)
     Project createNew(@NotNull Project project);
 
     @Operation(summary = "Gets a specific project.",

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/SCMRepositoryEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/SCMRepositoryEndpoint.java
@@ -29,6 +29,7 @@ import org.jboss.pnc.dto.response.ErrorResponse;
 import org.jboss.pnc.dto.response.Page;
 import org.jboss.pnc.dto.response.RepositoryCreationResponse;
 import org.jboss.pnc.processor.annotation.Client;
+import org.jboss.pnc.rest.annotation.RespondWithStatus;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.SCMRepositoryPage;
 
@@ -149,6 +150,7 @@ public interface SCMRepositoryEndpoint{
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
+    @RespondWithStatus(ACCEPTED_CODE)
     @Path("/create-and-sync")
     RepositoryCreationResponse createNew(@NotNull CreateAndSyncSCMRequest request);
 }

--- a/rest-new/src/main/java/org/jboss/pnc/rest/JaxRsActivatorNew.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/JaxRsActivatorNew.java
@@ -33,6 +33,7 @@ import org.jboss.pnc.rest.endpoints.SCMRepositoryEndpointImpl;
 import org.jboss.pnc.rest.endpoints.UserEndpointImpl;
 import org.jboss.pnc.rest.jackson.JacksonProvider;
 import org.jboss.pnc.rest.provider.AllOtherExceptionsMapper;
+import org.jboss.pnc.rest.provider.RespondWithStatusFilter;
 import org.jboss.resteasy.plugins.interceptors.CorsFilter;
 
 import javax.ws.rs.ApplicationPath;
@@ -63,6 +64,7 @@ public class JaxRsActivatorNew extends Application {
         addSwaggerResources(resources);
         addProjectResources(resources);
         addMetricsResources(resources);
+        addRespondWithStatusFilter(resources);
         addProviders(resources);
         return resources;
     }
@@ -114,9 +116,12 @@ public class JaxRsActivatorNew extends Application {
     private void addMetricsResources(Set<Class<?>> resources) {
     }
 
+    private void addRespondWithStatusFilter(Set<Class<?>> resources) {
+        resources.add(RespondWithStatusFilter.class);
+    }
+
     private void addProviders(Set<Class<?>> resources) {
         resources.add(JacksonProvider.class);
     }
-
 
 }

--- a/rest-new/src/main/java/org/jboss/pnc/rest/provider/RespondWithStatusFilter.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/provider/RespondWithStatusFilter.java
@@ -1,0 +1,45 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.provider;
+
+import org.jboss.pnc.rest.annotation.RespondWithStatus;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+
+@Provider
+public class RespondWithStatusFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) throws IOException {
+
+        // for any 2xx status code, this gets activated
+        if (containerResponseContext.getStatus() / 100 == 2) {
+            for (Annotation annotation : containerResponseContext.getEntityAnnotations()) {
+                if (annotation instanceof RespondWithStatus) {
+                    containerResponseContext.setStatus(Integer.parseInt(((RespondWithStatus) annotation).value()));
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
With the current strategy of implementing our REST endpoints, if
successful the JAX-RS method will always return with HTTP status 200 (or 204 if
we return void). This is because we now return the DTO in our JAX-RS
method instead of the `Response` object where we can specify the HTTP
status code.

This is problematic because we are expected to return HTTP status 201
(for creation of new stuff), and 202 for async accepted operations.

This commit adds a new annotation, `@RespondWithStatus`, to allow us to
annotate JAX-RS method with the appropriate HTTP status code. A filter
will intercept the annotation and update the HTTP to the one specified
in the annotation. The filter will only activate if a 2xx status is
returned from the JAX-RS method (typically 200 or 204)

The annotation strangely accepts the HTTP status code as a string so as
to be in harmony with the constants used in the OpenAPI documentation.
It is converted behind the scenes into an integer.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
