### PR TITLE
[NCL-4581] Add health check endpoint for PNC

### DIFF
--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/HealthCheckRepositoryImpl.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/HealthCheckRepositoryImpl.java
@@ -1,0 +1,43 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.datastore.repositories;
+
+import org.jboss.pnc.datastore.repositories.internal.AbstractRepository;
+import org.jboss.pnc.datastore.repositories.internal.HealthCheckSpringRepository;
+import org.jboss.pnc.model.HealthCheck;
+import org.jboss.pnc.spi.datastore.repositories.HealthCheckRepository;
+
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+
+@Stateless
+public class HealthCheckRepositoryImpl extends AbstractRepository<HealthCheck, Integer> implements HealthCheckRepository {
+
+    /**
+     * @deprecated Created for CDI.
+     */
+    @Deprecated
+    public HealthCheckRepositoryImpl() {
+        super(null, null);
+    }
+
+    @Inject
+    public HealthCheckRepositoryImpl(HealthCheckSpringRepository healthCheckSpringRepository) {
+        super(healthCheckSpringRepository, healthCheckSpringRepository);
+    }
+}

--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/internal/HealthCheckSpringRepository.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/internal/HealthCheckSpringRepository.java
@@ -1,0 +1,30 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.datastore.repositories.internal;
+
+import org.jboss.pnc.model.HealthCheck;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import javax.enterprise.context.Dependent;
+
+@Dependent
+public interface HealthCheckSpringRepository extends JpaRepository<HealthCheck, Integer>,
+        JpaSpecificationExecutor<HealthCheck> {
+
+}

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/HealthCheckProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/HealthCheckProviderImpl.java
@@ -1,0 +1,82 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.facade.providers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jboss.pnc.facade.providers.api.HealthCheckProvider;
+import org.jboss.pnc.model.HealthCheck;
+import org.jboss.pnc.spi.datastore.repositories.HealthCheckRepository;
+
+import javax.annotation.security.PermitAll;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@PermitAll
+@Stateless
+@Slf4j
+public class HealthCheckProviderImpl implements HealthCheckProvider {
+
+    @Inject
+    private HealthCheckRepository healthCheckRepository;
+
+    public Map<String, Boolean> check() {
+
+        Map<String, Boolean> result = new HashMap<>();
+        result.put("check-database-read", checkDatabaseRead());
+        result.put("check-database-write", checkDatabaseWrite());
+
+        return result;
+    }
+
+    private boolean checkDatabaseRead() {
+        try {
+            healthCheckRepository.queryAll().size();
+            return true;
+        } catch (Exception e) {
+            log.error("Error while reading from database", e);
+            return false;
+        }
+    }
+
+    private boolean checkDatabaseWrite() {
+
+        try {
+            List<HealthCheck> healthCheckList = healthCheckRepository.queryAll();
+
+            HealthCheck healthCheck;
+
+            if (healthCheckList.size() > 0) {
+                healthCheck = healthCheckList.get(0);
+            } else {
+                healthCheck = new HealthCheck();
+            }
+
+            healthCheck.setDate(new Date());
+            healthCheckRepository.save(healthCheck);
+
+            return true;
+        } catch (Exception e) {
+            log.error("Error while writing to database", e);
+            return false;
+        }
+    }
+}

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/api/HealthCheckProvider.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/api/HealthCheckProvider.java
@@ -1,0 +1,31 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.facade.providers.api;
+
+import java.util.Map;
+
+public interface HealthCheckProvider {
+
+    /**
+     * Checks for the system's health should be performed in this method. The returned map should
+     * contain the description of the test, and whether it passed or not
+     *
+     * @return results
+     */
+    Map<String, Boolean> check();
+}

--- a/model/src/main/java/org/jboss/pnc/model/HealthCheck.java
+++ b/model/src/main/java/org/jboss/pnc/model/HealthCheck.java
@@ -1,0 +1,56 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.model;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import java.util.Date;
+
+@Entity
+public class HealthCheck implements GenericEntity<Integer> {
+
+    public static final String SEQUENCE_NAME = "healthcheck_id_seq";
+
+    @Id
+    @SequenceGenerator(name = SEQUENCE_NAME, sequenceName = SEQUENCE_NAME, allocationSize = 1, initialValue = 100)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = SEQUENCE_NAME)
+    private Integer id;
+
+    private Date date;
+
+    @Override
+    public Integer getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+}

