### PR TITLE
[NCLSUP-40] Fix logic for keycloak `refreshRequired`

### DIFF
--- a/auth/src/main/java/org/jboss/pnc/auth/DefaultKeycloakServiceClient.java
+++ b/auth/src/main/java/org/jboss/pnc/auth/DefaultKeycloakServiceClient.java
@@ -65,9 +65,13 @@ public class DefaultKeycloakServiceClient implements KeycloakServiceClient {
     }
 
     private boolean refreshRequired() {
-        if (expiresAt.isAfter(Instant.now().plus(serviceTokenRefreshIfExpiresInSeconds, ChronoUnit.SECONDS))) {
+
+        if (expiresAt == null) {
+            // if we accidentally call this method before expiresAt is set, then we obviously need to get a new token
             return true;
         }
-        return false;
+        // make sure the token is still valid 'serviceTokenRefreshIfExpiresInSeconds' seconds from now, which is the
+        // max 'supported' duration of a build. We need that token to be valid for actions done at the end of the build
+        return expiresAt.isBefore(Instant.now().plus(serviceTokenRefreshIfExpiresInSeconds, ChronoUnit.SECONDS));
     }
 }

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/SystemConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/SystemConfig.java
@@ -97,10 +97,11 @@ public class SystemConfig extends AbstractModuleConfig {
                 10);
         this.brewTagPattern = brewTagPattern;
         this.keycloakServiceAccountConfig = keycloakServiceAccountConfig;
+        // 24 hours
         this.serviceTokenRefreshIfExpiresInSeconds = toIntWithDefault(
                 "serviceTokenRefreshIfExpiresInSeconds",
                 serviceTokenRefreshIfExpiresInSeconds,
-                3600);
+                86400);
         this.temporaryBuildsLifeSpan = toIntWithDefault("temporaryBuildsLifeSpan", temporaryBuildsLifeSpan, 14);
         this.messageSenderId = messageSenderId;
         this.messagingInternalQueueSize = toIntWithDefault(


### PR DESCRIPTION
The logic for the `refreshRequired` method in
`DefaultKeycloakServiceClient` is the reverse of what it should be
returning.

It should be:
- If the token is expiring *before* now + the max duration of the build,
  then we need to renew

It seems to have accidentally gone unnoticed for many years because
builds happening frequently (in less than 1 hour of each other)
accidentally renews the token. This is generally the case in Production
orch but not the case in Stage.

Furthermore if we redeploy our Devel environment after every commit
(which happens frequently), this tends to hide the issue.

The default for 'serviceTokenRefreshIfExpiresInSeconds' is also changed
from 1 hour to 24 hours to reflect the max allowed time for a build to
happen.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
