### PR TITLE
[NCL-5597] fix running conditions in BuildCoordinator's tests

### DIFF
--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/SkippingBuiltConfigsTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/SkippingBuiltConfigsTest.java
@@ -17,6 +17,15 @@
  */
 package org.jboss.pnc.coordinator.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.jboss.pnc.common.json.ConfigurationParseException;
 import org.jboss.pnc.enums.BuildStatus;
 import org.jboss.pnc.enums.RebuildMode;
@@ -33,15 +42,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 /**
  * Author: Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com Date: 9/22/16 Time: 2:51 PM
@@ -144,6 +144,7 @@ public class SkippingBuiltConfigsTest extends AbstractDependentBuildTest {
 
         // when
         coordinator.build(configurationB, user, buildOptions);
+        Thread.sleep(50);
         coordinator.build(configurationA, user, buildOptions);
 
         // then

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/BuildRecordRepositoryMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/BuildRecordRepositoryMock.java
@@ -17,15 +17,7 @@
  */
 package org.jboss.pnc.mock.repository;
 
-import org.jboss.pnc.model.Artifact;
-import org.jboss.pnc.model.BuildRecord;
-import org.jboss.pnc.model.IdRev;
-import org.jboss.pnc.enums.BuildStatus;
-import org.jboss.pnc.spi.datastore.repositories.BuildRecordRepository;
-import org.jboss.pnc.spi.datastore.repositories.GraphWithMetadata;
-import org.jboss.pnc.spi.datastore.repositories.api.PageInfo;
-import org.jboss.pnc.spi.datastore.repositories.api.Predicate;
-import org.jboss.pnc.spi.datastore.repositories.api.SortInfo;
+import static org.jboss.pnc.common.util.CollectionUtils.ofNullableCollection;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -35,7 +27,15 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.jboss.pnc.common.util.CollectionUtils.ofNullableCollection;
+import org.jboss.pnc.enums.BuildStatus;
+import org.jboss.pnc.model.Artifact;
+import org.jboss.pnc.model.BuildRecord;
+import org.jboss.pnc.model.IdRev;
+import org.jboss.pnc.spi.datastore.repositories.BuildRecordRepository;
+import org.jboss.pnc.spi.datastore.repositories.GraphWithMetadata;
+import org.jboss.pnc.spi.datastore.repositories.api.PageInfo;
+import org.jboss.pnc.spi.datastore.repositories.api.Predicate;
+import org.jboss.pnc.spi.datastore.repositories.api.SortInfo;
 
 /**
  * Author: Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com Date: 9/22/16 Time: 12:04 PM
@@ -83,8 +83,7 @@ public class BuildRecordRepositoryMock extends RepositoryMock<BuildRecord> imple
                 .filter(br -> br.getBuildConfigurationId().equals(configurationId))
                 .filter(br -> br.getStatus().equals(BuildStatus.SUCCESS))
                 .filter(br -> !(temporaryBuild == false && br.isTemporaryBuild()))
-                .sorted(Comparator.comparing(BuildRecord::getId).reversed())
-                .findFirst()
+                .max(Comparator.comparing(BuildRecord::getId))
                 .orElse(null);
     }
 
@@ -118,8 +117,7 @@ public class BuildRecordRepositoryMock extends RepositoryMock<BuildRecord> imple
                 .filter(
                         buildRecord -> buildRecord.getBuildConfigurationAuditedIdRev()
                                 .equals(buildConfigurationAuditedIdRev))
-                .sorted(Comparator.comparing(BuildRecord::getId).reversed())
-                .findFirst();
+                .max(Comparator.comparing(BuildRecord::getId));
         return first.orElse(null);
     }
 

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/RepositoryMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/RepositoryMock.java
@@ -17,18 +17,19 @@
  */
 package org.jboss.pnc.mock.repository;
 
-import org.jboss.pnc.model.GenericEntity;
-import org.jboss.pnc.spi.datastore.repositories.api.PageInfo;
-import org.jboss.pnc.spi.datastore.repositories.api.Predicate;
-import org.jboss.pnc.spi.datastore.repositories.api.Repository;
-import org.jboss.pnc.spi.datastore.repositories.api.SortInfo;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jboss.pnc.model.GenericEntity;
+import org.jboss.pnc.spi.datastore.repositories.api.PageInfo;
+import org.jboss.pnc.spi.datastore.repositories.api.Predicate;
+import org.jboss.pnc.spi.datastore.repositories.api.Repository;
+import org.jboss.pnc.spi.datastore.repositories.api.SortInfo;
 
 /**
  * Author: Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com Date: 8/29/16 Time: 7:03 AM
@@ -36,7 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @SuppressWarnings({ "WeakerAccess", "unchecked" })
 public class RepositoryMock<EntityType extends GenericEntity<Integer>> implements Repository<EntityType, Integer> {
     private final AtomicInteger idSequence = new AtomicInteger(0);
-    protected final List<EntityType> data = new ArrayList<>();
+    protected final List<EntityType> data = new CopyOnWriteArrayList<>();
 
     @Override
     public EntityType save(EntityType entity) {


### PR DESCRIPTION

InGroupDependentBuildsTest.shouldCreateTaskForDependentBuilt

There were 2 running conditions:

1. concurrent modification of mocked BuildRecordRepository (circa 1/100 probability)

- repository was returning direct reference to the data collection
- a method looping through the collection (in a stream) had the collection modified in the middle of loop resulting in a ConcurrentModificationException thrown from the inside of the Collection
- tried to wrap the collection in a new array so it wouldn't have direct reference but it caused some failures so I've decided to change the collection implementation to CopyOnWriteArray which is thread-safe (I haven't seen noticeable performance overhead)

2. successful BuildTask failing to notify dependant BuildTasks (circa 1/400 probability)

- the BuildTasks in a BuildTaskSet were added to the BuildQueue in a random order
- running condition happened when there was a BuildTask with dependants added to readyQueue and finished before its dependants to waitingQueue
- sometimes it happened that BuildCoordinator thread picked up the BuildTask with dependants and finished before any dependant was added to the waiting queue
- during finishing process there was no Task in waiting queue so the thread didn't notify any task
- fixed by ensuring that the order for adding task to queue is ordered from dependants to dependencies so that dependants are added to queue before dependencies

SkippingBuiltConfigsTest.shouldNotTriggerTheSameBuildConfigurationViaDependency

There were 2 running condition:

1. updateBuildTaskStatus method took too long to finish
- BuildTask had an dependency that was in BUILDING status before condition that places new BuildTasks in appropriate queue (waiting or ready), therefore it was decided to be placed in waiting queue
- race condition happened when a dependent Task finished before the aforementioned task was added to the waiting queue and after it was decided it should be placed in the waiting queue
- race condition resulted in stuck BuildTask in WAITING_FOR_DEPENDENCIES as the dependency could not not notify the BuildTask because waiting queue was at that time empty
- solved by short sleep in the test

2. BuildTask being placed in ready queue twice
- happened when attempting to add a Task to a queue when it was already there and an condition didn't catch it
- solved by ignoring BuildTasks that are not NEW or ENQUEUED when adding to BuildQueue

@matejonnet WDYT 