### PR TITLE
[v1.8][NCL-5520] Reset the MDC value after waiting task run

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
@@ -806,6 +806,8 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
                 throw new IllegalArgumentException("Unhandled build task status: " + task.getStatus() + ". Build task: " + task);
         }
 
+        // Need to re-add it because buildQueue.executeNewReadyTasks may alter the mdc values
+        MDCUtils.addContext(getMDCMeta(task));
         BuildSetTask buildSetTask = task.getBuildSetTask();
         if (buildSetTask != null && buildSetTask.isFinished()) {
             completeBuildSetTask(buildSetTask);


### PR DESCRIPTION
Once a build is done, PNC scans for builds that depend on the completed
build and triggers its lambda.

The issue is that the lambda sets an MDC value for the waiting build,
but doesn't reset it back to the old MDC values for the done build. This
causes the subsequent logs to be printed with the waiting build instead
of the done build.

This commit fixes it.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
