### PR TITLE
[NCL-5077] workaround for RepositoryManagerResultRest not having TargetRepo

### DIFF
--- a/mapper/src/main/java/org/jboss/pnc/mapper/api/TargetRepositoryMapper.java
+++ b/mapper/src/main/java/org/jboss/pnc/mapper/api/TargetRepositoryMapper.java
@@ -33,15 +33,10 @@ public interface TargetRepositoryMapper extends EntityMapper<TargetRepository, o
     @Mapping(target = "artifacts", source = "artifactIds")
     TargetRepository toEntity(org.jboss.pnc.dto.TargetRepository dtoEntity);
 
+    //Workaround for NCL-5077
     @Override
-    default TargetRepository toIDEntity(TargetRepositoryRef dtoEntity) {
-        if (dtoEntity == null) {
-            return null;
-        }
-        TargetRepository repository = new TargetRepository();
-        repository.setId(dtoEntity.getId());
-        return repository;
-    }
+    @Mapping(target = "artifacts", ignore = true)
+    TargetRepository toIDEntity(TargetRepositoryRef dtoEntity);
 
     @Override
     @Mapping(target = "artifactIds", source = "artifacts")


### PR DESCRIPTION
Kinda screws with mapper consistency but we can revert it later

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
