### PR TITLE
Fix package of moved GenericSettingProvider

### DIFF
--- a/facade/src/main/java/org/jboss/pnc/facade/impl/BuildTriggererImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/impl/BuildTriggererImpl.java
@@ -45,7 +45,7 @@ import org.jboss.pnc.model.BuildConfiguration;
 import org.jboss.pnc.model.BuildConfigurationAudited;
 import org.jboss.pnc.model.BuildConfigurationSet;
 import org.jboss.pnc.model.IdRev;
-import org.jboss.pnc.rest.provider.GenericSettingProvider;
+import org.jboss.pnc.facade.providers.GenericSettingProvider;
 import org.jboss.pnc.spi.BuildOptions;
 import org.jboss.pnc.spi.coordinator.BuildCoordinator;
 import org.jboss.pnc.spi.coordinator.BuildSetTask;

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/GenericSettingProvider.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/GenericSettingProvider.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.pnc.rest.provider;
+package org.jboss.pnc.facade.providers;
 
 import lombok.extern.slf4j.Slf4j;
 import org.jboss.pnc.model.GenericSetting;

--- a/indy-repository-manager/src/main/java/org/jboss/pnc/indyrepositorymanager/IndyRepositorySession.java
+++ b/indy-repository-manager/src/main/java/org/jboss/pnc/indyrepositorymanager/IndyRepositorySession.java
@@ -443,6 +443,9 @@ public class IndyRepositorySession implements RepositorySession {
             throw new RepositoryManagerException("Repository type " + repoType
                     + " is not supported by Indy repo manager driver.");
         }
+        if (!repoPath.endsWith("/")) {
+            repoPath += '/';
+        }
 
         return TargetRepository.newBuilder()
                 .identifier(identifier)
@@ -503,6 +506,9 @@ public class IndyRepositorySession implements RepositorySession {
         }
 
         String repoPath = "/api/" + content.contentPath(storeKey);
+        if (!repoPath.endsWith("/")) {
+            repoPath += '/';
+        }
         return TargetRepository.newBuilder()
                 .identifier(identifier)
                 .repositoryType(repoType)

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/internal/GenericSettingEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/internal/GenericSettingEndpointImpl.java
@@ -19,7 +19,7 @@ package org.jboss.pnc.rest.endpoints.internal;
 
 import org.jboss.pnc.dto.Banner;
 import org.jboss.pnc.rest.api.endpoints.GenericSettingEndpoint;
-import org.jboss.pnc.rest.provider.GenericSettingProvider;
+import org.jboss.pnc.facade.providers.GenericSettingProvider;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;


### PR DESCRIPTION
GenericSettingProvider in facade/src/main/java/org/jboss/pnc/facade/providers/ declared package org.jboss.pnc.rest.provider which is obviously wrong. Eclipse refused to compile the class.