### PR TITLE
[NCL-5507] fix WS messages not having set startTime when reporting BUILDING BuildTasks

### DIFF
--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/CancelledBuildTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/CancelledBuildTest.java
@@ -19,11 +19,11 @@ package org.jboss.pnc.coordinator.test;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.pnc.enums.BuildStatus;
 import org.jboss.pnc.mock.datastore.DatastoreMock;
 import org.jboss.pnc.mock.model.builders.TestProjectConfigurationBuilder;
 import org.jboss.pnc.model.BuildConfigurationSet;
 import org.jboss.pnc.model.BuildRecord;
-import org.jboss.pnc.enums.BuildStatus;
 import org.jboss.pnc.spi.coordinator.BuildCoordinator;
 import org.jboss.pnc.spi.coordinator.BuildSetTask;
 import org.jboss.pnc.spi.coordinator.BuildTask;
@@ -37,7 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -138,7 +137,7 @@ public class CancelledBuildTest extends ProjectBuilder {
         };
 
         // when
-        BuildSetTask buildSetTask = buildProjects(configurationSet, coordinator, onStatusUpdate, 1);
+        BuildSetTask buildSetTask = buildProjects(configurationSet, coordinator, onStatusUpdate, 2);
 
         // expect
         List<BuildRecord> buildRecords = datastoreMock.getBuildRecords();
