### PR TITLE
[NCL-4960] Appropriate http code for create-and-sync

### DIFF
--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/SCMRepositoryEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/SCMRepositoryEndpoint.java
@@ -141,8 +141,10 @@ public interface SCMRepositoryEndpoint{
     @Operation(summary = "Creates a new SCM repository.",
             description = "If the given URL is external, it does create the repository in the scm server.",
             responses = {
-                @ApiResponse(responseCode = ACCEPTED_CODE, description = ACCEPTED_DESCRIPTION,
+                @ApiResponse(responseCode = ACCEPTED_CODE, description = "SCM repository request is being created",
                     content = @Content(schema = @Schema(implementation = RepositoryCreationResponse.class))),
+                @ApiResponse(responseCode = SUCCESS_CODE, description = "SCM repository is already present in PNC",
+                        content = @Content(schema = @Schema(implementation = RepositoryCreationResponse.class))),
                 @ApiResponse(responseCode = INVALID_CODE, description = INVALID_DESCRIPTION,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                 @ApiResponse(responseCode = CONFLICTED_CODE, description = CONFLICTED_DESCRIPTION,
@@ -151,7 +153,6 @@ public interface SCMRepositoryEndpoint{
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @POST
-    @RespondWithStatus(Response.Status.ACCEPTED)
     @Path("/create-and-sync")
     RepositoryCreationResponse createNew(@NotNull CreateAndSyncSCMRequest request);
 }


### PR DESCRIPTION
For the scm-repositories/create-any-sync endpoint, we should return the
appropriate HTTP status code for the following scenarios:

- scm repository already exists in the PNC database (HTTP code: 200)
- scm repository is being created (HTTP code: 202)

The implementation uses `HttpServletResponse`. The `flushBuffer` method
call is required, based on experiments. Otherwise the desired http code
is never set.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
