### PR TITLE
[v1.8][NCL-5297] Add Maintenance mode an annoucement banner

### DIFF
--- a/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BannerRest.java
+++ b/rest-model/src/main/java/org/jboss/pnc/rest/restmodel/BannerRest.java
@@ -1,0 +1,30 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.restmodel;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Setter
+public class BannerRest {
+
+    private String banner;
+}

--- a/rest/src/main/java/org/jboss/pnc/rest/configuration/JaxRsActivator.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/configuration/JaxRsActivator.java
@@ -33,6 +33,7 @@ import org.jboss.pnc.rest.endpoint.BuildRecordEndpoint;
 import org.jboss.pnc.rest.endpoint.BuildRecordPushEndpoint;
 import org.jboss.pnc.rest.endpoint.BuildTaskEndpoint;
 import org.jboss.pnc.rest.endpoint.DebugEndpoint;
+import org.jboss.pnc.rest.endpoint.GenericSettingEndpoint;
 import org.jboss.pnc.rest.endpoint.HealthCheckEndpoint;
 import org.jboss.pnc.rest.endpoint.LicenseEndpoint;
 import org.jboss.pnc.rest.endpoint.ProductEndpoint;
@@ -123,6 +124,7 @@ public class JaxRsActivator extends Application {
         resources.add(BpmEndpoint.class);
         resources.add(DebugEndpoint.class);
         resources.add(HealthCheckEndpoint.class);
+        resources.add(GenericSettingEndpoint.class);
     }
 
     private void addExceptionMappers(Set<Class<?>> resources) {

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/GenericSettingEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/GenericSettingEndpoint.java
@@ -1,0 +1,110 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.endpoint;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.jboss.pnc.rest.provider.GenericSettingProvider;
+import org.jboss.pnc.rest.restmodel.BannerRest;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.SERVER_ERROR_CODE;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.SERVER_ERROR_DESCRIPTION;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.SUCCESS_CODE;
+import static org.jboss.pnc.rest.configuration.SwaggerConstants.SUCCESS_DESCRIPTION;
+
+@Api(value = "/generic-setting", description = "Generic Global settings")
+@Path("/generic-setting")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class GenericSettingEndpoint {
+
+    @Inject
+    private GenericSettingProvider genericSettingProvider;
+
+    @ApiOperation(value = "Get announcement banner")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION, response = BannerRest.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION)
+    })
+    @GET
+    @Path("announcement-banner")
+    public Response getAnnouncementBanner() {
+
+        BannerRest banner = new BannerRest();
+        banner.setBanner(genericSettingProvider.getAnnouncementBanner());
+        return Response.ok(banner).build();
+    }
+
+    @ApiOperation(value = "Set announcement banner")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION)
+    })
+    @POST
+    @Path("set-announcement-banner")
+    public Response setAnnouncementBanner(BannerRest banner) {
+        genericSettingProvider.setAnnouncementBanner(banner.getBanner());
+        return Response.ok().build();
+    }
+
+    @ApiOperation(value = "Get status of maintenance mode")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION, response = Boolean.class),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION)
+    })
+    @GET
+    @Path("in-maintenance-mode")
+    public Response isInMaintenanceMode() {
+        return Response.ok(genericSettingProvider.isInMaintenanceMode()).build();
+    }
+
+    @ApiOperation(value = "Activate maintenance mode. Needs to be admin")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION)
+    })
+    @POST
+    @Path("activate-maintenance-mode")
+    public Response activateMaintenanceMode(String reason) {
+        genericSettingProvider.activateMaintenanceMode(reason);
+        return Response.ok().build();
+    }
+
+    @ApiOperation(value = "Deactivate maintenance mode. Needs to be admin")
+    @ApiResponses(value = {
+            @ApiResponse(code = SUCCESS_CODE, message = SUCCESS_DESCRIPTION),
+            @ApiResponse(code = SERVER_ERROR_CODE, message = SERVER_ERROR_DESCRIPTION)
+    })
+    @POST
+    @Path("deactivate-maintenance-mode")
+    public Response deactivateMaintenanceMode() {
+        genericSettingProvider.deactivateMaintenanceMode();
+        return Response.ok().build();
+    }
+}

