### PR TITLE
[v1.8] NCL-5686 - Remove cache on collections related to BuildConfigurations dependencies

### DIFF
--- a/datastore/src/main/resources/META-INF/persistence.xml
+++ b/datastore/src/main/resources/META-INF/persistence.xml
@@ -101,7 +101,6 @@
           <property value= "1200000" name="hibernate.cache.infinispan.ear-package.ear#primary.org.jboss.pnc.model.BuildEnvironment.attributes.expiration.max_idle" />
           <property value= "1200000" name="hibernate.cache.infinispan.ear-package.ear#primary.org.jboss.pnc.model.BuildConfiguration.expiration.max_idle" />
           <property value= "1200000" name="hibernate.cache.infinispan.ear-package.ear#primary.org.jboss.pnc.model.BuildConfiguration.buildConfigurationSets.expiration.max_idle" />
-          <property value= "1200000" name="hibernate.cache.infinispan.ear-package.ear#primary.org.jboss.pnc.model.BuildConfiguration.dependencies.expiration.max_idle" />
           <property value= "1200000" name="hibernate.cache.infinispan.ear-package.ear#primary.org.jboss.pnc.model.BuildConfiguration.genericParameters.expiration.max_idle" />
           <property value= "1200000" name="hibernate.cache.infinispan.ear-package.ear#primary.org.jboss.pnc.model.BuildConfigurationSet.expiration.max_idle" />
           <property value= "1200000" name="hibernate.cache.infinispan.ear-package.ear#primary.org.jboss.pnc.model.BuildConfigurationSet.buildConfigurations.expiration.max_idle" />

--- a/model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildConfiguration.java
@@ -173,7 +173,6 @@ public class BuildConfiguration implements GenericEntity<Integer>, Cloneable {
      * The set of build configs upon which this build depends. The build configs contained in dependencies should normally be
      * completed before this build config is executed. Similar to Maven dependencies.
      */
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     @NotAudited
     @ManyToMany(cascade = { CascadeType.REFRESH })
     @JoinTable(name = "build_configuration_dep_map", joinColumns = {


### PR DESCRIPTION
As the other side of the relation is not cached

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
