### PR TITLE
[v1.8] NCL-5276 - optimization of implicit rebuild generated queries 

### DIFF
--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/AbstractDependentBuildTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/AbstractDependentBuildTest.java
@@ -102,6 +102,7 @@ public abstract class AbstractDependentBuildTest {
     protected static final AtomicInteger configIdSequence = new AtomicInteger(0);
     protected static final AtomicInteger configAuditedIdSequence = new AtomicInteger(0);
     protected static final AtomicInteger buildRecordIdSequence = new AtomicInteger(0);
+    protected static final AtomicInteger artifactsIdSequence = new AtomicInteger(0);
 
     protected List<BuildTask> builtTasks;
 
@@ -398,6 +399,7 @@ public abstract class AbstractDependentBuildTest {
                     .map(this::mockArtifactBuiltWith)
                     .collect(Collectors.toSet());
             record.setDependencies(artifacts);
+            artifacts.stream().forEach(artifact -> artifact.addDependantBuildRecord(record));
         }
 
         private Artifact mockArtifactBuiltWith(BuildConfiguration config) {
@@ -405,9 +407,12 @@ public abstract class AbstractDependentBuildTest {
 
             Set<BuildRecord> records = new HashSet<>();
             records.add(record);
-            return  Artifact.Builder.newBuilder()
+            Artifact artifact = Artifact.Builder.newBuilder()
+                    .id(artifactsIdSequence.incrementAndGet())
                     .buildRecords(records)
                     .build();
+            record.addBuiltArtifact(artifact);
+            return artifact;
         }
     }
 }

--- a/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
@@ -54,7 +54,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.jboss.pnc.common.util.CollectionUtils.ofNullableCollection;
-import static org.jboss.pnc.common.util.StreamCollectors.toFlatList;
 import static org.jboss.pnc.spi.datastore.predicates.ArtifactPredicates.withOriginUrl;
 import static org.jboss.pnc.spi.datastore.predicates.UserPredicates.withUserName;
 import static org.jboss.pnc.spi.datastore.predicates.BuildConfigurationPredicates.withBuildConfigurationSetId;
@@ -464,10 +463,13 @@ public class DefaultDatastore implements Datastore {
      * @return BuildRecords that produced captured dependencies artifacts
      */
     private Collection<BuildRecord> getRecordsUsedFor(BuildRecord record) {
-        return ofNullableCollection(record.getDependencies())
+        Set<Integer> dependenciesId = ofNullableCollection(record.getDependencies())
                 .stream()
-                .map(Artifact::getBuildRecords)
-                .collect(toFlatList());
+                .map(Artifact::getId)
+                .collect(Collectors.toSet());
+
+        logger.debug("Finding built artifacts for dependencies: {}", dependenciesId);
+        return dependenciesId.isEmpty() ? Collections.emptyList() : buildRecordRepository.findByBuiltArtifacts(dependenciesId);
     }
 
 }

--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/BuildRecordRepositoryImpl.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/BuildRecordRepositoryImpl.java
@@ -45,6 +45,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.jboss.pnc.spi.datastore.predicates.BuildRecordPredicates.buildFinishedBefore;
 import static org.jboss.pnc.spi.datastore.predicates.BuildRecordPredicates.temporaryBuild;
@@ -165,6 +166,11 @@ public class BuildRecordRepositoryImpl extends AbstractRepository<BuildRecord, I
         } else {
             return buildRecords.get(0);
         }
+    }
+
+    @Override
+    public Set<BuildRecord> findByBuiltArtifacts(Set<Integer> artifactsId) {
+        return repository.findByBuiltArtifacts(artifactsId);
     }
 
 }

--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/internal/BuildRecordSpringRepository.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/internal/BuildRecordSpringRepository.java
@@ -22,6 +22,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Set;
 import javax.enterprise.context.Dependent;
 
 @Dependent
@@ -37,4 +38,8 @@ public interface BuildRecordSpringRepository
             + "left join fetch br.user "
             + "where br.id = ?1")
     BuildRecord findByIdFetchProperties(Integer id);
+    @Query("SELECT DISTINCT br.id, br.buildConfigurationId, br.buildConfigurationRev FROM BuildRecord br "
+            + "JOIN br.builtArtifacts builtArtifacts "
+            + "WHERE builtArtifacts.id IN (?1)")
+    Set<BuildRecord> findByBuiltArtifacts(Set<Integer> dependenciesIds);
 }

