### PR TITLE
[NCL-5596] improve stability of TermBuildDriver cancelling test

### DIFF
--- a/termd-build-driver/src/test/java/org/jboss/pnc/termdbuilddriver/ClientMockFactory.java
+++ b/termd-build-driver/src/test/java/org/jboss/pnc/termdbuilddriver/ClientMockFactory.java
@@ -67,7 +67,7 @@ public class ClientMockFactory implements ClientFactory {
 
             @Override
             public boolean isFullyDownloaded() {
-                return false;
+                return true;
             }
 
             @Override


### PR DESCRIPTION
@matejonnet You probably know why there was a thread sleep. After BuildAgent reports that the build is RUNNING we should be able to immediately call cancel. 

The script executed in the test by BuildAgent always fails (it tried to execute "git clone null"). This test tries to cancel it before BuildAgent reports the execution as failed. There is a running condition where mostly cancellation wins(98/100). The sleep there is contra-productive as it gives BuildAgent more time to report failing execution. 

I've deleted a thread sleep so that is calls cancel earlier. It didn't solve the issue but it made the test more stable. 

Statistics: 

- with sleep: 31 tests failed out of 2000 
- without sleep: 2 tests failed out of 2000

Is there an additional reason for the Thread.sleep? I for sure could've missed something as I am not familiar with termd/buildagent.