### PR TITLE
[v1.8][NCL-5267] Log duration of stage in PNC

### DIFF
--- a/build-coordinator/pom.xml
+++ b/build-coordinator/pom.xml
@@ -219,7 +219,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <!-- /Test coverage -->

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/BuildTasksInitializer.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/BuildTasksInitializer.java
@@ -18,7 +18,9 @@
 
 package org.jboss.pnc.coordinator.builder;
 
+import org.apache.commons.lang3.time.StopWatch;
 import org.jboss.pnc.common.mdc.MDCUtils;
+import org.jboss.pnc.common.util.BuildStageUtils;
 import org.jboss.pnc.coordinator.builder.datastore.DatastoreAdapter;
 import org.jboss.pnc.model.BuildConfigSetRecord;
 import org.jboss.pnc.model.BuildConfiguration;
@@ -41,6 +43,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -65,6 +68,8 @@ public class BuildTasksInitializer {
                                            BuildOptions buildOptions,
                                            Supplier<Integer> buildTaskIdProvider,
                                            Set<BuildTask> submittedBuildTasks) {
+
+        StopWatch stopWatch = StopWatch.createStarted();
         BuildSetTask buildSetTask =
                 BuildSetTask.Builder.newBuilder()
                         .buildOptions(buildOptions)
@@ -84,6 +89,8 @@ public class BuildTasksInitializer {
                 submittedBuildTasks,
                 buildOptions);
 
+        stopWatch.stop();
+        BuildStageUtils.logBuildStage("Scheduling", stopWatch.getTime(TimeUnit.SECONDS));
         return buildSetTask;
     }
 

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
@@ -17,12 +17,14 @@
  */
 package org.jboss.pnc.coordinator.builder;
 
+import org.apache.commons.lang3.time.StopWatch;
 import org.jboss.pnc.common.concurrent.MDCExecutors;
 import org.jboss.pnc.common.concurrent.NamedThreadFactory;
 import org.jboss.pnc.common.json.moduleconfig.SystemConfig;
 import org.jboss.pnc.common.mdc.BuildTaskContext;
 import org.jboss.pnc.common.mdc.MDCUtils;
 import org.jboss.pnc.common.monitor.PullingMonitor;
+import org.jboss.pnc.common.util.BuildStageUtils;
 import org.jboss.pnc.coordinator.BuildCoordinationException;
 import org.jboss.pnc.coordinator.builder.datastore.DatastoreAdapter;
 import org.jboss.pnc.model.BuildConfigSetRecord;
@@ -65,6 +67,7 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -635,6 +638,12 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
                 log.error("Unable to store error [" + error.getMessage() + "] of build coordination task [" + task.getId() + "].", e1);
             }
             throw error;
+        } finally {
+            if (task.getSubmitTime() != null) {
+                BuildStageUtils.logBuildStage("Enqueued", ChronoUnit.SECONDS.between(task.getSubmitTime().toInstant(), Instant.now()));
+            } else {
+                BuildStageUtils.logBuildStage("Enqueued", 0);
+            }
         }
     }
 

--- a/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionSession.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionSession.java
@@ -18,6 +18,8 @@
 
 package org.jboss.pnc.executor;
 
+import org.apache.commons.lang3.time.StopWatch;
+import org.jboss.pnc.common.util.BuildStageUtils;
 import org.jboss.pnc.spi.BuildExecutionStatus;
 import org.jboss.pnc.spi.BuildResult;
 import org.jboss.pnc.spi.builddriver.BuildDriverResult;
@@ -37,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import java.net.URI;
 import java.util.Date;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static org.jboss.pnc.spi.BuildExecutionStatus.DONE_WITH_ERRORS;
