### PR TITLE
Apply PATCH workaround for REST endpoints

### DIFF
--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductEndpoint.java
@@ -106,6 +106,7 @@ public interface ProductEndpoint {
     })
     @GET
     @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON_PATCH_JSON) // workaround for PATCH support
     Product getSpecific(@Parameter(description = P_ID) @PathParam("id") String id);
 
     @Operation(summary = "Updates an existing product.",

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductMilestoneEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductMilestoneEndpoint.java
@@ -98,6 +98,7 @@ public interface ProductMilestoneEndpoint{
     })
     @GET
     @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON_PATCH_JSON) // workaround for PATCH support
     ProductMilestone getSpecific(@Parameter(description = PM_ID) @PathParam("id") String id);
 
     @Operation(summary = "Updates an existing product milestone.",

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductReleaseEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductReleaseEndpoint.java
@@ -92,6 +92,7 @@ public interface ProductReleaseEndpoint{
     })
     @GET
     @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON_PATCH_JSON) // workaround for PATCH support
     ProductRelease getSpecific(@Parameter(description = PR_ID) @PathParam("id") String id);
 
     @Operation(summary = "Updates an existing product release.",

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductVersionEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductVersionEndpoint.java
@@ -99,6 +99,7 @@ public interface ProductVersionEndpoint{
     })
     @GET
     @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON_PATCH_JSON) // workaround for PATCH support
     ProductVersion getSpecific(@Parameter(description = PV_ID) @PathParam("id") String id);
 
     @Operation(summary = "Updates an existing product version.",

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/SCMRepositoryEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/SCMRepositoryEndpoint.java
@@ -103,6 +103,7 @@ public interface SCMRepositoryEndpoint{
     })
     @GET
     @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON_PATCH_JSON) // workaround for PATCH support
     SCMRepository getSpecific(@Parameter(description = SCM_ID) @PathParam("id") String id);
 
     @Operation(summary = "Updates an existing SCM repository.",


### PR DESCRIPTION
From a558bdf commit, an extra `@Consumes(MediaType.APPLICATION_JSON_PATCH_JSON)`
is required on `getSpecific` methods whose class contains a
`patchSpecific` method with `@PATCH` annotation.

This commit applies the extra `@Consumes` on all the other endpoints.
The `ProjectEndpoint.java` does not have the fix because it is already
included in PR #2589

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
