### PR TITLE
[v1.8][NCL-5267] Log PNC build related stages begin and end

### DIFF
--- a/build-coordinator/pom.xml
+++ b/build-coordinator/pom.xml
@@ -219,7 +219,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <!-- /Test coverage -->

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/BuildTasksInitializer.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/BuildTasksInitializer.java
@@ -19,6 +19,7 @@
 package org.jboss.pnc.coordinator.builder;
 
 import org.jboss.pnc.common.mdc.MDCUtils;
+import org.jboss.pnc.common.util.ProcessStageUtils;
 import org.jboss.pnc.coordinator.builder.datastore.DatastoreAdapter;
 import org.jboss.pnc.model.BuildConfigSetRecord;
 import org.jboss.pnc.model.BuildConfiguration;
@@ -65,6 +66,9 @@ public class BuildTasksInitializer {
                                            BuildOptions buildOptions,
                                            Supplier<Integer> buildTaskIdProvider,
                                            Set<BuildTask> submittedBuildTasks) {
+
+        ProcessStageUtils.logProcessStageBegin("Scheduling");
+
         BuildSetTask buildSetTask =
                 BuildSetTask.Builder.newBuilder()
                         .buildOptions(buildOptions)
@@ -84,6 +88,7 @@ public class BuildTasksInitializer {
                 submittedBuildTasks,
                 buildOptions);
 
+        ProcessStageUtils.logProcessStageEnd("Scheduling");
         return buildSetTask;
     }
 
@@ -281,6 +286,7 @@ public class BuildTasksInitializer {
                         productMilestone,
                         buildContentId);
                 log.debug("Created new buildTask {} for BuildConfigurationAudited {}.", buildTask, buildConfigAudited);
+                ProcessStageUtils.logProcessStageBegin("Enqueued");
             }
 
             buildSetTask.addBuildTask(buildTask);

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
@@ -23,6 +23,7 @@ import org.jboss.pnc.common.json.moduleconfig.SystemConfig;
 import org.jboss.pnc.common.mdc.BuildTaskContext;
 import org.jboss.pnc.common.mdc.MDCUtils;
 import org.jboss.pnc.common.monitor.PullingMonitor;
+import org.jboss.pnc.common.util.ProcessStageUtils;
 import org.jboss.pnc.coordinator.BuildCoordinationException;
 import org.jboss.pnc.coordinator.builder.datastore.DatastoreAdapter;
 import org.jboss.pnc.model.BuildConfigSetRecord;
@@ -635,6 +636,8 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
                 log.error("Unable to store error [" + error.getMessage() + "] of build coordination task [" + task.getId() + "].", e1);
             }
             throw error;
+        } finally {
+            ProcessStageUtils.logProcessStageEnd("Enqueued");
         }
     }
 

--- a/common/src/main/java/org/jboss/pnc/common/util/ProcessStageUtils.java
+++ b/common/src/main/java/org/jboss/pnc/common/util/ProcessStageUtils.java
@@ -1,0 +1,66 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.common.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ProcessStageUtils {
+
+    private static final Logger log = LoggerFactory.getLogger("org.jboss.pnc._userlog_.process-stage-update");
+    public static final String MDC_PROCESS_STAGE_NAME = "process_stage_name";
+    public static final String MDC_PROCESS_STAGE_STEP = "process_stage_step";
+
+    /**
+     * Log the process stage's begin and end stage
+     *
+     * Note that in the future this might be modified to send logs via Kafka
+     *
+     * @param processStage process stage name
+
+     */
+    public static void logProcessStage(String processStage, Step step) {
+
+        Map<String, String> mdc = MDC.getCopyOfContextMap();
+        if (mdc == null) {
+            mdc = new HashMap<>();
+        }
+
+        try (MDC.MDCCloseable a = MDC.putCloseable(MDC_PROCESS_STAGE_NAME, processStage);
+             MDC.MDCCloseable b = MDC.putCloseable(MDC_PROCESS_STAGE_STEP, step.toString())) {
+
+            log.info("{}: {} ", step, processStage);
+        }
+    }
+
+    public static void logProcessStageBegin(String processStage) {
+        logProcessStage(processStage, Step.BEGIN);
+    }
+
+    public static void logProcessStageEnd(String processStage) {
+        logProcessStage(processStage, Step.END);
+    }
+
+    public enum Step {
+        BEGIN, END
+    }
+}


### PR DESCRIPTION
The build stages logged are:

- Scheduling (when a build config is being broken down into build tasks)
- Enqueued (build stayed in enqueued state)

- The various stages in `BuildExecutionStatus`
  * NEW,
  * REPO_SETTING_UP,
  * BUILD_ENV_SETTING_UP,
  * BUILD_ENV_WAITING,
  * BUILD_ENV_SETUP_COMPLETE_SUCCESS,
  * BUILD_SETTING_UP,
  * BUILD_WAITING,
  * COLLECTING_RESULTS_FROM_BUILD_DRIVER,
  * COLLECTING_RESULTS_FROM_REPOSITORY_MANAGER,
  * REPOSITORY_MANAGER_SEALING_TRACKING_RECORD,
  * REPOSITORY_MANAGER_DOWNLOADING_TRACKING_REPORT,
  * REPOSITORY_MANAGER_PROCESSING_DEPENDENCIES,
  * REPOSITORY_MANAGER_PROCESSING_BUILT_ARTIFACTS,
  * REPOSITORY_MANAGER_REMOVE_BUILD_AGGREGATION_GROUP,
  * REPOSITORY_MANAGER_PROMOTION_BUILD_CONTENT_SET,
  * COLLECTING_RESULTS_FROM_REPOSITORY_MANAGER_COMPLETED_SUCCESS,
  * BUILD_COMPLETED_SUCCESS,
  * BUILD_ENV_DESTROYING,
  * BUILD_ENV_DESTROYED,
  * FINALIZING_EXECUTION,

While this PR doesn't try to log into Kafka directly, it is useful to identify if everything is being logged properly in Kibana. The next step would be to modify the static method logging the changes to send the data to a particular kafka topic.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