@@ -66,6 +69,8 @@ public class DefaultBuildExecutionSession implements BuildExecutionSession {
     private Runnable cancelHook;
 
     private String accessToken;
+
+    private final StopWatch stopWatch = StopWatch.createStarted();
 
     public DefaultBuildExecutionSession(BuildExecutionConfiguration buildExecutionConfiguration,
                                         Consumer<BuildExecutionStatusChangedEvent> onBuildExecutionStatusChangedEvent) {
@@ -132,6 +137,12 @@ public class DefaultBuildExecutionSession implements BuildExecutionSession {
         this.status = status;
         onBuildExecutionStatusChangedEvent.accept(statusChanged);
         log.debug("Fired events after build execution task {} update.", getId());
+
+        BuildStageUtils.logBuildStage(status.toString(), stopWatch.getTime(TimeUnit.SECONDS));
+
+        // reset and start to note the duration to the next status being done
+        stopWatch.reset();
+        stopWatch.start();
     }
 
     private BuildResult getBuildResult() {

--- a/common/src/main/java/org/jboss/pnc/common/util/BuildStageUtils.java
+++ b/common/src/main/java/org/jboss/pnc/common/util/BuildStageUtils.java
@@ -37,7 +37,7 @@ public class BuildStageUtils {
      * @param buildStage build stage who's duration we're logging
      * @param duration in seconds
      */
-    public static void logBuildStage(String buildStage, int duration) {
+    public static void logBuildStage(String buildStage, long duration) {
 
         Map<String, String> mdc = MDC.getCopyOfContextMap();
         if (mdc == null) {

--- a/common/src/main/java/org/jboss/pnc/common/util/BuildStageUtils.java
+++ b/common/src/main/java/org/jboss/pnc/common/util/BuildStageUtils.java
@@ -1,0 +1,52 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.common.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class BuildStageUtils {
+
+    public static final String MDC_BUILD_STAGE = "build_stage";
+    public static final String MDC_BUILD_STAGE_DURATION = "build_stage_duration";
+
+    /**
+     * Log the build stage's duration.
+     *
+     * Note that in the future this might be modified to send logs via Kafka
+     *
+     * @param buildStage build stage who's duration we're logging
+     * @param duration in seconds
+     */
+    public static void logBuildStage(String buildStage, int duration) {
+
+        Map<String, String> mdc = MDC.getCopyOfContextMap();
+        if (mdc == null) {
+            mdc = new HashMap<>();
+        }
+        mdc.put(MDC_BUILD_STAGE, buildStage);
+        mdc.put(MDC_BUILD_STAGE_DURATION, String.valueOf(duration));
+        MDC.setContextMap(mdc);
+
+        log.info("END: {}, took: {} seconds", buildStage, duration);
+    }
+}


### PR DESCRIPTION
This PR provides:

- a static method to log the build stage completed and the duration in seconds
  - the static method can potentially be augmented in the future to send messages to other services later if required
- log the duration of the different phases in PNC-Orch (Repour and Causeway durations are not logged yet)

The build stages logged are:

- Scheduling (when a build config is being broken down into build tasks)
- Enqueued (the amount of time the build stayed in enqueued state)

- The various stages in `BuildExecutionStatus`
  * NEW,
  * REPO_SETTING_UP,
  * BUILD_ENV_SETTING_UP,
  * BUILD_ENV_WAITING,
  * BUILD_ENV_SETUP_COMPLETE_SUCCESS,
  * BUILD_SETTING_UP,
  * BUILD_WAITING,
  * COLLECTING_RESULTS_FROM_BUILD_DRIVER,
  * COLLECTING_RESULTS_FROM_REPOSITORY_MANAGER,
  * REPOSITORY_MANAGER_SEALING_TRACKING_RECORD,
  * REPOSITORY_MANAGER_DOWNLOADING_TRACKING_REPORT,
  * REPOSITORY_MANAGER_PROCESSING_DEPENDENCIES,
  * REPOSITORY_MANAGER_PROCESSING_BUILT_ARTIFACTS,
  * REPOSITORY_MANAGER_REMOVE_BUILD_AGGREGATION_GROUP,
  * REPOSITORY_MANAGER_PROMOTION_BUILD_CONTENT_SET,
  * COLLECTING_RESULTS_FROM_REPOSITORY_MANAGER_COMPLETED_SUCCESS,
  * BUILD_COMPLETED_SUCCESS,
  * BUILD_ENV_DESTROYING,
  * BUILD_ENV_DESTROYED,
  * FINALIZING_EXECUTION,

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
