### PR TITLE
Add log context when setting waiting for dep/enqueued

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
@@ -307,6 +307,9 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
     }
 
     private void addTaskToBuildQueue(BuildTask buildTask) {
+
+        MDCUtils.addContext(getMDCMeta(buildTask));
+
         if (isBuildConfigurationAlreadyInQueue(buildTask)) {
             log.debug("Skipping buildTask {}, its buildConfiguration is already in the buildQueue.", buildTask);
             return;
@@ -327,6 +330,8 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
             buildQueue.addWaitingTask(buildTask, onTaskReady);
             ProcessStageUtils.logProcessStageBegin(BuildCoordinationStatus.WAITING_FOR_DEPENDENCIES.toString());
         }
+
+        MDCUtils.clear();
     }
 
     private boolean isBuildConfigurationAlreadyInQueue(BuildTask buildTask) {


### PR DESCRIPTION
When we set the initial states for the build task, both for internal and
logging purposes, the log context is not set properly. This commit
attempts to fix this.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
