### PR TITLE
[v1.8][NCL-5254] Move the keycloak client secret to a path

### DIFF
--- a/auth/src/test/resources/testConfig.json
+++ b/auth/src/test/resources/testConfig.json
@@ -16,7 +16,7 @@
             "ssl-required": "none",
             "resource": "pnc-orchestrator",
             "credentials": {
-              "secret": "1234-5678-..."
+              "secretFileLocation": "/tmp/super-secret"
             }
           }
         }

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/KeycloakClientConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/KeycloakClientConfig.java
@@ -21,14 +21,19 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.jboss.pnc.common.util.IoUtils;
 
 import javax.ws.rs.DefaultValue;
+import java.io.File;
+import java.io.IOException;
 import java.util.Map;
 
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
  */
 @Getter
+@Slf4j
 public class KeycloakClientConfig {
     private final String realm;
     private final String realmPublicKey;
@@ -55,6 +60,12 @@ public class KeycloakClientConfig {
 
     @JsonIgnore
     public String getSecret() {
-        return credentials.get("secret");
+        String secretPath = credentials.get("secretFileLocation");
+        try {
+            return IoUtils.readFileAsString(new File(secretPath)).trim();
+        } catch(IOException e) {
+            log.error("Error while getting secret token", e);
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/pnc-mock/src/main/resources/keycloakClientConfig.json
+++ b/pnc-mock/src/main/resources/keycloakClientConfig.json
@@ -5,6 +5,6 @@
     "ssl-required": "none",
     "resource": "pnc-orchestrator",
     "credentials": {
-        "secret": "abc1234-123abc-..."
+        "secretFileLocation": "/tmp/super-secret"
     }
 }


### PR DESCRIPTION
This is done so that we don't leak our secret in our main config file.

As such, the change required in the config file is from:

```
credentials: {
    "secret": "super-secret-token"
}
```

to:

```
credentials: {
    "secretFileLocation": "/path/to/file/that/contains/token"
}
```

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [x] Have you added unit tests for your change?
