### PR TITLE
[v1.8] Replace entity healthcheck with generic setting

### DIFF
--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/GenericSettingRepositoryImpl.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/GenericSettingRepositoryImpl.java
@@ -18,26 +18,32 @@
 package org.jboss.pnc.datastore.repositories;
 
 import org.jboss.pnc.datastore.repositories.internal.AbstractRepository;
-import org.jboss.pnc.datastore.repositories.internal.HealthCheckSpringRepository;
-import org.jboss.pnc.model.HealthCheck;
-import org.jboss.pnc.spi.datastore.repositories.HealthCheckRepository;
+import org.jboss.pnc.datastore.repositories.internal.GenericSettingSpringRepository;
+import org.jboss.pnc.model.GenericSetting;
+import org.jboss.pnc.spi.datastore.predicates.GenericSettingPredicates;
+import org.jboss.pnc.spi.datastore.repositories.GenericSettingRepository;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 
 @Stateless
-public class HealthCheckRepositoryImpl extends AbstractRepository<HealthCheck, Integer> implements HealthCheckRepository {
+public class GenericSettingRepositoryImpl extends AbstractRepository<GenericSetting, Integer> implements GenericSettingRepository {
 
     /**
      * @deprecated Created for CDI.
      */
     @Deprecated
-    public HealthCheckRepositoryImpl() {
+    public GenericSettingRepositoryImpl() {
         super(null, null);
     }
 
     @Inject
-    public HealthCheckRepositoryImpl(HealthCheckSpringRepository healthCheckSpringRepository) {
-        super(healthCheckSpringRepository, healthCheckSpringRepository);
+    public GenericSettingRepositoryImpl(GenericSettingSpringRepository genericSettingSpringRepository) {
+        super(genericSettingSpringRepository, genericSettingSpringRepository);
+    }
+
+    @Override
+    public GenericSetting queryByKey(String key) {
+        return queryByPredicates(GenericSettingPredicates.withKey(key));
     }
 }

--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/internal/GenericSettingSpringRepository.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/internal/GenericSettingSpringRepository.java
@@ -15,13 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.pnc.spi.datastore.repositories;
+package org.jboss.pnc.datastore.repositories.internal;
 
-import org.jboss.pnc.model.HealthCheck;
-import org.jboss.pnc.spi.datastore.repositories.api.Repository;
+import org.jboss.pnc.model.GenericSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-/**
- * Interface for manipulating {@link org.jboss.pnc.model.HealthCheck} entity.
- */
-public interface HealthCheckRepository extends Repository<HealthCheck, Integer> {
+import javax.enterprise.context.Dependent;
+
+@Dependent
+public interface GenericSettingSpringRepository extends JpaRepository<GenericSetting, Integer>,
+        JpaSpecificationExecutor<GenericSetting> {
 }

--- a/model/src/main/java/org/jboss/pnc/model/GenericSetting.java
+++ b/model/src/main/java/org/jboss/pnc/model/GenericSetting.java
@@ -17,24 +17,38 @@
  */
 package org.jboss.pnc.model;
 
+import org.hibernate.annotations.Type;
+
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Lob;
 import javax.persistence.SequenceGenerator;
-import java.util.Date;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
 
 @Entity
-public class HealthCheck implements GenericEntity<Integer> {
+@Table(indexes = {@Index(name="idx_key", columnList = "key")})
+public class GenericSetting implements GenericEntity<Integer> {
 
-    public static final String SEQUENCE_NAME = "healthcheck_id_seq";
+    public static final String SEQUENCE_NAME = "generic_setting_id_seq";
 
     @Id
     @SequenceGenerator(name = SEQUENCE_NAME, sequenceName = SEQUENCE_NAME, allocationSize = 1, initialValue = 100)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = SEQUENCE_NAME)
     private Integer id;
 
-    private Date date;
+    @NotNull
+    @Column(unique=true)
+    private String key;
+
+    @NotNull
+    @Lob
+    @Type(type = "org.hibernate.type.TextType")
+    private String value;
 
     @Override
     public Integer getId() {
@@ -46,11 +60,19 @@ public class HealthCheck implements GenericEntity<Integer> {
         this.id = id;
     }
 
-    public Date getDate() {
-        return date;
+    public String getKey() {
+        return key;
     }
 
-    public void setDate(Date date) {
-        this.date = date;
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
     }
 }

--- a/model/src/main/resources/db-update/00006-from-1.7.1-to-1.8.0.sql
+++ b/model/src/main/resources/db-update/00006-from-1.7.1-to-1.8.0.sql
@@ -33,8 +33,10 @@ set externalurlnormalized = substring(externalurlnormalized from '%@#"%#"' for '
 where externalurlnormalized like '%@%';
 
 -- NCL-4581: add health check
-create sequence healthcheck_id_seq;
-create table HealthCheck (
-    id integer default nextval('healthcheck_id_seq') not null,
-    date timestamp with time zone
+create sequence generic_setting_id_seq;
+create table GenericSetting (
+    id integer default nextval('generic_setting_id_seq') not null,
+    key varchar(255) unique not null,
+    value text not null,
+    primary key (id)
 );

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/GenericSettingPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/GenericSettingPredicates.java
@@ -1,0 +1,32 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.spi.datastore.predicates;
+
+import org.jboss.pnc.model.GenericSetting;
+import org.jboss.pnc.model.GenericSetting_;
+import org.jboss.pnc.spi.datastore.repositories.api.Predicate;
+
+/**
+ * Predicates for {@link org.jboss.pnc.model.GenericSetting} entity.
+ */
+public class GenericSettingPredicates {
+
+    public static Predicate<GenericSetting> withKey(String key) {
+        return (root, query, cb) -> cb.equal(root.get(GenericSetting_.key), key);
+    }
+}

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/GenericSettingRepository.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/GenericSettingRepository.java
@@ -15,15 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.pnc.datastore.repositories.internal;
+package org.jboss.pnc.spi.datastore.repositories;
 
-import org.jboss.pnc.model.HealthCheck;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.jboss.pnc.model.GenericSetting;
+import org.jboss.pnc.spi.datastore.repositories.api.Repository;
 
-import javax.enterprise.context.Dependent;
+/**
+ * Interface for manipulating {@link GenericSetting} entity.
+ */
+public interface GenericSettingRepository extends Repository<GenericSetting, Integer> {
 
-@Dependent
-public interface HealthCheckSpringRepository extends JpaRepository<HealthCheck, Integer>,
-        JpaSpecificationExecutor<HealthCheck> {
+
+    GenericSetting queryByKey(String key);
 }


### PR DESCRIPTION
The new entity will be more generic and will also be used to setup the
maintenance mode.

In general you can now use the new entity for key=value settings

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
