### PR TITLE
[v1.8] NCL-5276 implicit rebuild optimization 2

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/datastore/DatastoreAdapter.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/datastore/DatastoreAdapter.java
@@ -349,14 +349,16 @@ public class DatastoreAdapter {
 
     public boolean requiresRebuild(BuildConfigurationAudited buildConfigurationAudited,
             boolean checkImplicitDependencies,
-            boolean temporaryBuild) {
-        return datastore.requiresRebuild(buildConfigurationAudited, checkImplicitDependencies, temporaryBuild);
+            boolean temporaryBuild,
+            Set<Integer> processedDependenciesCache) {
+        return datastore.requiresRebuild(buildConfigurationAudited, checkImplicitDependencies, temporaryBuild, processedDependenciesCache);
     }
 
-    public boolean requiresRebuild(BuildTask task) {
+    public boolean requiresRebuild(BuildTask task, Set<Integer> processedDependenciesCache) {
         return datastore.requiresRebuild(task.getBuildConfigurationAudited(),
                 task.getBuildOptions().isImplicitDependenciesCheck(),
-                task.getBuildOptions().isTemporaryBuild());
+                task.getBuildOptions().isTemporaryBuild(),
+                processedDependenciesCache);
     }
 
     public Set<BuildConfiguration> getBuildConfigurations(BuildConfigurationSet buildConfigurationSet) {

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinatorTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinatorTest.java
@@ -76,6 +76,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anySet;
 
 /**
  * Author: Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
@@ -142,8 +143,8 @@ public class DefaultBuildCoordinatorTest {
     public void setUp() throws DatastoreException {
         MockitoAnnotations.initMocks(this);
         when(systemConfig.getTemporalBuildExpireDate()).thenReturn(new Date(1));
-        when(datastore.requiresRebuild(any(BuildConfigurationAudited.class), any(Boolean.class), any(Boolean.class))).thenReturn(true);
-        when(datastore.requiresRebuild(any(BuildConfigurationAudited.class), any(Boolean.class), any(Boolean.class))).thenReturn(true);
+        when(datastore.requiresRebuild(any(BuildConfigurationAudited.class), any(Boolean.class), any(Boolean.class), anySet())).thenReturn(true);
+        when(datastore.requiresRebuild(any(BuildConfigurationAudited.class), any(Boolean.class), any(Boolean.class), anySet())).thenReturn(true);
         when(datastore.saveBuildConfigSetRecord(any())).thenAnswer(new SaveBuildConfigSetRecordAnswer());
         coordinator = new DefaultBuildCoordinator(
                 datastoreAdapter,

--- a/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
@@ -476,13 +476,15 @@ public class DefaultDatastore implements Datastore {
         if (dependenciesId.isEmpty()) {
             return Collections.emptyList();
         }
-        // If the cache of already processed dependencies is not null, remove them from the list of dependencies still to be processed to avoid multiple iterated checks on same items
+
         if (processedDependenciesCache != null) {
+            // If the cache of already processed dependencies is not null, remove them from the list of dependencies still to be processed to avoid multiple iterated checks on same items
             dependenciesId.removeAll(processedDependenciesCache);
             logger.debug("Retrieved dependencies after removal of already processed cache size: {}, list: {}", dependenciesId.size(), dependenciesId);
+
+            // Populate the cache with the list of processed dependencies
+            processedDependenciesCache.addAll(dependenciesId);
         }
-        // Populate the cache with the list of processed dependencies
-        processedDependenciesCache.addAll(dependenciesId);
 
         logger.debug("Finding built artifacts for dependencies: {}", dependenciesId);
         return dependenciesId.isEmpty() ? Collections.emptyList() : buildRecordRepository.findByBuiltArtifacts(dependenciesId);

--- a/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
@@ -364,7 +364,8 @@ public class DefaultDatastore implements Datastore {
     @TransactionAttribute(TransactionAttributeType.REQUIRED)
     public boolean requiresRebuild(BuildConfigurationAudited buildConfigurationAudited,
             boolean checkImplicitDependencies,
-            boolean temporaryBuild) {
+            boolean temporaryBuild,
+            Set<Integer> processedDependenciesCache) {
         IdRev idRev = buildConfigurationAudited.getIdRev();
         BuildRecord latestSuccessfulBuildRecord = buildRecordRepository.getLatestSuccessfulBuildRecord(idRev, temporaryBuild);
         if (latestSuccessfulBuildRecord == null) {
@@ -376,7 +377,7 @@ public class DefaultDatastore implements Datastore {
         }
         if (checkImplicitDependencies) {
             logger.debug("Checking if BCA: {} has implicit dependencies that need rebuild", idRev);
-            boolean rebuild = hasARebuiltImplicitDependency(latestSuccessfulBuildRecord, temporaryBuild);
+            boolean rebuild = hasARebuiltImplicitDependency(latestSuccessfulBuildRecord, temporaryBuild, processedDependenciesCache);
             logger.debug("Implicit dependency check for rebuild of buildConfiguration.idRev: {} required: {}.", idRev, rebuild);
             if (rebuild) {
                 return rebuild;
@@ -392,10 +393,11 @@ public class DefaultDatastore implements Datastore {
     @Deprecated
     @Override
     @TransactionAttribute(TransactionAttributeType.REQUIRED)
-    public boolean requiresRebuild(BuildTask task) {
+    public boolean requiresRebuild(BuildTask task, Set<Integer> processedDependenciesCache) {
         return requiresRebuild(task.getBuildConfigurationAudited(),
                 task.getBuildOptions().isImplicitDependenciesCheck(),
-                task.getBuildOptions().isTemporaryBuild());
+                task.getBuildOptions().isTemporaryBuild(),
+                processedDependenciesCache);
     }
 
     /**
@@ -418,9 +420,10 @@ public class DefaultDatastore implements Datastore {
     /**
      * Check is some of the dependencies from the previous build were rebuild.
      * Checking is done based on captured dependencies which are stored in the Build Record.
+     * Dependencies which have already been processed and are contained in the provided cache processedDependenciesCache (if any), are not processed again
      */
-    private boolean hasARebuiltImplicitDependency(BuildRecord latestSuccessfulBuildRecord, boolean temporaryBuild) {
-        Collection<BuildRecord> lastBuiltFrom = getRecordsUsedFor(latestSuccessfulBuildRecord);
+    private boolean hasARebuiltImplicitDependency(BuildRecord latestSuccessfulBuildRecord, boolean temporaryBuild, Set<Integer> processedDependenciesCache) {
+        Collection<BuildRecord> lastBuiltFrom = getRecordsUsedFor(latestSuccessfulBuildRecord, processedDependenciesCache);
         return lastBuiltFrom.stream()
                 .anyMatch(br -> {
                     if(hasNewerVersion(br, temporaryBuild)) {
@@ -462,11 +465,24 @@ public class DefaultDatastore implements Datastore {
     /**
      * @return BuildRecords that produced captured dependencies artifacts
      */
-    private Collection<BuildRecord> getRecordsUsedFor(BuildRecord record) {
+    private Collection<BuildRecord> getRecordsUsedFor(BuildRecord record, Set<Integer> processedDependenciesCache) {
         Set<Integer> dependenciesId = ofNullableCollection(record.getDependencies())
                 .stream()
                 .map(Artifact::getId)
                 .collect(Collectors.toSet());
+
+        logger.debug("Retrieved dependencies size: {}, list: {}", dependenciesId.size(), dependenciesId);
+        // If there are no dependencies to process, return
+        if (dependenciesId.isEmpty()) {
+            return Collections.emptyList();
+        }
+        // If the cache of already processed dependencies is not null, remove them from the list of dependencies still to be processed to avoid multiple iterated checks on same items
+        if (processedDependenciesCache != null) {
+            dependenciesId.removeAll(processedDependenciesCache);
+            logger.debug("Retrieved dependencies after removal of already processed cache size: {}, list: {}", dependenciesId.size(), dependenciesId);
+        }
+        // Populate the cache with the list of processed dependencies
+        processedDependenciesCache.addAll(dependenciesId);
 
         logger.debug("Finding built artifacts for dependencies: {}", dependenciesId);
         return dependenciesId.isEmpty() ? Collections.emptyList() : buildRecordRepository.findByBuiltArtifacts(dependenciesId);

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/datastore/DatastoreMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/datastore/DatastoreMock.java
@@ -150,7 +150,7 @@ public class DatastoreMock implements Datastore {
     }
 
     @Override
-    public boolean requiresRebuild(BuildTask task) {
+    public boolean requiresRebuild(BuildTask task, Set<Integer> processedDependenciesCache) {
         return true;
     }
 
@@ -161,7 +161,7 @@ public class DatastoreMock implements Datastore {
 
     @Override
     public boolean requiresRebuild(BuildConfigurationAudited buildConfigurationAudited, boolean checkImplicitDependencies,
-            boolean temporaryBuild) {
+            boolean temporaryBuild, Set<Integer> processedDependenciesCache) {
         return true;
     }
 

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/Datastore.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/Datastore.java
@@ -114,10 +114,11 @@ public interface Datastore {
      */
     boolean requiresRebuild(BuildConfigurationAudited buildConfigurationAudited,
             boolean checkImplicitDependencies,
-            boolean temporaryBuild);
+            boolean temporaryBuild,
+            Set<Integer> processedDependenciesCache);
 
     @Deprecated
-    boolean requiresRebuild(BuildTask task);
+    boolean requiresRebuild(BuildTask task, Set<Integer> processedDependenciesCache);
 
     Set<BuildConfiguration> getBuildConfigurations(BuildConfigurationSet buildConfigurationSet);
 }


### PR DESCRIPTION
@jbartece this is an extension of the work done in https://github.com/project-ncl/pnc/pull/2777, to create a cache to avoid duplicated checks. As we are processing dependencies, it could be very common that in a set of BuildRecords to be verified during an implicit rebuild, the same dependencies are present (e.g. parent upstream poms). This cache aims to avoid making the same queries for the same dependencies. Thanks for the review!