### PR TITLE
[NCL-5413] Serialize also null values to JSON

### DIFF
--- a/common/src/main/java/org/jboss/pnc/common/json/JsonOutputConverterMapper.java
+++ b/common/src/main/java/org/jboss/pnc/common/json/JsonOutputConverterMapper.java
@@ -41,7 +41,6 @@ public class JsonOutputConverterMapper {
     private static final ObjectMapper mapper = new ObjectMapper();
 
     static {
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         mapper.registerModule(new Jdk8Module());
         mapper.registerModule(new JavaTimeModule());
 

--- a/common/src/test/java/org/jboss/pnc/common/json/JSonOutputConverterTest.java
+++ b/common/src/test/java/org/jboss/pnc/common/json/JSonOutputConverterTest.java
@@ -76,39 +76,4 @@ public class JSonOutputConverterTest {
         //then
         assertThat(convertedString).isEqualTo("{}");
     }
-
-    @Test
-    public void shouldNotRenderNulls() throws Exception {
-        //given
-        class SampleObject {
-
-            String sampleField;
-            String sampleNullField;
-
-            public String getSampleField() {
-                return sampleField;
-            }
-
-            public void setSampleField(String sampleField) {
-                this.sampleField = sampleField;
-            }
-
-            public String getSampleNullField() {
-                return sampleNullField;
-            }
-
-            public void setSampleNullField(String sampleNullField) {
-                this.sampleNullField = sampleNullField;
-            }
-        }
-
-        SampleObject sampleObject = new SampleObject();
-        sampleObject.sampleField = "test";
-
-        //when
-        String convertedString = JsonOutputConverterMapper.apply(sampleObject);
-
-        //then
-        assertThat(convertedString).isEqualTo("{\"sampleField\":\"test\"}");
-    }
 }

--- a/integration-test/src/test/java/org/jboss/pnc/integration_new/endpoint/notifications/ProcessProgressNotificationTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration_new/endpoint/notifications/ProcessProgressNotificationTest.java
@@ -121,7 +121,7 @@ public class ProcessProgressNotificationTest {
         //then
         logger.info("Received: " + notificationCollector.getMessages().get(0));
 
-        assertTrue(notificationCollector.getMessages().get(0).startsWith("{\"oldStatus\":\"NEW\",\"build\":{\"id\":\"1\",\"status\":\"SUCCESS\","));
+        assertTrue(notificationCollector.getMessages().get(0).startsWith("{\"oldStatus\":\"NEW\",\"build\":{\"id\":\"1\",\"submitTime\":null,\"startTime\":null,\"endTime\":null,\"progress\":null,\"status\":\"SUCCESS\","));
     }
 
     private void waitForMessages(int numberOfMessages) {

--- a/integration-test/src/test/java/org/jboss/pnc/integration_new/endpoint/notifications/WebSocketsNotificationTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration_new/endpoint/notifications/WebSocketsNotificationTest.java
@@ -106,7 +106,7 @@ public class WebSocketsNotificationTest {
                 build.getStatus());
 
         String buildString = JsonOutputConverterMapper.apply(build);
-        String expectedJsonResponse = "{\"oldStatus\":\"NEW\",\"build\":" + buildString + ",\"job\":\"BUILD\",\"notificationType\":\"BUILD_STATUS_CHANGED\",\"progress\":\"FINISHED\",\"oldProgress\":\"PENDING\"}";
+        String expectedJsonResponse = "{\"oldStatus\":\"NEW\",\"build\":" + buildString + ",\"job\":\"BUILD\",\"notificationType\":\"BUILD_STATUS_CHANGED\",\"progress\":\"FINISHED\",\"oldProgress\":\"PENDING\",\"message\":null}";
 
         //when
         buildStatusNotificationEvent.fire(buildStatusChangedEvent);
@@ -131,7 +131,7 @@ public class WebSocketsNotificationTest {
         BuildSetStatusChangedEvent buildStatusChangedEvent = new DefaultBuildSetStatusChangedEvent(
                 BuildSetStatus.NEW, BuildSetStatus.DONE, groupBuild, "description");
         String groupBuildString = JsonOutputConverterMapper.apply(groupBuild);
-        String expectedJsonResponse = "{\"groupBuild\":" + groupBuildString + ",\"job\":\"GROUP_BUILD\",\"notificationType\":\"GROUP_BUILD_STATUS_CHANGED\",\"progress\":\"FINISHED\",\"oldProgress\":\"IN_PROGRESS\"}";
+        String expectedJsonResponse = "{\"groupBuild\":" + groupBuildString + ",\"job\":\"GROUP_BUILD\",\"notificationType\":\"GROUP_BUILD_STATUS_CHANGED\",\"progress\":\"FINISHED\",\"oldProgress\":\"IN_PROGRESS\",\"message\":null}";
 
         //when
         buildSetStatusNotificationEvent.fire(buildStatusChangedEvent);


### PR DESCRIPTION
In REST we serialize also NULL values, in WS we use object mapper from
common and it was not ommiting fields with NULL values.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