--- a/rest/src/main/java/org/jboss/pnc/rest/provider/GenericSettingProvider.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/provider/GenericSettingProvider.java
@@ -1,0 +1,119 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.rest.provider;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jboss.pnc.model.GenericSetting;
+import org.jboss.pnc.spi.datastore.repositories.GenericSettingRepository;
+import org.jboss.util.Strings;
+
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+
+@PermitAll
+@Stateless
+@Slf4j
+public class GenericSettingProvider {
+
+    public static final String ANNOUNCEMENT_BANNER = "ANNOUNCEMENT_BANNER";
+    public static final String MAINTENANCE_MODE = "MAINTENANCE_MODE";
+
+    @Inject
+    private GenericSettingRepository genericSettingRepository;
+
+    @Deprecated
+    public GenericSettingProvider() {}
+
+    @RolesAllowed("system-user")
+    public void activateMaintenanceMode(String reason) {
+
+        log.info("Activating Maintenance mode, with reason: '{}'", reason);
+        GenericSetting maintenanceMode = createGenericParameterIfNotFound(MAINTENANCE_MODE);
+
+        maintenanceMode.setValue(Boolean.TRUE.toString());
+        genericSettingRepository.save(maintenanceMode);
+
+        setAnnouncementBanner(reason);
+    }
+
+    @RolesAllowed("system-user")
+    public void deactivateMaintenanceMode() {
+
+        log.info("Deactivating Maintenance mode");
+        GenericSetting maintenanceMode = genericSettingRepository.queryByKey(MAINTENANCE_MODE);
+
+        if (maintenanceMode != null && Boolean.parseBoolean(maintenanceMode.getValue())) {
+            // reset announcement banner if we switch from maintenance mode on -> off
+            setAnnouncementBanner(Strings.EMPTY);
+        }
+
+        if (maintenanceMode == null) {
+            maintenanceMode = new GenericSetting();
+            maintenanceMode.setKey(MAINTENANCE_MODE);
+        }
+
+        maintenanceMode.setValue(Boolean.FALSE.toString());
+        genericSettingRepository.save(maintenanceMode);
+    }
+
+    public boolean isInMaintenanceMode() {
+
+        GenericSetting maintenanceMode = genericSettingRepository.queryByKey(MAINTENANCE_MODE);
+
+        if (maintenanceMode == null) {
+            return false;
+        } else {
+            return Boolean.parseBoolean(maintenanceMode.getValue());
+        }
+
+    }
+
+    @RolesAllowed("system-user")
+    public void setAnnouncementBanner(String banner) {
+
+        log.info("Announcement banner set to: '{}'", banner);
+        GenericSetting announcementBanner = createGenericParameterIfNotFound(ANNOUNCEMENT_BANNER);
+        announcementBanner.setValue(banner);
+        genericSettingRepository.save(announcementBanner);
+    }
+
+    public String getAnnouncementBanner() {
+
+        GenericSetting announcementBanner = genericSettingRepository.queryByKey(ANNOUNCEMENT_BANNER);
+
+        if (announcementBanner == null) {
+            return Strings.EMPTY;
+        } else {
+            return announcementBanner.getValue();
+        }
+    }
+
+    private GenericSetting createGenericParameterIfNotFound(String key) {
+
+        GenericSetting genericSetting = genericSettingRepository.queryByKey(key);
+
+        if (genericSetting == null) {
+            genericSetting = new GenericSetting();
+            genericSetting.setKey(key);
+        }
+
+        return genericSetting;
+    }
+}

--- a/rest/src/main/java/org/jboss/pnc/rest/trigger/BuildTriggerer.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/trigger/BuildTriggerer.java
@@ -31,6 +31,7 @@ import org.jboss.pnc.model.BuildConfigurationAudited;
 import org.jboss.pnc.model.BuildConfigurationSet;
 import org.jboss.pnc.model.IdRev;
 import org.jboss.pnc.model.User;
+import org.jboss.pnc.rest.provider.GenericSettingProvider;
 import org.jboss.pnc.rest.restmodel.BuildConfigurationAuditedRest;
 import org.jboss.pnc.rest.restmodel.BuildConfigurationSetWithAuditedBCsRest;
 import org.jboss.pnc.rest.utils.BpmNotifier;