--- a/model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
@@ -401,8 +401,12 @@ public class BuildConfiguration implements GenericEntity<Integer>, Cloneable {
             BuildConfiguration nextConfig = configsToCheck.get(0);
             for (BuildConfiguration nextDep : nextConfig.getDependencies()) {
                 if (!indirectDependencies.contains(nextDep)) {
+                    // Do not add an indirect dependency multiple times
                     indirectDependencies.add(nextDep);
-                    configsToCheck.add(nextDep);
+                    // Do not check a config multiple times
+                    if (!configsToCheck.contains(nextDep)) {
+                        configsToCheck.add(nextDep);
+                    }
                 }
             }
             configsToCheck.remove(nextConfig);

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/datastore/DatastoreMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/datastore/DatastoreMock.java
@@ -69,7 +69,7 @@ public class DatastoreMock implements Datastore {
         BuildConfiguration buildConfiguration = buildRecord.getBuildConfigurationAudited().getBuildConfiguration();
         log.info("Storing build " + buildConfiguration);
         synchronized (this) {
-            boolean exists = getBuildRecords().stream().anyMatch(br -> br.equals(buildRecord.getId()));
+            boolean exists = getBuildRecords().stream().anyMatch(br -> br.getId().equals(buildRecord.getId()));
             if (exists) {
                 throw new PersistenceException("Unique constraint violation, the record with id [" + buildRecord.getId()+ "] already exists.");
             }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/BuildConfigurationAuditedRepositoryMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/BuildConfigurationAuditedRepositoryMock.java
@@ -62,7 +62,7 @@ public class BuildConfigurationAuditedRepositoryMock implements BuildConfigurati
     }
 
     public void delete(IdRev id) {
-        data.removeIf(c -> c.getId().equals(id));
+        data.removeIf(c -> c.getIdRev().equals(id));
     }
 
     @Override
@@ -75,7 +75,7 @@ public class BuildConfigurationAuditedRepositoryMock implements BuildConfigurati
 
     private Optional<BuildConfigurationAudited> getOptionalById(IdRev id) {
         return data.stream()
-                .filter(m -> id.equals(m.getId()))
+                .filter(m -> id.equals(m.getIdRev()))
                 .findAny();
     }
 

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/BuildRecordRepositoryMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/BuildRecordRepositoryMock.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.mock.repository;
 
+import org.jboss.pnc.model.Artifact;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.BuildStatus;
 import org.jboss.pnc.model.IdRev;
@@ -26,12 +27,15 @@ import org.jboss.pnc.spi.datastore.repositories.api.PageInfo;
 import org.jboss.pnc.spi.datastore.repositories.api.Predicate;
 import org.jboss.pnc.spi.datastore.repositories.api.SortInfo;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.jboss.pnc.common.util.CollectionUtils.ofNullableCollection;
 /**
  * Author: Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
  * Date: 9/22/16
@@ -113,5 +117,21 @@ public class BuildRecordRepositoryMock extends RepositoryMock<BuildRecord> imple
     @Override
     public List<BuildRecord> queryAll() {
         return super.queryAll();
+    }
+
+    @Override
+    public Set<BuildRecord> findByBuiltArtifacts(Set<Integer> artifactsId) {
+
+        return data.stream()
+                .filter(buildRecord -> {
+                    Set<Integer> builtArtifactsId =
+                    ofNullableCollection(buildRecord.getBuiltArtifacts())
+                    .stream()
+                    .map(Artifact::getId)
+                    .collect(Collectors.toSet());
+
+                    // Get the build records which have any built artifact ids corresponding to a list of dependencies
+                    return !Collections.disjoint(artifactsId, builtArtifactsId);
+                }).collect(Collectors.toSet());
     }
 }

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildRecordPushEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BuildRecordPushEndpoint.java
@@ -231,7 +231,7 @@ public class BuildRecordPushEndpoint extends AbstractEndpoint<BuildRecordPushRes
     @GET
     @Path("/{buildRecordPushResultId}")
     public Response get(
-            @ApiParam(value = "Build Record id", required = true) @PathParam("buildRecordId") Integer buildRecordPushResultId
+            @ApiParam(value = "Build Record id", required = true) @PathParam("buildRecordPushResultId") Integer buildRecordPushResultId
     ) throws RestValidationException, ProcessException {
         return getSpecific(buildRecordPushResultId);
     }

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/BuildRecordRepository.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/BuildRecordRepository.java
@@ -28,6 +28,7 @@ import org.jboss.pnc.spi.datastore.repositories.api.SortInfo;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Interface for manipulating {@link org.jboss.pnc.model.BuildRecord} entity.
@@ -74,4 +75,5 @@ public interface BuildRecordRepository extends Repository<BuildRecord, Integer> 
     GraphWithMetadata<BuildRecord, Integer> getDependencyGraph(Integer buildRecordId);
 
     BuildRecord getLatestSuccessfulBuildRecord(IdRev buildConfigurationAuditedIdRev, boolean temporaryBuild);
+    Set<BuildRecord> findByBuiltArtifacts(Set<Integer> artifactsId);
 }


### PR DESCRIPTION
@thescouser89 @jbartece 
Recreated from https://github.com/project-ncl/pnc/pull/2772.
So working on https://github.com/project-ncl/pnc/pull/2771, I noticed that the "record.getDependencies()" call generates one single query, while the ".map(Artifact::getBuildRecords)" generates one query per dependency. So if there is a list of 1000 dependencies in a BuildRecord, 1000 queries are generated. I kept the first query and then attempted to create a single query for the rest, using a JPA query to optimize as much as possible. This should improve the checks for the implicit rebuilds by drastically reducing the number of executed queries. There could be more optimizations coming also (e.g. not trying to query multiple times for the same dependency).
Also, I resolved some warnings about mismatching param names and objects wrongly compared.
Thanks!
