### PR TITLE
Remove `<str>.isBlank()` method call

### DIFF
--- a/common/src/main/java/org/jboss/pnc/common/util/StringUtils.java
+++ b/common/src/main/java/org/jboss/pnc/common/util/StringUtils.java
@@ -239,7 +239,7 @@ public class StringUtils {
     }
 
     public static String nullIfBlank(String string){
-        if(string == null || string.isBlank()){
+        if(string == null || string.trim().isEmpty()){
             return null;
         }
         return string;


### PR DESCRIPTION
Replace it with:
```
<str>.trim().isEmpty()
```

Reasoning:

`isBlank` String method is only available in Java 11, and since we're
still targetting Java 1.8, this method shouldn't be used.

https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#isBlank()
### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
