### PR TITLE
Propagating default ALIGNMENT_PARAMETERS into build configuration wizard

### DIFF
--- a/ui/app/build-configs/directives/pnc-create-build-config-wizard/pnc-create-build-config-wizard.html
+++ b/ui/app/build-configs/directives/pnc-create-build-config-wizard/pnc-create-build-config-wizard.html
@@ -49,7 +49,7 @@
       </pf-wizard-substep>
 
       <pf-wizard-substep step-title="Build Parameters" next-enabled="true" step-id="parameters" step-priority="20" show-review="true" show-review-details="false" review-template="build-configs/directives/pnc-create-build-config-wizard/review-build-parameters.html">
-          <pnc-select-build-parameters ng-model="$ctrl.wizardData.buildParameters"></pnc-select-build-parameters>
+          <pnc-select-build-parameters build-type="$ctrl.wizardData.general.buildType" ng-model="$ctrl.wizardData.buildParameters"></pnc-select-build-parameters>
       </pf-wizard-substep>
 
       <pf-wizard-substep step-title="Dependencies" next-enabled="true" step-id="parameters" step-priority="30" show-review="true" show-review-details="false" review-template="build-configs/directives/pnc-create-build-config-wizard/review-dependencies.html">

--- a/ui/app/build-configs/directives/pnc-select-build-parameters/pncDisplayBuildParameters.js
+++ b/ui/app/build-configs/directives/pnc-select-build-parameters/pncDisplayBuildParameters.js
@@ -25,10 +25,10 @@
       onRemove: '&'
     },
     templateUrl: 'build-configs/directives/pnc-select-build-parameters/pnc-display-build-parameters.html',
-    controller: [Controller]
+    controller: ['$scope', Controller]
   });
 
-  function Controller() {
+  function Controller($scope) {
     var $ctrl = this,
         editMap = {};
 
@@ -44,9 +44,12 @@
       $ctrl.currentParams = angular.copy($ctrl.params);
     }
 
-    $ctrl.$onInit = function () {
-      copyParams();
+    $ctrl.$onInit = function(){
+      $scope.$watchCollection('$ctrl.params', function () {
+        copyParams();
+      });
     };
+
 
     $ctrl.$doCheck = function () {
       if (angular.isUndefined($ctrl.currentParams)) {

--- a/ui/app/build-configs/directives/pnc-select-build-parameters/pncSelectBuildParameters.js
+++ b/ui/app/build-configs/directives/pnc-select-build-parameters/pncSelectBuildParameters.js
@@ -22,11 +22,14 @@
     require: {
       ngModel: '?ngModel'
     },
+    bindings: {
+      buildType: '<'
+    },
     templateUrl: 'build-configs/directives/pnc-select-build-parameters/pnc-select-build-parameters.html',
-    controller: ['$scope', '$log', 'utils', 'BuildConfiguration', Controller]
+    controller: ['$scope', '$log', 'utils', 'BuildConfiguration', 'BuildConfigResource', Controller]
   });
 
-  function Controller($scope, $log, utils, BuildConfiguration) {
+  function Controller($scope, $log, utils, BuildConfiguration, BuildConfigResource) {
     var $ctrl = this;
 
     // -- Controller API --
@@ -37,6 +40,7 @@
     $ctrl.addParam = addParam;
     $ctrl.removeParam = removeParam;
     $ctrl.hasParams = hasParams;
+
 
     // --------------------
 
@@ -56,6 +60,12 @@
       $ctrl.ngModel.$render = function () {
         $ctrl.params = angular.isDefined($ctrl.ngModel.$viewValue) ? $ctrl.ngModel.$viewValue : {};
       };
+
+      $scope.$watch('$ctrl.buildType', function (newBuildType) {
+        BuildConfigResource.getAlignmentParameters(newBuildType).then(function(parameters){
+          addParam('ALIGNMENT_PARAMETERS', parameters);
+        });
+      });
     };
 
     function addParam(key, value) {

--- a/ui/app/common/pnc-client/resources/BuildConfigResource.js
+++ b/ui/app/common/pnc-client/resources/BuildConfigResource.js
@@ -25,10 +25,11 @@
 
   module.factory('BuildConfigResource', [
     '$resource',
+    '$http',
     'restConfig',
     'patchHelper',
     'BUILD_CONFIG_PATH',
-    ($resource, restConfig, patchHelper, BUILD_CONFIG_PATH) => {
+    ($resource, $http, restConfig, patchHelper, BUILD_CONFIG_PATH) => {
       const ENDPOINT = restConfig.getPncRestUrl() + BUILD_CONFIG_PATH;
 
       const resource = $resource(ENDPOINT, {
@@ -85,6 +86,12 @@
           successNotification: false
         }
       });
+
+      resource.getAlignmentParameters = function(buildType) {
+        return $http.get(restConfig.getPncRestUrl() + '/build-configs/default-alignment-parameters/' + buildType).then(function (r) {
+          return r.data.parameters;
+        });
+      };
 
       patchHelper.assignPatchMethods(resource);
 


### PR DESCRIPTION
### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?


If the user comes back in the build configuration process and changes buildType, the parameters he added will be overridden. It could be done better if the new ones would stay but I don't know if this feature is so important to be included. 