@@ -176,10 +175,12 @@ public class CancelledBuildTest extends ProjectBuilder {
                     break;
                 case 2:
                     assertStatusUpdateReceived(receivedStatuses, BuildStatus.WAITING_FOR_DEPENDENCIES, buildTaskId);
+                    assertStatusUpdateReceived(receivedStatuses, BuildStatus.ENQUEUED, buildTaskId);
                     assertStatusUpdateReceived(receivedStatuses, BuildStatus.BUILDING, buildTaskId);
                     assertStatusUpdateReceived(receivedStatuses, BuildStatus.CANCELLED, buildTaskId);
                     break;
                 case 3:
+                    assertStatusUpdateReceived(receivedStatuses, BuildStatus.ENQUEUED, buildTaskId);
                     assertStatusUpdateReceived(receivedStatuses, BuildStatus.BUILDING, buildTaskId);
                     assertStatusUpdateReceived(receivedStatuses, BuildStatus.SUCCESS, buildTaskId);
                     break;

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/ProjectBuilder.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/ProjectBuilder.java
@@ -19,7 +19,9 @@ package org.jboss.pnc.coordinator.test;
 
 import org.jboss.pnc.coordinator.test.event.TestCDIBuildSetStatusChangedReceiver;
 import org.jboss.pnc.coordinator.test.event.TestCDIBuildStatusChangedReceiver;
+import org.jboss.pnc.enums.BuildCoordinationStatus;
 import org.jboss.pnc.enums.BuildStatus;
+import org.jboss.pnc.enums.RebuildMode;
 import org.jboss.pnc.mock.datastore.DatastoreMock;
 import org.jboss.pnc.mock.model.MockUser;
 import org.jboss.pnc.mock.model.builders.ArtifactBuilder;
@@ -27,16 +29,14 @@ import org.jboss.pnc.mock.model.builders.TestProjectConfigurationBuilder;
 import org.jboss.pnc.model.Artifact;
 import org.jboss.pnc.model.BuildConfiguration;
 import org.jboss.pnc.model.BuildConfigurationSet;
-import org.jboss.pnc.enums.BuildCoordinationStatus;
 import org.jboss.pnc.spi.BuildOptions;
 import org.jboss.pnc.spi.BuildSetStatus;
-import org.jboss.pnc.enums.RebuildMode;
 import org.jboss.pnc.spi.coordinator.BuildCoordinator;
 import org.jboss.pnc.spi.coordinator.BuildSetTask;
 import org.jboss.pnc.spi.coordinator.BuildTask;
 import org.jboss.pnc.spi.datastore.DatastoreException;
-import org.jboss.pnc.spi.events.BuildStatusChangedEvent;
 import org.jboss.pnc.spi.events.BuildSetStatusChangedEvent;
+import org.jboss.pnc.spi.events.BuildStatusChangedEvent;
 import org.jboss.pnc.spi.exception.BuildConflictException;
 import org.jboss.pnc.spi.exception.CoreException;
 import org.junit.Before;
@@ -45,7 +45,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -68,8 +67,8 @@ public class ProjectBuilder {
     private static final Logger log = LoggerFactory.getLogger(ProjectBuilder.class);
 
     private static final int BUILD_SET_STATUS_UPDATES = 2;
-    public static final int N_STATUS_UPDATES_PER_TASK = 2;
-    public static final int N_STATUS_UPDATES_PER_TASK_WITH_DEPENDENCIES = 3; // additional WAITING_FOR_DEPENDENCIES
+    public static final int N_STATUS_UPDATES_PER_TASK = 3;
+    public static final int N_STATUS_UPDATES_PER_TASK_WITH_DEPENDENCIES = 4; // additional WAITING_FOR_DEPENDENCIES
     public static final int N_STATUS_UPDATES_PER_TASK_WAITING_FOR_FAILED_DEPS = 2; // only REJECTED_FAILED_DEPENDENCIES
                                                                                    // and WAITING_FOR_DEPENDENCIES
 
@@ -347,6 +346,7 @@ public class ProjectBuilder {
     }
 
     private void assertAllStatusUpdateReceived(List<BuildStatusChangedEvent> receivedStatuses, Integer buildTaskId) {
+        assertStatusUpdateReceived(receivedStatuses, BuildStatus.ENQUEUED, buildTaskId);
         assertStatusUpdateReceived(receivedStatuses, BuildStatus.BUILDING, buildTaskId);
         assertStatusUpdateReceived(receivedStatuses, BuildStatus.SUCCESS, buildTaskId);
     }
@@ -354,6 +354,7 @@ public class ProjectBuilder {
     private void assertAllStatusUpdateReceivedForFailedBuild(
             List<BuildStatusChangedEvent> receivedStatuses,
             Integer buildTaskId) {
+        assertStatusUpdateReceived(receivedStatuses, BuildStatus.ENQUEUED, buildTaskId);
         assertStatusUpdateReceived(receivedStatuses, BuildStatus.BUILDING, buildTaskId);
         assertStatusUpdateReceived(receivedStatuses, BuildStatus.FAILED, buildTaskId);
     }

--- a/constants/src/main/java/org/jboss/pnc/enums/BuildCoordinationStatus.java
+++ b/constants/src/main/java/org/jboss/pnc/enums/BuildCoordinationStatus.java
@@ -101,6 +101,7 @@ public enum BuildCoordinationStatus {
         BuildStatus[] rejectedFailedDependencies = { BuildStatus.REJECTED_FAILED_DEPENDENCIES };
         BuildStatus[] cancelled = { BuildStatus.CANCELLED };
         BuildStatus[] newBuild = { BuildStatus.NEW };
+        BuildStatus[] enqueued = { BuildStatus.ENQUEUED };
         BuildStatus[] building = { BuildStatus.BUILDING };
         BuildStatus[] waitingForDependencies = { BuildStatus.WAITING_FOR_DEPENDENCIES };
         BuildStatus[] notRequired = { BuildStatus.NO_REBUILD_REQUIRED };
@@ -115,6 +116,8 @@ public enum BuildCoordinationStatus {
             return REJECTED_FAILED_DEPENDENCIES;
         } else if (Arrays.asList(newBuild).contains(buildStatus)) {
             return NEW;
+        } else if (Arrays.asList(enqueued).contains(buildStatus)) {
+            return ENQUEUED;
         } else if (Arrays.asList(building).contains(buildStatus)) {
             return BUILDING;
         } else if (Arrays.asList(waitingForDependencies).contains(buildStatus)) {

--- a/constants/src/main/java/org/jboss/pnc/enums/BuildStatus.java
+++ b/constants/src/main/java/org/jboss/pnc/enums/BuildStatus.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.enums;
 
 import java.util.Arrays;
+
 import static org.jboss.pnc.enums.BuildProgress.FINISHED;
 import static org.jboss.pnc.enums.BuildProgress.IN_PROGRESS;
 import static org.jboss.pnc.enums.BuildProgress.PENDING;
@@ -44,6 +45,11 @@ public enum BuildStatus {
      * updates).
      */
     NO_REBUILD_REQUIRED(FINISHED, true),
+
+    /**
+     * A build has been placed in a queue. It will be processed shortly.
+     */
+    ENQUEUED(PENDING),
 
     /**
      * Build is waiting for dependencies to finish
@@ -111,7 +117,8 @@ public enum BuildStatus {
         BuildCoordinationStatus[] failed = { BuildCoordinationStatus.DONE_WITH_ERRORS };
         BuildCoordinationStatus[] cancelled = { BuildCoordinationStatus.CANCELLED };
         BuildCoordinationStatus[] newBuild = { BuildCoordinationStatus.NEW };
-        BuildCoordinationStatus[] building = { BuildCoordinationStatus.ENQUEUED, BuildCoordinationStatus.BUILDING,
+        BuildCoordinationStatus[] enqueued = { BuildCoordinationStatus.ENQUEUED };
+        BuildCoordinationStatus[] building = { BuildCoordinationStatus.BUILDING,
                 BuildCoordinationStatus.BUILD_COMPLETED };
         BuildCoordinationStatus[] waitingForDependencies = { BuildCoordinationStatus.WAITING_FOR_DEPENDENCIES };
         BuildCoordinationStatus[] notRequired = { BuildCoordinationStatus.REJECTED_ALREADY_BUILT };
@@ -126,6 +133,8 @@ public enum BuildStatus {
             return CANCELLED;
         } else if (Arrays.asList(newBuild).contains(buildCoordinationStatus)) {
             return NEW;
+        } else if (Arrays.asList(enqueued).contains(buildCoordinationStatus)) {
+            return ENQUEUED;
         } else if (Arrays.asList(building).contains(buildCoordinationStatus)) {
             return BUILDING;
         } else if (Arrays.asList(waitingForDependencies).contains(buildCoordinationStatus)) {


### PR DESCRIPTION
### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
