### PR TITLE
[v1.8] Log process stage end for enqueued/waiting for dependencies

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
@@ -829,8 +829,14 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
     }
 
     private void finishDueToFailedDependency(BuildTask failedTask, BuildTask dependentTask) {
-        log.debug("Finishing task {} due ta failed dependency.", dependentTask);
+
+        MDCUtils.addContext(getMDCMeta(dependentTask));
+
+        log.debug("Finishing task {} due to a failed dependency.", dependentTask);
         buildQueue.removeTask(dependentTask);
+
+        ProcessStageUtils.logProcessStageEnd(dependentTask.getStatus().toString(), "Ended due to failed dependency of " + failedTask.getContentId());
+
         if (failedTask.getStatus() == BuildCoordinationStatus.CANCELLED) {
             updateBuildTaskStatus(dependentTask, BuildCoordinationStatus.CANCELLED,
                     "Dependent build " + failedTask.getBuildConfigurationAudited().getName() + " was cancelled");
@@ -841,6 +847,8 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
         }
         log.trace("Status of build task {} updated.", dependentTask);
         storeRejectedTask(dependentTask);
+
+        MDCUtils.clear();
     }
 
     public List<BuildTask> getSubmittedBuildTasks() {


### PR DESCRIPTION
If a build is in 'enqueued' or waiting for dependencies', and one of its
dependencies fail, the stage end is not logged. This tricks the build
metrics into thinking nothing happened.

This commit properly logs the process stage end if a dependent build
failed.

CC: @matedo1 

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
