### PR TITLE
[NCL-5490] Create scm repository from bpm notification

### DIFF
--- a/bpm/src/main/java/org/jboss/pnc/bpm/BpmEventType.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/BpmEventType.java
@@ -17,14 +17,9 @@
  */
 package org.jboss.pnc.bpm;
 
-import org.jboss.pnc.bpm.model.RepositoryCreationSuccess;
-
 import lombok.ToString;
-import org.jboss.pnc.bpm.model.BpmEvent;
-import org.jboss.pnc.bpm.model.BpmStringMapNotificationRest;
-import org.jboss.pnc.bpm.model.BuildResultRest;
+import org.jboss.pnc.bpm.model.*;
 import org.jboss.pnc.bpm.model.causeway.MilestoneReleaseResultRest;
-import org.jboss.pnc.bpm.model.ProcessProgressUpdate;
 
 import static java.util.Objects.requireNonNull;
 
@@ -48,12 +43,10 @@ public enum BpmEventType { // TODO merge with org.jboss.pnc.spi.notifications.mo
     BUILD_COMPLETE(BuildResultRest.class),
     RC_REPO_CREATION_SUCCESS(BpmStringMapNotificationRest.class),
     RC_REPO_CREATION_ERROR(BpmStringMapNotificationRest.class),
-    RC_REPO_CLONE_SUCCESS(BpmStringMapNotificationRest.class),
+    RC_REPO_CLONE_SUCCESS(RepositoryCloneSuccess.class),
     RC_REPO_CLONE_ERROR(BpmStringMapNotificationRest.class),
 
     // notification for bpm task completion
-    RC_CREATION_SUCCESS(RepositoryCreationSuccess.class),
-    RC_CREATION_ERROR(BpmStringMapNotificationRest.class),
     BCC_CONFIG_SET_ADDITION_SUCCESS(BpmStringMapNotificationRest.class),
     BCC_CONFIG_SET_ADDITION_ERROR(BpmStringMapNotificationRest.class);
 

--- a/bpm/src/main/java/org/jboss/pnc/bpm/model/RepositoryCloneSuccess.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/model/RepositoryCloneSuccess.java
@@ -24,12 +24,12 @@ import lombok.Data;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @Data
-public class RepositoryCreationSuccess extends BpmEvent {
+public class RepositoryCloneSuccess extends BpmEvent {
 
     private RepositoryCreationDataWrapper data;
 
     @Override
     public String getEventType() {
-        return "RC_CREATION_SUCCESS";
+        return "RC_REPO_CLONE_SUCCESS";
     }
 }

--- a/bpm/src/main/java/org/jboss/pnc/bpm/model/RepositoryCreationDataWrapper.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/model/RepositoryCreationDataWrapper.java
@@ -23,5 +23,11 @@ import lombok.Data;
 public class RepositoryCreationDataWrapper {
 
     private String message;
-    private String repositoryConfigurationId;
+    private String externalUrl;
+    private String internalUrl;
+    private String preBuildSyncEnabled;
+
+    public boolean isPreBuildSyncEnabled() {
+        return Boolean.parseBoolean(preBuildSyncEnabled);
+    }
 }

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoint/BpmEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoint/BpmEndpoint.java
@@ -21,34 +21,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.v3.oas.annotations.Hidden;
 import org.jboss.pnc.auth.AuthenticationProvider;
 import org.jboss.pnc.auth.AuthenticationProviderFactory;
-import org.jboss.pnc.auth.LoggedInUser;
 import org.jboss.pnc.bpm.BpmEventType;
 import org.jboss.pnc.bpm.BpmManager;
 import org.jboss.pnc.bpm.model.BpmEvent;
-import org.jboss.pnc.bpm.model.RepositoryCreationProcess;
-import org.jboss.pnc.bpm.model.RepositoryCreationResultRest;
-import org.jboss.pnc.bpm.model.RepositoryCreationSuccess;
-import org.jboss.pnc.bpm.task.RepositoryCreationTask;
 import org.jboss.pnc.common.Configuration;
-import org.jboss.pnc.common.concurrent.MDCWrappers;
 import org.jboss.pnc.common.json.ConfigurationParseException;
 import org.jboss.pnc.common.json.JsonOutputConverterMapper;
 import org.jboss.pnc.common.json.moduleconfig.ScmModuleConfig;
 import org.jboss.pnc.common.json.moduleprovider.PncConfigProvider;
-import org.jboss.pnc.common.logging.MDCUtils;
-import org.jboss.pnc.model.BuildConfiguration;
-import org.jboss.pnc.model.RepositoryConfiguration;
 import org.jboss.pnc.rest.provider.BuildConfigurationSetProvider;
 import org.jboss.pnc.rest.provider.RepositoryConfigurationProvider;
-import org.jboss.pnc.rest.restmodel.BuildConfigurationRest;
-import org.jboss.pnc.rest.restmodel.RepositoryConfigurationRest;
-import org.jboss.pnc.rest.restmodel.bpm.RepositoryCreationUrlAutoRest;
-import org.jboss.pnc.rest.validation.ValidationBuilder;
-import org.jboss.pnc.rest.validation.exceptions.EmptyEntityException;
-import org.jboss.pnc.rest.validation.exceptions.InvalidEntityException;
-import org.jboss.pnc.rest.validation.exceptions.RestValidationException;
-import org.jboss.pnc.rest.validation.groups.WhenCreatingNew;
-import org.jboss.pnc.rest.validation.validators.ScmUrlValidator;
 import org.jboss.pnc.spi.datastore.repositories.BuildConfigurationRepository;
 import org.jboss.pnc.spi.datastore.repositories.RepositoryConfigurationRepository;
 import org.jboss.pnc.spi.datastore.repositories.SequenceHandlerRepository;
@@ -71,8 +53,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.Set;
-import java.util.function.Consumer;
 
 /**
  * This endpoint is used for starting and interacting with BPM processes.
@@ -176,221 +156,5 @@ public class BpmEndpoint extends AbstractEndpoint {
 
             return result.toString();
         }
-    }
-
-    /**
-     * Given the successful BC creation, add the BC into the BC sets. This solution has been selected because if this
-     * was done in BPM process there would have to be a foreach cycle and at least two REST requests for each BC Set ID.
-     * The process would become too complicated. Notification listeners are ideal for these kind of operations.
-     */
-    private void onRCCreationSuccess(BpmEvent notification, BuildConfigurationRest buildConfigurationRest) {
-        LOG.debug("Received BPM event RC_CREATION_SUCCESS: " + notification);
-
-        RepositoryCreationSuccess repositoryCreationTaskResult = (RepositoryCreationSuccess) notification;
-
-        int repositoryConfigurationId = Integer
-                .parseInt(repositoryCreationTaskResult.getData().getRepositoryConfigurationId());
-        int buildConfigurationSavedId = -1;
-
-        RepositoryConfiguration repositoryConfiguration = repositoryConfigurationRepository
-                .queryById(repositoryConfigurationId);
-        if (repositoryConfiguration == null) {
-            String errorMessage = "Repository Configuration was not found in database.";
-            LOG.error(errorMessage);
-            sendErrorMessage(repositoryConfigurationId, buildConfigurationSavedId, errorMessage);
-            return;
-        }
-
-        if (buildConfigurationRest != null) { // TODO test me
-            BuildConfiguration buildConfiguration = buildConfigurationRest.toDBEntityBuilder()
-                    .repositoryConfiguration(repositoryConfiguration)
-                    .build();
-            BuildConfiguration buildConfigurationSaved = buildConfigurationRepository.save(buildConfiguration);
-            buildConfigurationSavedId = buildConfigurationSaved.getId();
-
-            Set<Integer> bcSetIds = buildConfigurationRest.getBuildConfigurationSetIds();
-            try {
-                if (bcSetIds != null) {
-                    addBuildConfigurationToSet(buildConfigurationSaved, bcSetIds);
-                }
-            } catch (Exception e) {
-                LOG.error(e.getMessage());
-                sendErrorMessage(repositoryConfigurationId, buildConfigurationSavedId, e.getMessage());
-                return;
-            }
-        }
-
-        RepositoryCreationResultRest repositoryCreationResultRest = new RepositoryCreationResultRest(
-                repositoryConfigurationId,
-                buildConfigurationSavedId,
-                RepositoryCreationResultRest.EventType.RC_CREATION_SUCCESS,
-                null);
-
-        wsNotifier.sendMessage(repositoryCreationResultRest); // TODO test me!
-    }
-
-    private void sendErrorMessage(int repositoryConfigurationId, int buildConfigurationId, String message) {
-        RepositoryCreationResultRest repositoryCreationResultRest = new RepositoryCreationResultRest(
-                repositoryConfigurationId,
-                buildConfigurationId,
-                RepositoryCreationResultRest.EventType.RC_CREATION_ERROR,
-                message);
-        wsNotifier.sendMessage(repositoryCreationResultRest); // TODO test me!
-    }
-
-    private Response checkIfInternalUrlExits(String internalUrl) throws InvalidEntityException {
-        if (internalUrl != null) {
-            RepositoryConfiguration repositoryConfiguration = repositoryConfigurationRepository
-                    .queryByInternalScm(internalUrl);
-            if (repositoryConfiguration != null) {
-                String message = "{ \"repositoryConfigurationId\" : " + repositoryConfiguration.getId() + "}";
-                return Response.status(Response.Status.CONFLICT).entity(message).build();
-            }
-        }
-        return null;
-    }
-
-    private Response checkIfExternalUrlExits(String externalUrl) throws InvalidEntityException {
-        if (externalUrl != null) {
-            RepositoryConfiguration repositoryConfiguration = repositoryConfigurationRepository
-                    .queryByExternalScm(externalUrl);
-            if (repositoryConfiguration != null) {
-                String message = "{ \"repositoryConfigurationId\" : " + repositoryConfiguration.getId() + "}";
-                return Response.status(Response.Status.CONFLICT).entity(message).build();
-            }
-        }
-        return null;
-    }
-
-    @POST
-    @Path("/tasks/start-repository-configuration-creation-url-auto")
-    @Consumes(MediaType.APPLICATION_JSON)
-    public Response startRCreationTaskWithSingleUrl(
-            RepositoryCreationUrlAutoRest repositoryCreationUrlAutoRest,
-            @Context HttpServletRequest httpServletRequest)
-            throws CoreException, InvalidEntityException, EmptyEntityException {
-
-        LOG.debug("Received request to start RC creation with url autodetect: " + repositoryCreationUrlAutoRest);
-        final BuildConfigurationRest buildConfigurationRest = repositoryCreationUrlAutoRest.getBuildConfigurationRest();
-
-        ValidationBuilder.validateObject(repositoryCreationUrlAutoRest, WhenCreatingNew.class).validateAnnotations();
-        ValidationBuilder.validateObject(buildConfigurationRest, WhenCreatingNew.class).validateAnnotations();
-
-        RepositoryConfigurationRest.RepositoryConfigurationRestBuilder repositoryConfigurationBuilder = RepositoryConfigurationRest
-                .builder();
-
-        String internalScmAuthority = moduleConfig.getInternalScmAuthority();
-        String scmUrl = repositoryCreationUrlAutoRest.getScmUrl();
-        if (!ScmUrlValidator.isValid(scmUrl)) {
-            throw new InvalidEntityException("Invalid scmUrl: " + scmUrl);
-        }
-        Boolean isUrlInternal = scmUrl.contains(internalScmAuthority);
-
-        if (isUrlInternal) {
-            repositoryConfigurationProvider.validateInternalRepository(scmUrl);
-            Response message = checkIfInternalUrlExits(scmUrl);
-            if (message != null) {
-                return message;
-            }
-            repositoryConfigurationBuilder.internalUrl(scmUrl);
-        } else {
-            Response message = checkIfExternalUrlExits(scmUrl);
-            if (message != null) {
-                return message;
-            }
-            // when creating new SCM config with external Url, enable preBuildSync if it is not specified
-            if (repositoryCreationUrlAutoRest.getPreBuildSyncEnabled() != null) {
-                repositoryConfigurationBuilder
-                        .preBuildSyncEnabled(repositoryCreationUrlAutoRest.getPreBuildSyncEnabled());
-            } else {
-                repositoryConfigurationBuilder.preBuildSyncEnabled(true);
-            }
-            repositoryConfigurationBuilder.externalUrl(scmUrl);
-        }
-
-        RepositoryConfigurationRest repositoryConfigurationRest = repositoryConfigurationBuilder.build();
-        repositoryConfigurationRest.validate();
-
-        RepositoryCreationTask task = startRCreationTask(
-                repositoryConfigurationRest,
-                buildConfigurationRest,
-                httpServletRequest);
-        return Response.ok(task.getTaskId()).build();
-    }
-
-    private RepositoryCreationTask startRCreationTask(
-            RepositoryConfigurationRest repositoryConfigurationRest,
-            BuildConfigurationRest buildConfigurationRest,
-            HttpServletRequest httpServletRequest) throws CoreException, InvalidEntityException, EmptyEntityException {
-        LoggedInUser loginInUser = authenticationProvider.getLoggedInUser(httpServletRequest);
-
-        Long buildConfigurationId = sequenceHandlerRepository.getNextID(BuildConfiguration.SEQUENCE_NAME);
-        buildConfigurationRest.setId(buildConfigurationId.intValue());
-        MDCUtils.addProcessContext(buildConfigurationId.toString());
-
-        String revision = null;
-        if (buildConfigurationRest != null) {
-            revision = buildConfigurationRest.getScmRevision();
-        }
-        org.jboss.pnc.bpm.model.RepositoryConfiguration repositoryConfig = org.jboss.pnc.bpm.model.RepositoryConfiguration
-                .builder()
-                .externalUrl(repositoryConfigurationRest.getExternalUrl())
-                .internalUrl(repositoryConfigurationRest.getInternalUrl())
-                .preBuildSyncEnabled(repositoryConfigurationRest.getPreBuildSyncEnabled())
-                .build();
-
-        RepositoryCreationProcess repositoryConfigurationProcessRest = new RepositoryCreationProcess(
-                repositoryConfig,
-                revision);
-
-        RepositoryCreationTask repositoryCreationTask = new RepositoryCreationTask(
-                repositoryConfigurationProcessRest,
-                loginInUser.getTokenString());
-
-        repositoryCreationTask.addListener(
-                BpmEventType.RC_CREATION_SUCCESS,
-                MDCWrappers.wrap(x -> onRCCreationSuccess(x, buildConfigurationRest)));
-
-        repositoryCreationTask.addListener(
-                BpmEventType.RC_CREATION_ERROR,
-                MDCWrappers.wrap(x -> LOG.debug("Received BPM event RC_CREATION_ERROR: " + x)));
-
-        addWebsocketForwardingListeners(repositoryCreationTask);
-
-        try {
-            bpmManager.startTask(repositoryCreationTask);
-        } catch (CoreException e) {
-            throw new CoreException("Could not start BPM task: " + repositoryCreationTask, e);
-        }
-        MDCUtils.removeProcessContext();
-        return repositoryCreationTask;
-    }
-
-    private void addBuildConfigurationToSet(BuildConfiguration buildConfiguration, Set<Integer> bcSetIds)
-            throws Exception {
-        for (Integer setId : bcSetIds) {
-            try {
-                bcSetProvider.addConfiguration(setId, buildConfiguration.getId());
-            } catch (RestValidationException e) {
-                throw new Exception(
-                        "Could not add BC with ID '" + buildConfiguration.getId() + "' to a BC Set with id '" + setId
-                                + "'.",
-                        e);
-            }
-        }
-    }
-
-    /**
-     * This method will add listeners to all important RCC event types and forward the event to WS clients.
-     */
-    private void addWebsocketForwardingListeners(RepositoryCreationTask task) {
-        Consumer<? extends BpmEvent> doNotify = (e) -> wsNotifier.sendMessage(e);
-        task.addListener(BpmEventType.RC_REPO_CREATION_SUCCESS, doNotify);
-        task.addListener(BpmEventType.RC_REPO_CREATION_ERROR, doNotify);
-        task.addListener(BpmEventType.RC_REPO_CLONE_SUCCESS, doNotify);
-        task.addListener(BpmEventType.RC_REPO_CLONE_ERROR, doNotify);
-        // clients are notified from callback in startRCreationTask
-        // task.addListener(BpmEventType.RC_CREATION_SUCCESS, doNotify);
-        task.addListener(BpmEventType.RC_CREATION_ERROR, doNotify);
     }
 }

--- a/rest/src/test/java/org/jboss/pnc/rest/endpoint/BpmEndpointTest.java
+++ b/rest/src/test/java/org/jboss/pnc/rest/endpoint/BpmEndpointTest.java
@@ -137,52 +137,6 @@ public class BpmEndpointTest {
 
     }
 
-    @Test
-    public void shouldNotStartRCCreateTaskWithInternalURLWORepoName() throws Exception {
-        RepositoryCreationUrlAutoRest configuration = configuration(
-                "shouldNotStartRCCreateTaskWithInternalURLWORepoName",
-                INTERNAL_SCM_URL_WO_NAME);
-        assertThrows(
-                () -> bpmEndpoint.startRCreationTaskWithSingleUrl(configuration, null),
-                InvalidEntityException.class);
-    }
-
-    @Test
-    public void shouldNotStartRCCreateTaskWithInvalidInternalURL() throws Exception {
-        RepositoryCreationUrlAutoRest configuration = configuration(
-                "shouldNotStartRCCreateTaskWithInvalidInternalURL",
-                INTERNAL_SCM_URL_WO_NAME);
-        assertThrows(
-                () -> bpmEndpoint.startRCreationTaskWithSingleUrl(configuration, null),
-                InvalidEntityException.class);
-    }
-
-    @Test
-    public void shouldStartRCCreateTaskWithValidInternalURL() throws Exception {
-        RepositoryCreationUrlAutoRest configuration = configuration(
-                "shouldStartRCCreateTaskWithValidInternalURL",
-                VALID_INTERNAL_SCM_URL);
-        Response response = bpmEndpoint.startRCreationTaskWithSingleUrl(configuration, null);
-        assertThat(response.getStatus()).isEqualTo(200);
-    }
-
-    @Test
-    public void shouldNotStartRCCreateTaskWithExistingInternalURL() throws Exception {
-        RepositoryCreationUrlAutoRest configuration = configuration(
-                "shouldStartRCCreateTaskWithExistingInternalURL",
-                EXISTING_INTERNAL_SCM_URL);
-        Response response = bpmEndpoint.startRCreationTaskWithSingleUrl(configuration, null);
-        assertThat(response.getStatus()).isEqualTo(Response.Status.CONFLICT.getStatusCode());
-    }
-
-    @Test
-    public void shouldNotStartRCCreateTaskWithExistingExternalURL() throws Exception {
-        RepositoryCreationUrlAutoRest configuration = RepositoryCreationUrlAutoRestMockBuilder
-                .mock("shouldStartRCCreateTaskWithExistingExternalURL", "mvn clean deploy", EXISTING_EXTERNAL_SCM_URL);
-        Response response = bpmEndpoint.startRCreationTaskWithSingleUrl(configuration, null);
-        assertThat(response.getStatus()).isEqualTo(Response.Status.CONFLICT.getStatusCode());
-    }
-
     private RepositoryCreationUrlAutoRest configuration(String name, String internalUrl) {
         return RepositoryCreationUrlAutoRestMockBuilder.mock(name, "mvn clean deploy", internalUrl);
     }


### PR DESCRIPTION
Instead of BPM creating the scm repository as part of its process, BPM
should now only report the internal url in its success notification.
From there on, PNC-Orch will use the internal url to create the scm
repository in its database.

This should simplify the BPM process for repository configuration.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
