### PR TITLE
[NCL-5520] Remove too many MDCUtils.clear()

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
@@ -328,8 +328,6 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
                 ProcessStageUtils.logProcessStageEnd(BuildCoordinationStatus.WAITING_FOR_DEPENDENCIES.toString());
                 updateBuildTaskStatus(buildTask, BuildCoordinationStatus.ENQUEUED);
                 ProcessStageUtils.logProcessStageBegin(BuildCoordinationStatus.ENQUEUED.toString());
-
-                MDCUtils.clear();
             };
             buildQueue.addWaitingTask(buildTask, onTaskReady);
             ProcessStageUtils.logProcessStageBegin(BuildCoordinationStatus.WAITING_FOR_DEPENDENCIES.toString());
@@ -340,16 +338,12 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
 
     private boolean isBuildConfigurationAlreadyInQueue(BuildTask buildTask) {
 
-        MDCUtils.addContext(getMDCMeta(buildTask));
-
         BuildConfigurationAudited buildConfigurationAudited = buildTask.getBuildConfigurationAudited();
         Optional<BuildTask> unfinishedTask = buildQueue.getUnfinishedTask(buildConfigurationAudited);
         if (unfinishedTask.isPresent()) {
             log.debug("Task with the same buildConfigurationAudited is in the queue {}.", unfinishedTask.get());
-            MDCUtils.clear();
             return true;
         } else {
-            MDCUtils.clear();
             return false;
         }
     }
@@ -376,7 +370,6 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
             return true;
         } else {
             log.warn("Cannot find task {} to cancel.", buildTaskId);
-            MDCUtils.clear();
             return false;
         }
     }
@@ -411,7 +404,6 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
                         && t.getBuildSetTask().getId().equals(buildSetTaskId))
                 .forEach(buildTask -> {
                     try {
-                        MDCUtils.addContext(getMDCMeta(buildTask));
                         log.debug("Received cancel request for buildTaskId: {}.", buildTask.getId());
                         cancel(buildTask.getId());
                     } catch (CoreException e){
@@ -442,8 +434,6 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
             }
             log.warn("Cancellation did not complete in {} seconds.", cancellationTimeout);
             cancelInternal(buildTask);
-
-            MDCUtils.clear();
         };
         ScheduledFuture<?> timer = monitor.timer(invokeCancelInternal, cancellationTimeout, TimeUnit.SECONDS);
         //TODO optimization: cancel the timer when the task is canceled
@@ -451,8 +441,6 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
     }
 
     private void cancelInternal(BuildTask buildTask) {
-
-        MDCUtils.addContext(getMDCMeta(buildTask));
 
         BuildResult result = new BuildResult(
                 CompletionStatus.CANCELLED,
@@ -467,8 +455,6 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
         //TODO 2.0 completeNoBuild(buildTask, CompletionStatus.CANCELLED); NCL-4242
 
         log.info("Task {} canceled internally.", buildTask.getId());
-
-        MDCUtils.clear();
     }
 
     private void checkForCyclicDependencies(BuildSetTask buildSetTask) {
@@ -489,16 +475,12 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
 
     private boolean rejectAlreadySubmitted(BuildTask buildTask) {
 
-        MDCUtils.addContext(getMDCMeta(buildTask));
-
         Optional<BuildTask> alreadyActiveBuildTask = buildQueue.getUnfinishedTask(buildTask.getBuildConfigurationAudited());
         if (alreadyActiveBuildTask.isPresent()) {
             updateBuildTaskStatus(buildTask, BuildCoordinationStatus.REJECTED,
                     "The configuration is already in the build queue.");
-            MDCUtils.clear();
             return false;
         } else {
-            MDCUtils.clear();
             return true;
         }
     }
@@ -593,7 +575,6 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
 
         buildStatusChangedEventNotifier.fire(buildStatusChanged);
         log.debug("Fired buildStatusChangedEventNotifier after task {} status update to {}.", task.getId(), status);
-        MDCUtils.clear();
     }
 
     private void updateBuildSetTaskStatus(BuildSetTask buildSetTask, BuildSetStatus status) {
@@ -688,7 +669,6 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
             throw error;
         } finally {
             ProcessStageUtils.logProcessStageEnd(BuildCoordinationStatus.ENQUEUED.toString());
-            MDCUtils.clear();
         }
     }
 
@@ -722,7 +702,6 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
             coordinationStatus = BuildCoordinationStatus.SYSTEM_ERROR;
         } finally {
             updateBuildTaskStatus(buildTask, coordinationStatus);
-            MDCUtils.clear();
         }
     }
 
@@ -800,7 +779,6 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
             updateBuildTaskStatus(buildTask, coordinationStatus);
             //Starts when the build execution completes
             ProcessStageUtils.logProcessStageEnd("FINALIZING_BUILD", "Finalizing completed.");
-            MDCUtils.clear();
         }
     }
 
@@ -832,8 +810,6 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
         if (buildSetTask != null && buildSetTask.isFinished()) {
             completeBuildSetTask(buildSetTask);
         }
-
-        MDCUtils.clear();
     }
 
     private void handleErroneousFinish(BuildTask failedTask) {
@@ -847,7 +823,6 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
                     .filter(t -> !t.getStatus().isCompleted())
                     .forEach(t -> finishDueToFailedDependency(failedTask, t));
         }
-        MDCUtils.clear();
     }
 
     /**
@@ -904,8 +879,6 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
         }
         log.trace("Status of build task {} updated.", dependentTask);
         storeRejectedTask(dependentTask);
-
-        MDCUtils.clear();
     }
 
     public List<BuildTask> getSubmittedBuildTasks() {


### PR DESCRIPTION
This caused us to accidentally delete the MDC context on method calls.
Only the essential ones are used now.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