@@ -78,6 +79,8 @@ public class BuildTriggerer {
 
     private SystemConfig systemConfig;
 
+    private GenericSettingProvider genericSettingProvider;
+
     @Deprecated //not meant for usage its only to make CDI happy
     public BuildTriggerer() {
     }
@@ -92,7 +95,8 @@ public class BuildTriggerer {
                           BpmNotifier bpmNotifier,
                           HibernateLazyInitializer hibernateLazyInitializer,
                           SortInfoProducer sortInfoProducer,
-                          SystemConfig systemConfig) {
+                          SystemConfig systemConfig,
+                          GenericSettingProvider genericSettingProvider) {
         this.buildCoordinator = buildCoordinator;
         this.buildConfigurationRepository = buildConfigurationRepository;
         this.buildConfigurationAuditedRepository = buildConfigurationAuditedRepository;
@@ -103,6 +107,7 @@ public class BuildTriggerer {
         this.hibernateLazyInitializer = hibernateLazyInitializer;
         this.sortInfoProducer = sortInfoProducer;
         this.systemConfig = systemConfig;
+        this.genericSettingProvider = genericSettingProvider;
     }
 
     public int triggerBuild(final Integer buildConfigurationId,
@@ -111,6 +116,11 @@ public class BuildTriggerer {
                             BuildOptions buildOptions,
                             URL callBackUrl)
             throws BuildConflictException, CoreException {
+
+        if (genericSettingProvider.isInMaintenanceMode()) {
+            throw new BuildConflictException("PNC is in maintenance mode");
+        }
+
         Consumer<BuildCoordinationStatusChangedEvent> onStatusUpdate = (statusChangedEvent) -> {
             if (statusChangedEvent.getNewStatus().isCompleted()) {
                 // Expecting URL like: http://host:port/business-central/rest/runtime/org.test:Test1:1.0/process/instance/7/signal?signal=testSig
@@ -136,6 +146,11 @@ public class BuildTriggerer {
                             User currentUser,
                             BuildOptions buildOptions)
             throws BuildConflictException, CoreException {
+
+        if (genericSettingProvider.isInMaintenanceMode()) {
+            throw new BuildConflictException("PNC is in maintenance mode");
+        }
+
         BuildConfigurationSetTriggerResult result =
                 doTriggerBuild(configurationId, buildConfigurationRevision, currentUser, buildOptions);
         return selectBuildRecordIdOf(result.getBuildTasks(), configurationId);
@@ -178,6 +193,11 @@ public class BuildTriggerer {
             BuildOptions buildOptions,
             URL callBackUrl)
             throws CoreException {
+
+        if (genericSettingProvider.isInMaintenanceMode()) {
+            throw new CoreException("PNC is in maintenance mode");
+        }
+
         Consumer<BuildSetStatusChangedEvent> onStatusUpdate = buildSetStatusChangedEventConsumer(callBackUrl);
 
         BuildConfigurationSetTriggerResult result = triggerBuildConfigurationSet(buildConfigurationSetId, currentUser, buildOptions);
@@ -190,6 +210,11 @@ public class BuildTriggerer {
             User currentUser,
             BuildOptions buildOptions)
             throws CoreException {
+
+        if (genericSettingProvider.isInMaintenanceMode()) {
+            throw new CoreException("PNC is in maintenance mode");
+        }
+
         final BuildConfigurationSet buildConfigurationSet = buildConfigurationSetRepository.queryById(buildConfigurationSetId);
         Preconditions.checkArgument(buildConfigurationSet != null,
                 "Can't find configuration with given id=" + buildConfigurationSetId);
@@ -208,6 +233,11 @@ public class BuildTriggerer {
             BuildOptions buildOptions,
             URL callBackUrl)
             throws CoreException, InvalidEntityException {
+
+        if (genericSettingProvider.isInMaintenanceMode()) {
+            throw new CoreException("PNC is in maintenance mode");
+        }
+
         Consumer<BuildSetStatusChangedEvent> onStatusUpdate = buildSetStatusChangedEventConsumer(callBackUrl);
 
         BuildConfigurationSetTriggerResult result = triggerBuildConfigurationSet(buildConfigurationSetAuditedRest, currentUser, buildOptions);
@@ -220,6 +250,11 @@ public class BuildTriggerer {
             User currentUser,
             BuildOptions buildOptions)
             throws CoreException, InvalidEntityException {
+
+        if (genericSettingProvider.isInMaintenanceMode()) {
+            throw new CoreException("PNC is in maintenance mode");
+        }
+
         final BuildConfigurationSet buildConfigurationSet = buildConfigurationSetRepository.queryById(buildConfigurationSetAuditedRest.getId());
         Preconditions.checkArgument(buildConfigurationSet != null,
                 "Can't find configuration with given id=" + buildConfigurationSetAuditedRest.getId());


### PR DESCRIPTION
When maintenance mode is on, no new builds will be allowed into the
system. An exception will be thrown with reason being that PNC is in
maintenance mode.

The announcement banner is used to display messages to users for future
migration dates and announcements.

When the maintenance mode is switched to on with a reason, the
announcement banner will be set with the reason.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
