### PR TITLE
[v1.8] Add log context when setting waiting for dep/enqueued

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
@@ -304,6 +304,9 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
     }
 
     private void addTaskToBuildQueue(BuildTask buildTask) {
+
+        MDCUtils.addContext(getMDCMeta(buildTask));
+
         if (isBuildConfigurationAlreadyInQueue(buildTask)) {
             log.debug("Skipping buildTask {}, its buildConfiguration is already in the buildQueue.", buildTask);
             return;
@@ -324,6 +327,8 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
             buildQueue.addWaitingTask(buildTask, onTaskReady);
             ProcessStageUtils.logProcessStageBegin(BuildCoordinationStatus.WAITING_FOR_DEPENDENCIES.toString());
         }
+
+        MDCUtils.clear();
     }
 
     private boolean isBuildConfigurationAlreadyInQueue(BuildTask buildTask) {


### PR DESCRIPTION
When we set the initial states for the build task, both for internal and
logging purposes, the log context is not set properly. This commit
attempts to fix this.

Currently this is what happens:
![waiting-for-dependencies](https://user-images.githubusercontent.com/630746/74184493-e435a800-4c14-11ea-9a87-b21c80a6cccc.png)

The logs from Kibana indicates that different builds were logged with the same processContext.

CC: @matedo1 

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