--- a/rest-new/src/main/java/org/jboss/pnc/rest/JaxRsActivatorNew.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/JaxRsActivatorNew.java
@@ -36,6 +36,7 @@ import org.jboss.pnc.rest.endpoints.SCMRepositoryEndpointImpl;
 import org.jboss.pnc.rest.endpoints.UserEndpointImpl;
 import org.jboss.pnc.rest.endpoints.internal.BpmEndpointImpl;
 import org.jboss.pnc.rest.endpoints.internal.BuildTaskEndpointImpl;
+import org.jboss.pnc.rest.endpoints.internal.HealthCheckEndpointImpl;
 import org.jboss.pnc.rest.jackson.JacksonProvider;
 import org.jboss.pnc.rest.provider.AllOtherExceptionsMapper;
 import org.jboss.pnc.rest.provider.BuildConflictExceptionMapper;
@@ -208,6 +209,8 @@ public class JaxRsActivatorNew extends Application {
         resources.add(UserEndpointImpl.class);
 
         resources.add(BuildRecordAliasEndpointImpl.class);
+
+        resources.add(HealthCheckEndpointImpl.class);
     }
 
     private void addExceptionMappers(Set<Class<?>> resources) {

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/internal/HealthCheckEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/internal/HealthCheckEndpointImpl.java
@@ -1,0 +1,54 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.endpoints.internal;
+
+import org.jboss.pnc.facade.providers.api.HealthCheckProvider;
+import org.jboss.pnc.rest.endpoints.internal.api.HealthCheckEndpoint;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+@ApplicationScoped
+public class HealthCheckEndpointImpl implements HealthCheckEndpoint {
+
+    @Inject
+    private HealthCheckProvider healthCheckProvider;
+
+    @Override
+    public Response check() {
+        return generateResponseFromResult(healthCheckProvider.check());
+    }
+
+    private Response generateResponseFromResult(Map<String, Boolean> result) {
+        if (result == null) {
+            return Response.serverError().build();
+        } else {
+
+            boolean atLeastOneCheckFailed = result.entrySet().stream().anyMatch(e -> !e.getValue());
+
+            if (atLeastOneCheckFailed) {
+                return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(result).build();
+            } else {
+                return Response.ok(result).build();
+            }
+        }
+
+    }
+}

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/internal/api/HealthCheckEndpoint.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/internal/api/HealthCheckEndpoint.java
@@ -1,0 +1,46 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.endpoints.internal.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.SERVER_ERROR_CODE;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.SUCCESS_CODE;
+
+@Tag(name = "Internal")
+@Path("/health")
+@Produces(MediaType.APPLICATION_JSON)
+public interface HealthCheckEndpoint {
+
+    @Operation(summary = "Performs health checks on the system to see if all the components are go",
+            responses = {
+                    @ApiResponse(responseCode = SUCCESS_CODE, description = "Success"),
+                    @ApiResponse(responseCode = SERVER_ERROR_CODE, description = "At least one of the health checks has failed")
+            })
+    @GET
+    Response check();
+}

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/HealthCheckRepository.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/HealthCheckRepository.java
@@ -1,0 +1,27 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.spi.datastore.repositories;
+
+import org.jboss.pnc.model.HealthCheck;
+import org.jboss.pnc.spi.datastore.repositories.api.Repository;
+
+/**
+ * Interface for manipulating {@link org.jboss.pnc.model.HealthCheck} entity.
+ */
+public interface HealthCheckRepository extends Repository<HealthCheck, Integer> {
+}


### PR DESCRIPTION
Right now the health check done are:

- check that we can read from database
- check that we can write to database

The endpoint will return 500 if *any* of the checks fail, otherwise 200.

More checks can be added in the `HealthCheckProviderImpl` in the future.

We decided to not use the Microprofile health since it is in technology
preview for EAP 7.2.x. At the point of writing, we are using EAP 7.2.x
for PNC.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
