### PR TITLE
[NCLSUP-48] Name the id in BuildRecordAttribute

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
@@ -279,8 +279,11 @@ public class BuildRecord implements GenericEntity<Integer> {
      * Example attributes POST_BUILD_REPO_VALIDATION: REPO_SYSTEM_ERROR
      */
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
-    @JoinColumn(name = "build_record_id", foreignKey = @ForeignKey(name = "fk_build_record_attributes_build_record"))
+    @OneToMany(
+            mappedBy = "build_record_attributes",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.EAGER)
     private Set<BuildRecordAttribute> attributes = new HashSet<>();
 
     @Lob
@@ -652,7 +655,7 @@ public class BuildRecord implements GenericEntity<Integer> {
             throw new PersistenceException("Build record id must be set before adding the attributes.");
         }
         Optional<BuildRecordAttribute> old = getAttributeEntity(key);
-        BuildRecordAttribute attribute = new BuildRecordAttribute(this.id, key, value);
+        BuildRecordAttribute attribute = new BuildRecordAttribute(this, key, value);
         old.ifPresent(attributes::remove);
         attributes.add(attribute);
         if (old.isPresent()) {
@@ -970,7 +973,7 @@ public class BuildRecord implements GenericEntity<Integer> {
 
             Set<BuildRecordAttribute> buildRecordAttributes = attributes.entrySet()
                     .stream()
-                    .map(kv -> new BuildRecordAttribute(id, kv.getKey(), kv.getValue()))
+                    .map(kv -> new BuildRecordAttribute(buildRecord, kv.getKey(), kv.getValue()))
                     .collect(Collectors.toSet());
             buildRecord.setAttributes(buildRecordAttributes);
 

--- a/model/src/main/java/org/jboss/pnc/model/BuildRecordAttribute.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildRecordAttribute.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.model;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
@@ -29,7 +30,9 @@ import java.util.Objects;
 @IdClass(BuildRecordAttribute.AttributeId.class)
 public class BuildRecordAttribute implements Serializable {
 
+    // specify the column name for backwards compatibility with how it was named in PNC 1.x
     @Id
+    @Column(name = "build_record_id")
     private Integer buildRecordId;
 
     @Id

--- a/model/src/main/java/org/jboss/pnc/model/BuildRecordAttribute.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildRecordAttribute.java
@@ -21,6 +21,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import java.io.Serializable;
 import java.util.Objects;
@@ -33,6 +34,7 @@ public class BuildRecordAttribute implements Serializable {
     // specify the column name for backwards compatibility with how it was named in PNC 1.x
     @Id
     @Column(name = "build_record_id")
+    @ManyToOne
     private BuildRecord buildRecord;
 
     @Id

--- a/model/src/main/java/org/jboss/pnc/model/BuildRecordAttribute.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildRecordAttribute.java
@@ -33,7 +33,7 @@ public class BuildRecordAttribute implements Serializable {
     // specify the column name for backwards compatibility with how it was named in PNC 1.x
     @Id
     @Column(name = "build_record_id")
-    private Integer buildRecordId;
+    private BuildRecord buildRecord;
 
     @Id
     private String key;
@@ -43,14 +43,14 @@ public class BuildRecordAttribute implements Serializable {
     public BuildRecordAttribute() {
     }
 
-    public BuildRecordAttribute(Integer buildRecordId, String key, String value) {
-        this.buildRecordId = buildRecordId;
+    public BuildRecordAttribute(BuildRecord buildRecord, String key, String value) {
+        this.buildRecord = buildRecord;
         this.key = key;
         this.value = value;
     }
 
-    public Integer getBuildRecordId() {
-        return buildRecordId;
+    public BuildRecord getBuildRecord() {
+        return buildRecord;
     }
 
     public String getKey() {
@@ -61,8 +61,8 @@ public class BuildRecordAttribute implements Serializable {
         return value;
     }
 
-    public void setBuildRecordId(Integer buildRecordId) {
-        this.buildRecordId = buildRecordId;
+    public void setBuildRecord(BuildRecord buildRecord) {
+        this.buildRecord = buildRecord;
     }
 
     public void setKey(String key) {
@@ -110,11 +110,11 @@ public class BuildRecordAttribute implements Serializable {
         if (o == null || getClass() != o.getClass())
             return false;
         BuildRecordAttribute that = (BuildRecordAttribute) o;
-        return buildRecordId.equals(that.buildRecordId) && key.equals(that.key);
+        return buildRecord.equals(that.buildRecord) && key.equals(that.key);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(buildRecordId, key);
+        return Objects.hash(buildRecord, key);
     }
 }

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuildRecordPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuildRecordPredicates.java
@@ -228,7 +228,7 @@ public class BuildRecordPredicates {
             subquery.where(
                     cb.and(
                             cb.equal(subRoot.get(BuildRecordAttribute_.key), key),
-                            cb.equal(root.get(BuildRecord_.id), subRoot.get(BuildRecordAttribute_.buildRecordId))));
+                            cb.equal(root.get(BuildRecord_.id), subRoot.get(BuildRecordAttribute_.buildRecord))));
             return query.where(cb.not(cb.exists(subquery))).getRestriction();
         };
     }


### PR DESCRIPTION
In PNC 2.0, the `BuildRecordAttribute` is extracted from `BuildRecord`
into its own class.

Due to Hibernate's weird naming conventions, the `build_record_id`
column got renamed to `buildrecordid` with that extraction. This caused
Hibernate to create an extra column named 'buildrecordid' in our
database.

This commit fixes it by explicitly naming the column 'build_record_id'

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
