### PR TITLE
[NCL-5680] - Update the model related to Artifacts and revision of quality levels change

### DIFF
--- a/bpm/src/test/java/org/jboss/pnc/bpm/test/BuildResultSerializationTest.java
+++ b/bpm/src/test/java/org/jboss/pnc/bpm/test/BuildResultSerializationTest.java
@@ -27,6 +27,7 @@ import org.jboss.pnc.common.json.moduleprovider.PncConfigProvider;
 import org.jboss.pnc.mapper.AbstractArtifactMapper;
 import org.jboss.pnc.mapper.AbstractArtifactMapperImpl;
 import org.jboss.pnc.mapper.api.TargetRepositoryMapper;
+import org.jboss.pnc.mapper.api.UserMapper;
 import org.jboss.pnc.mock.spi.BuildResultMock;
 import org.jboss.pnc.enums.BuildStatus;
 import org.jboss.pnc.common.json.JsonOutputConverterMapper;
@@ -67,6 +68,9 @@ public class BuildResultSerializationTest {
     private BuildMapper buildMapper;
 
     @Spy
+    private UserMapper userMapper;
+
+    @Spy
     private AbstractArtifactMapperImpl artifactMapper;
 
     @Spy
@@ -95,6 +99,7 @@ public class BuildResultSerializationTest {
                 targetRepositoryMapper,
                 AbstractArtifactMapperImpl.class);
         injectMethod("buildMapper", artifactMapper, buildMapper, AbstractArtifactMapperImpl.class);
+        injectMethod("userMapper", artifactMapper, userMapper, AbstractArtifactMapperImpl.class);
         when(configuration.getModuleConfig(new PncConfigProvider<>(IndyRepoDriverModuleConfig.class)))
                 .thenReturn(indyRepoDriverModuleConfig);
     }

--- a/bpm/src/test/java/org/jboss/pnc/bpm/test/RepositoryManagerResultSerializationTest.java
+++ b/bpm/src/test/java/org/jboss/pnc/bpm/test/RepositoryManagerResultSerializationTest.java
@@ -26,6 +26,7 @@ import org.jboss.pnc.common.json.moduleprovider.PncConfigProvider;
 import org.jboss.pnc.mapper.AbstractArtifactMapper;
 import org.jboss.pnc.mapper.AbstractArtifactMapperImpl;
 import org.jboss.pnc.mapper.api.TargetRepositoryMapper;
+import org.jboss.pnc.mapper.api.UserMapper;
 import org.jboss.pnc.mock.repositorymanager.RepositoryManagerResultMock;
 import org.jboss.pnc.common.json.JsonOutputConverterMapper;
 import org.jboss.pnc.spi.repositorymanager.RepositoryManagerResult;
@@ -64,6 +65,9 @@ public class RepositoryManagerResultSerializationTest {
     private BuildMapper buildMapper;
 
     @Spy
+    private UserMapper userMapper;
+
+    @Spy
     private AbstractArtifactMapperImpl artifactMapper;
 
     @Spy
@@ -86,6 +90,7 @@ public class RepositoryManagerResultSerializationTest {
                 targetRepositoryMapper,
                 AbstractArtifactMapperImpl.class);
         injectMethod("buildMapper", artifactMapper, buildMapper, AbstractArtifactMapperImpl.class);
+        injectMethod("userMapper", artifactMapper, userMapper, AbstractArtifactMapperImpl.class);
     }
 
     private void injectMethod(String fieldName, Object to, Object what, Class clazz)

--- a/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
@@ -106,7 +106,7 @@ public class DefaultDatastore implements Datastore {
         this.targetRepositoryRepository = targetRepositoryRepository;
     }
 
-    private static final String ARITFACT_ALREADY_BUILT_CONFLICT_MESSAGE = "This artifact was already built in build #";
+    private static final String ARTIFACT_ALREADY_BUILT_CONFLICT_MESSAGE = "This artifact was already built in build #";
 
     @Override
     public Map<Artifact, String> checkForBuiltArtifacts(Collection<Artifact> artifacts) {
@@ -116,7 +116,7 @@ public class DefaultDatastore implements Datastore {
         Map<Artifact, String> conflicts = new HashMap<>();
         for (Artifact conflict : conflicting) {
             Artifact artifact = sha256s.get(conflict.getSha256());
-            conflicts.put(artifact, ARITFACT_ALREADY_BUILT_CONFLICT_MESSAGE + conflict.getBuildRecord().getId());
+            conflicts.put(artifact, ARTIFACT_ALREADY_BUILT_CONFLICT_MESSAGE + conflict.getBuildRecord().getId());
         }
         return conflicts;
     }

--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/ArtifactAuditedRepositoryImpl.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/ArtifactAuditedRepositoryImpl.java
@@ -1,0 +1,88 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.datastore.repositories;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import org.hibernate.envers.AuditReaderFactory;
+import org.hibernate.envers.DefaultRevisionEntity;
+import org.hibernate.envers.query.AuditEntity;
+import org.jboss.pnc.model.Artifact;
+import org.jboss.pnc.model.ArtifactAudited;
+import org.jboss.pnc.model.IdRev;
+import org.jboss.pnc.spi.datastore.repositories.ArtifactAuditedRepository;
+import org.jboss.pnc.spi.datastore.repositories.BuildRecordRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Stateless
+public class ArtifactAuditedRepositoryImpl implements ArtifactAuditedRepository {
+
+    Logger logger = LoggerFactory.getLogger(ArtifactAuditedRepositoryImpl.class);
+
+    EntityManager entityManager;
+
+    BuildRecordRepository buildRecordRepository;
+
+    @Deprecated // CDI workaround
+    public ArtifactAuditedRepositoryImpl() {
+    }
+
+    @Inject
+    public ArtifactAuditedRepositoryImpl(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Override
+    public List<ArtifactAudited> findAllByIdOrderByRevDesc(Integer artifactId) {
+
+        List<Object[]> result = AuditReaderFactory.get(entityManager)
+                .createQuery()
+                .forRevisionsOfEntity(Artifact.class, false, false)
+                .add(AuditEntity.id().eq(artifactId))
+                .addOrder(AuditEntity.revisionNumber().desc())
+                .getResultList();
+
+        return result.stream().map(o -> createAudited(o[0], o[1])).collect(Collectors.toList());
+    }
+
+    @Override
+    public ArtifactAudited queryById(IdRev idRev) {
+        logger.trace("Querying for ArtifactAudited.idRev: {}.", idRev);
+        Artifact artifact = AuditReaderFactory.get(entityManager).find(Artifact.class, idRev.getId(), idRev.getRev());
+
+        if (artifact == null) {
+            return null;
+        }
+
+        return ArtifactAudited.fromArtifact(artifact, idRev.getRev());
+    }
+
+    private ArtifactAudited createAudited(Object entity, Object revision) {
+        Artifact artifact = (Artifact) entity;
+        DefaultRevisionEntity revisionEntity = (DefaultRevisionEntity) revision;
+
+        return ArtifactAudited.fromArtifact(artifact, revisionEntity.getId());
+    }
+
+}

--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/ArtifactRepositoryImpl.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/ArtifactRepositoryImpl.java
@@ -76,6 +76,6 @@ public class ArtifactRepositoryImpl extends AbstractRepository<Artifact, Integer
 
     private boolean equalAuditedValues(Artifact persisted, Artifact toUpdate) {
         return Objects.equals(persisted.getArtifactQuality(), toUpdate.getArtifactQuality())
-                && Objects.equals(persisted.getReason(), toUpdate.getReason());
+                && Objects.equals(persisted.getQualityLevelReason(), toUpdate.getQualityLevelReason());
     }
 }

--- a/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
+++ b/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import org.jboss.pnc.common.concurrent.Sequence;
 import org.jboss.pnc.common.json.moduleconfig.DemoDataConfig;
 import org.jboss.pnc.common.json.moduleconfig.SystemConfig;
+import org.jboss.pnc.enums.ArtifactQuality;
 import org.jboss.pnc.enums.BuildStatus;
 import org.jboss.pnc.enums.BuildType;
 import org.jboss.pnc.enums.MilestoneCloseStatus;
@@ -45,6 +46,7 @@ import org.jboss.pnc.model.RepositoryConfiguration;
 import org.jboss.pnc.model.TargetRepository;
 import org.jboss.pnc.model.User;
 import org.jboss.pnc.spi.datastore.Datastore;
+import org.jboss.pnc.spi.datastore.repositories.ArtifactAuditedRepository;
 import org.jboss.pnc.spi.datastore.repositories.ArtifactRepository;
 import org.jboss.pnc.spi.datastore.repositories.BuildConfigSetRecordRepository;
 import org.jboss.pnc.spi.datastore.repositories.BuildConfigurationAuditedRepository;
@@ -111,6 +113,9 @@ public class DatabaseDataInitializer {
 
     @Inject
     private ArtifactRepository artifactRepository;
+
+    @Inject
+    private ArtifactAuditedRepository artifactAuditedRepository;
 
     @Inject
     private TargetRepositoryRepository targetRepositoryRepository;
@@ -543,6 +548,7 @@ public class DatabaseDataInitializer {
                 .sha1("3a8ff25c890f2a4a283876a91037ff6c57474a14")
                 .sha256("1660168483cb8a05d1cc2e77c861682a42ed9517ba945159d5538950c5db00fa")
                 .size(10L)
+                .artifactQuality(ArtifactQuality.NEW)
                 .build();
         Artifact builtArtifact2 = Artifact.Builder.newBuilder()
                 .identifier("demo:built-artifact2:jar:1.0")
@@ -552,6 +558,7 @@ public class DatabaseDataInitializer {
                 .sha1("61dad16e14438d2d8c8cbd18b267d62944f37898")
                 .sha256("2fafc2ed0f752ac2540283d48c5cd663254a853c5cb13dec02dce023fc7471a9")
                 .size(11L)
+                .artifactQuality(ArtifactQuality.NEW)
                 .build();
         Artifact builtArtifact3 = Artifact.Builder.newBuilder()
                 .identifier("demo:built-artifact11:jar:1.0")
@@ -561,6 +568,7 @@ public class DatabaseDataInitializer {
                 .sha1("550748f6f58ed8d4f6b63850a867ac207da30013")
                 .sha256("b39f88c9937f201981767e539025121971e72bc590ea20ed7fdfffafc05f55a9")
                 .size(10L)
+                .artifactQuality(ArtifactQuality.NEW)
                 .build();
         Artifact builtArtifact4 = Artifact.Builder.newBuilder()
                 .identifier("demo:built-artifact22:jar:1.0")
@@ -570,6 +578,7 @@ public class DatabaseDataInitializer {
                 .sha1("6ce2fd75c35e7eed2c45338b943be34d0b974f16")
                 .sha256("61c9ccd3ba0013311ddb89cb9a29389b6761061bdcdfb48f0096bf98c7279a21")
                 .size(11L)
+                .artifactQuality(ArtifactQuality.NEW)
                 .build();
 
         builtArtifact1 = artifactRepository.save(builtArtifact1);
@@ -587,6 +596,7 @@ public class DatabaseDataInitializer {
                 .sha1("sha1-fake-abcd1234")
                 .sha256("sha256-fake-abcd1234")
                 .size(10L)
+                .artifactQuality(ArtifactQuality.NEW)
                 .deployPath("/imported1")
                 .build();
         Artifact importedArtifact2 = Artifact.Builder.newBuilder()
@@ -599,6 +609,7 @@ public class DatabaseDataInitializer {
                 .sha1("sha1-fake-abcd1234")
                 .sha256("sha256-fake-abcd1234")
                 .size(10L)
+                .artifactQuality(ArtifactQuality.NEW)
                 .deployPath("/imported2")
                 .build();
 
@@ -689,6 +700,7 @@ public class DatabaseDataInitializer {
                 .sha1("61dad16e14438d2d8c8cbd18b267d62944f37898")
                 .sha256("1660168483cb8a05d1cc2e77c861682a42ed9517ba945159d5538950c5db00fa")
                 .size(10L)
+                .artifactQuality(ArtifactQuality.NEW)
                 .deployPath("/built3")
                 .build();
         Artifact builtArtifact6 = Artifact.Builder.newBuilder()
@@ -699,6 +711,7 @@ public class DatabaseDataInitializer {
                 .sha1("sha1-fake-abcd1234")
                 .sha256("sha256-fake-abcd1234")
                 .size(10L)
+                .artifactQuality(ArtifactQuality.NEW)
                 .deployPath("/built4")
                 .build();
 
@@ -710,6 +723,7 @@ public class DatabaseDataInitializer {
                 .sha1("a56asdf87a3cvx231b87987fasd6f5ads4f32sdf")
                 .sha256("sad5f64sf87b3cvx2b1v87tr89h7d3f5g432xcz1zv87fawrv23n8796534564er")
                 .size(10L)
+                .artifactQuality(ArtifactQuality.NEW)
                 .deployPath("/built5")
                 .build();
         Artifact builtArtifact8 = Artifact.Builder.newBuilder()
@@ -720,6 +734,7 @@ public class DatabaseDataInitializer {
                 .sha1("sha1-fake-abcdefg1234")
                 .sha256("sha256-fake-abcdefg1234")
                 .size(10L)
+                .artifactQuality(ArtifactQuality.NEW)
                 .deployPath("/built6")
                 .build();
 

--- a/dto/src/main/java/org/jboss/pnc/dto/Artifact.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/Artifact.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.jboss.pnc.enums.ArtifactQuality;
+import org.jboss.pnc.processor.annotation.PatchSupport;
 
 import java.time.Instant;
 
@@ -33,6 +34,7 @@ import lombok.ToString;
  *
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
+@PatchSupport
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
@@ -43,6 +45,15 @@ public class Artifact extends ArtifactRef {
     private final TargetRepository targetRepository;
     private final Build build;
 
+    /**
+     * The user who created this artifact.
+     */
+    private final User creationUser;
+
+    /**
+     * The user who last modified the Quality label of this artifact.
+     */
+    private final User modificationUser;
     @lombok.Builder(builderClassName = "Builder", toBuilder = true)
     private Artifact(
             TargetRepository targetRepository,
@@ -59,7 +70,12 @@ public class Artifact extends ArtifactRef {
             String originUrl,
             Long size,
             String deployUrl,
-            String publicUrl) {
+            String publicUrl,
+            User creationUser,
+            User modificationUser,
+            Instant creationTime,
+            Instant modificationTime,
+            String reason) {
         super(
                 id,
                 identifier,
@@ -73,9 +89,14 @@ public class Artifact extends ArtifactRef {
                 originUrl,
                 size,
                 deployUrl,
-                publicUrl);
+                publicUrl,
+                creationTime,
+                modificationTime,
+                reason);
         this.targetRepository = targetRepository;
         this.build = build;
+        this.creationUser = creationUser;
+        this.modificationUser = modificationUser;
     }
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/dto/src/main/java/org/jboss/pnc/dto/Artifact.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/Artifact.java
@@ -54,6 +54,7 @@ public class Artifact extends ArtifactRef {
      * The user who last modified the Quality label of this artifact.
      */
     private final User modificationUser;
+
     @lombok.Builder(builderClassName = "Builder", toBuilder = true)
     private Artifact(
             TargetRepository targetRepository,

--- a/dto/src/main/java/org/jboss/pnc/dto/Artifact.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/Artifact.java
@@ -76,7 +76,7 @@ public class Artifact extends ArtifactRef {
             User modificationUser,
             Instant creationTime,
             Instant modificationTime,
-            String reason) {
+            String qualityLevelReason) {
         super(
                 id,
                 identifier,
@@ -93,7 +93,7 @@ public class Artifact extends ArtifactRef {
                 publicUrl,
                 creationTime,
                 modificationTime,
-                reason);
+                qualityLevelReason);
         this.targetRepository = targetRepository;
         this.build = build;
         this.creationUser = creationUser;

--- a/dto/src/main/java/org/jboss/pnc/dto/ArtifactRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ArtifactRef.java
@@ -20,11 +20,13 @@ package org.jboss.pnc.dto;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import org.jboss.pnc.enums.ArtifactQuality;
+import org.jboss.pnc.processor.annotation.PatchSupport;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
 
+import static org.jboss.pnc.processor.annotation.PatchSupport.Operation.REPLACE;
 import java.time.Instant;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -50,6 +52,8 @@ public class ArtifactRef implements DTOEntity {
     @NotNull(groups = { WhenCreatingNew.class, WhenUpdating.class })
     protected final String identifier;
 
+    @PatchSupport({ REPLACE })
+    @NotNull(groups = { WhenCreatingNew.class, WhenUpdating.class })
     protected final ArtifactQuality artifactQuality;
 
     protected final String md5;
@@ -77,6 +81,21 @@ public class ArtifactRef implements DTOEntity {
      * Public url to the artifact using public network domain.
      */
     protected final String publicUrl;
+    /**
+     * The creation time of this artifact.
+     */
+    protected final Instant creationTime;
+
+    /**
+     * The time at which the Quality label of this artifact was last modified.
+     */
+    protected final Instant modificationTime;
+
+    /**
+     * The reason why the Quality label of the artifact was modified.
+     */
+    @PatchSupport({ REPLACE })
+    protected final String reason;
 
     @JsonPOJOBuilder(withPrefix = "")
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/dto/src/main/java/org/jboss/pnc/dto/ArtifactRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ArtifactRef.java
@@ -92,10 +92,10 @@ public class ArtifactRef implements DTOEntity {
     protected final Instant modificationTime;
 
     /**
-     * The reason why the Quality label of the artifact was modified.
+     * The reason for the Quality level setting (change) of this artifact.
      */
     @PatchSupport({ REPLACE })
-    protected final String reason;
+    protected final String qualityLevelReason;
 
     @JsonPOJOBuilder(withPrefix = "")
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/dto/src/main/java/org/jboss/pnc/dto/ArtifactRevision.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ArtifactRevision.java
@@ -46,11 +46,11 @@ public class ArtifactRevision extends ArtifactRevisionRef {
     private ArtifactRevision(
             String id,
             Integer rev,
-            String reason,
+            String qualityLevelReason,
             Instant modificationTime,
             ArtifactQuality artifactQuality,
             User modificationUser) {
-        super(id, rev, reason, modificationTime, artifactQuality);
+        super(id, rev, qualityLevelReason, modificationTime, artifactQuality);
         this.modificationUser = modificationUser;
     }
 

--- a/dto/src/main/java/org/jboss/pnc/dto/ArtifactRevision.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ArtifactRevision.java
@@ -40,8 +40,6 @@ import lombok.ToString;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ArtifactRevision extends ArtifactRevisionRef {
 
-    private final User creationUser;
-
     private final User modificationUser;
 
     @lombok.Builder(builderClassName = "Builder", toBuilder = true)
@@ -49,13 +47,10 @@ public class ArtifactRevision extends ArtifactRevisionRef {
             String id,
             Integer rev,
             String reason,
-            Instant creationTime,
             Instant modificationTime,
             ArtifactQuality artifactQuality,
-            User creationUser,
             User modificationUser) {
-        super(id, rev, reason, creationTime, modificationTime, artifactQuality);
-        this.creationUser = creationUser;
+        super(id, rev, reason, modificationTime, artifactQuality);
         this.modificationUser = modificationUser;
     }
 

--- a/dto/src/main/java/org/jboss/pnc/dto/ArtifactRevision.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ArtifactRevision.java
@@ -1,0 +1,66 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.dto;
+
+import java.time.Instant;
+
+import org.jboss.pnc.enums.ArtifactQuality;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ *
+ * @author Andrea Vibelli &lt;avibelli@redhat.com&gt;
+ */
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@JsonDeserialize(builder = ArtifactRevision.Builder.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ArtifactRevision extends ArtifactRevisionRef {
+
+    private final User creationUser;
+
+    private final User modificationUser;
+
+    @lombok.Builder(builderClassName = "Builder", toBuilder = true)
+    private ArtifactRevision(
+            String id,
+            Integer rev,
+            String reason,
+            Instant creationTime,
+            Instant modificationTime,
+            ArtifactQuality artifactQuality,
+            User creationUser,
+            User modificationUser) {
+        super(id, rev, reason, creationTime, modificationTime, artifactQuality);
+        this.creationUser = creationUser;
+        this.modificationUser = modificationUser;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+    }
+}

--- a/dto/src/main/java/org/jboss/pnc/dto/ArtifactRevisionRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ArtifactRevisionRef.java
@@ -51,8 +51,6 @@ public class ArtifactRevisionRef implements DTOEntity {
 
     protected final String reason;
 
-    protected final Instant creationTime;
-
     protected final Instant modificationTime;
 
     protected final ArtifactQuality artifactQuality;

--- a/dto/src/main/java/org/jboss/pnc/dto/ArtifactRevisionRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ArtifactRevisionRef.java
@@ -49,7 +49,7 @@ public class ArtifactRevisionRef implements DTOEntity {
 
     protected final Integer rev;
 
-    protected final String reason;
+    protected final String qualityLevelReason;
 
     protected final Instant modificationTime;
 

--- a/dto/src/main/java/org/jboss/pnc/dto/ArtifactRevisionRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ArtifactRevisionRef.java
@@ -1,0 +1,65 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.dto;
+
+import java.time.Instant;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Null;
+
+import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
+import org.jboss.pnc.dto.validation.groups.WhenUpdating;
+import org.jboss.pnc.enums.ArtifactQuality;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ *
+ * @author Andrea Vibelli &lt;avibelli@redhat.com&gt;
+ */
+
+@Data
+@Builder(builderClassName = "Builder", builderMethodName = "refBuilder")
+@JsonDeserialize(builder = ArtifactRevisionRef.Builder.class)
+public class ArtifactRevisionRef implements DTOEntity {
+
+    @NotNull(groups = WhenUpdating.class)
+    @Null(groups = WhenCreatingNew.class)
+    protected final String id;
+
+    protected final Integer rev;
+
+    protected final String reason;
+
+    protected final Instant creationTime;
+
+    protected final Instant modificationTime;
+
+    protected final ArtifactQuality artifactQuality;
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+    }
+
+}

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/ArtifactProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/ArtifactProviderImpl.java
@@ -26,7 +26,6 @@ import static org.jboss.pnc.spi.datastore.predicates.ArtifactPredicates.withSha1
 import static org.jboss.pnc.spi.datastore.predicates.ArtifactPredicates.withSha256;
 
 import java.time.Instant;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/ArtifactProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/ArtifactProviderImpl.java
@@ -78,6 +78,7 @@ public class ArtifactProviderImpl extends AbstractProvider<Integer, Artifact, or
     private UserService userService;
 
     private UserMapper userMapper;
+
     @Inject
     public ArtifactProviderImpl(
             ArtifactRepository repository,
@@ -177,6 +178,7 @@ public class ArtifactProviderImpl extends AbstractProvider<Integer, Artifact, or
                 query,
                 withDependantBuildRecordId(BuildMapper.idMapper.toEntity(buildId)));
     }
+
     @Override
     public Page<ArtifactRevision> getRevisions(int pageIndex, int pageSize, String id) {
         List<ArtifactAudited> auditedBuildConfigs = artifactAuditedRepository

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/api/ArtifactProvider.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/api/ArtifactProvider.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.facade.providers.api;
 
 import org.jboss.pnc.dto.Artifact;
 import org.jboss.pnc.dto.ArtifactRef;
+import org.jboss.pnc.dto.ArtifactRevision;
 import org.jboss.pnc.dto.response.Page;
 
 import java.util.Optional;
@@ -47,5 +48,8 @@ public interface ArtifactProvider
             String sortingRsql,
             String query,
             String buildId);
+    Page<ArtifactRevision> getRevisions(int pageIndex, int pageSize, String id);
+
+    ArtifactRevision getRevision(String id, Integer rev);
 
 }

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/api/ArtifactProvider.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/api/ArtifactProvider.java
@@ -48,6 +48,7 @@ public interface ArtifactProvider
             String sortingRsql,
             String query,
             String buildId);
+
     Page<ArtifactRevision> getRevisions(int pageIndex, int pageSize, String id);
 
     ArtifactRevision getRevision(String id, Integer rev);

--- a/facade/src/test/java/org/jboss/pnc/facade/providers/AbstractProviderTest.java
+++ b/facade/src/test/java/org/jboss/pnc/facade/providers/AbstractProviderTest.java
@@ -24,6 +24,7 @@ import org.jboss.pnc.common.json.moduleprovider.PncConfigProvider;
 import org.jboss.pnc.facade.rsql.RSQLProducer;
 import org.jboss.pnc.mapper.AbstractArtifactMapper;
 import org.jboss.pnc.mapper.AbstractArtifactMapperImpl;
+import org.jboss.pnc.mapper.ArtifactRevisionMapperImpl;
 import org.jboss.pnc.mapper.BuildBCRevisionFetcher;
 import org.jboss.pnc.mapper.BuildConfigurationMapperImpl;
 import org.jboss.pnc.mapper.BuildConfigurationRevisionMapperImpl;
@@ -43,6 +44,7 @@ import org.jboss.pnc.mapper.SCMRepositoryMapperImpl;
 import org.jboss.pnc.mapper.TargetRepositoryMapperImpl;
 import org.jboss.pnc.mapper.UserMapperImpl;
 import org.jboss.pnc.mapper.api.ArtifactMapper;
+import org.jboss.pnc.mapper.api.ArtifactRevisionMapper;
 import org.jboss.pnc.mapper.api.BuildConfigurationMapper;
 import org.jboss.pnc.mapper.api.BuildConfigurationRevisionMapper;
 import org.jboss.pnc.mapper.api.BuildMapper;
@@ -100,6 +102,9 @@ public abstract class AbstractProviderTest<ID extends Serializable, T extends Ge
 
     @Spy
     protected ArtifactMapper artifactMapper = new AbstractArtifactMapperImpl();
+
+    @Spy
+    protected ArtifactRevisionMapper artifactRevisionMapper = new ArtifactRevisionMapperImpl();
 
     @Spy
     protected BuildConfigurationRevisionMapper buildConfigurationRevisionMapper = new BuildConfigurationRevisionMapperImpl();
@@ -162,6 +167,7 @@ public abstract class AbstractProviderTest<ID extends Serializable, T extends Ge
                 targetRepositoryMapper,
                 AbstractArtifactMapperImpl.class);
         injectMethod("buildMapper", artifactMapper, buildMapper, AbstractArtifactMapperImpl.class);
+        injectMethod("userMapper", artifactMapper, userMapper, AbstractArtifactMapperImpl.class);
         injectMethod("config", artifactMapper, configuration, AbstractArtifactMapper.class);
 
         injectMethod(
@@ -216,6 +222,7 @@ public abstract class AbstractProviderTest<ID extends Serializable, T extends Ge
                 buildConfigurationRevisionMapper,
                 userMapper,
                 BuildConfigurationRevisionMapperImpl.class);
+        injectMethod("userMapper", artifactRevisionMapper, userMapper, ArtifactRevisionMapperImpl.class);
 
         injectMethod(
                 "productMilestoneMapper",

--- a/facade/src/test/java/org/jboss/pnc/facade/providers/ArtifactProviderTest.java
+++ b/facade/src/test/java/org/jboss/pnc/facade/providers/ArtifactProviderTest.java
@@ -19,15 +19,24 @@ package org.jboss.pnc.facade.providers;
 
 import org.assertj.core.api.Condition;
 import org.jboss.pnc.dto.Artifact;
+import org.jboss.pnc.dto.ArtifactRevision;
+import org.jboss.pnc.dto.BuildConfigurationRevision;
 import org.jboss.pnc.dto.response.Page;
 import org.jboss.pnc.enums.ArtifactQuality;
 import org.jboss.pnc.facade.validation.DTOValidationException;
+import org.jboss.pnc.spi.datastore.repositories.ArtifactAuditedRepository;
 import org.jboss.pnc.spi.datastore.repositories.ArtifactRepository;
+import org.jboss.pnc.spi.datastore.repositories.BuildConfigurationAuditedRepository;
 import org.jboss.pnc.spi.datastore.repositories.BuildRecordRepository;
 import org.jboss.pnc.spi.datastore.repositories.TargetRepositoryRepository;
 import org.jboss.pnc.spi.datastore.repositories.api.Predicate;
 import org.jboss.pnc.spi.datastore.repositories.api.Repository;
 import org.jboss.pnc.spi.datastore.repositories.api.SortInfo;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.assertj.core.api.Condition;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,6 +56,19 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.jboss.pnc.enums.ArtifactQuality;
+import org.jboss.pnc.facade.util.UserService;
+import org.jboss.pnc.facade.validation.DTOValidationException;
+import org.jboss.pnc.model.ArtifactAudited;
+import org.jboss.pnc.model.BuildConfigurationAudited;
+import org.jboss.pnc.model.IdRev;
+import org.jboss.pnc.model.User;
+import org.jboss.pnc.spi.datastore.repositories.api.Repository;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 
 /**
  *
@@ -57,12 +79,16 @@ public class ArtifactProviderTest extends AbstractIntIdProviderTest<org.jboss.pn
 
     @Mock
     private ArtifactRepository repository;
+    @Mock
+    private ArtifactAuditedRepository artifactAuditedRepository;
 
     @Mock
     private BuildRecordRepository buildRecordRepository;
 
     @Mock
     private TargetRepositoryRepository targetRepositoryRepository;
+    @Mock
+    private UserService userService;
 
     @Spy
     @InjectMocks
@@ -90,14 +116,26 @@ public class ArtifactProviderTest extends AbstractIntIdProviderTest<org.jboss.pn
 
     @Before
     public void prepareMocks() throws ReflectiveOperationException {
+        User currentUser = prepareNewUser();
+        when(userService.currentUser()).thenReturn(currentUser);
         when(rsqlPredicateProducer.getCriteriaPredicate(any(), anyString())).thenReturn(mock(Predicate.class));
         when(rsqlPredicateProducer.getSortInfo(any(), anyString())).thenReturn(mock(SortInfo.class));
     }
 
+    private User prepareNewUser() {
+
+        return User.Builder.newBuilder()
+                .id(113)
+                .email("example@example.com")
+                .firstName("Andrea")
+                .lastName("Vibelli")
+                .username("avibelli")
+                .build();
+    }
     @Test
     public void testStore() {
         final String identifier = "foo:bar:0.0.1";
-        Artifact artifact = Artifact.builder().identifier(identifier).build();
+        Artifact artifact = Artifact.builder().identifier(identifier).artifactQuality(ArtifactQuality.NEW).build();
 
         Artifact stored = provider.store(artifact);
 
@@ -109,7 +147,11 @@ public class ArtifactProviderTest extends AbstractIntIdProviderTest<org.jboss.pn
     @Test
     public void testStoreWithId() {
         final String identifier = "foo:bar:0.0.1";
-        Artifact artifact = Artifact.builder().id("123").identifier(identifier).build();
+        Artifact artifact = Artifact.builder()
+                .id("123")
+                .identifier(identifier)
+                .artifactQuality(ArtifactQuality.NEW)
+                .build();
 
         try {
             provider.store(artifact);
@@ -176,6 +218,50 @@ public class ArtifactProviderTest extends AbstractIntIdProviderTest<org.jboss.pn
         } catch (UnsupportedOperationException ex) {
             // ok
         }
+    }
+
+    @Test
+    public void testGetRevision() {
+        // With
+        final Integer revision = 1;
+        ArtifactAudited aa = ArtifactAudited.fromArtifact(artifact1, revision);
+        when(artifactAuditedRepository.queryById(new IdRev(artifact1.getId(), revision))).thenReturn(aa);
+
+        // When
+        ArtifactRevision ar = provider.getRevision(artifact1.getId().toString(), revision);
+
+        // Then
+        assertThat(ar).isNotNull();
+        assertThat(ar.getId()).isEqualTo(artifact1.getId().toString());
+        assertThat(ar.getRev()).isEqualTo(revision);
+    }
+
+    @Test
+    public void testGetRevisions() {
+        // With
+        final Integer revision = 1;
+        ArtifactAudited aa1 = ArtifactAudited.fromArtifact(artifact1, revision);
+        ArtifactAudited aa2 = ArtifactAudited.fromArtifact(artifact1, revision + 1);
+        List<org.jboss.pnc.model.ArtifactAudited> artifactRevisions = new ArrayList<org.jboss.pnc.model.ArtifactAudited>();
+        artifactRevisions.add(aa1);
+        artifactRevisions.add(aa2);
+        when(artifactAuditedRepository.findAllByIdOrderByRevDesc(artifact1.getId())).thenReturn(artifactRevisions);
+
+        // When
+        Page<ArtifactRevision> pagedAr = provider.getRevisions(0, 20, artifact1.getId().toString());
+
+        // Then
+        assertEquals(pagedAr.getContent().size(), 2);
+        Iterator<ArtifactRevision> itARev = pagedAr.getContent().iterator();
+
+        ArtifactRevision aRev1 = itARev.next();
+
+        assertThat(aRev1.getId()).isEqualTo(artifact1.getId().toString());
+        assertThat(aRev1.getRev()).isEqualTo(revision);
+
+        ArtifactRevision aRev2 = itARev.next();
+        assertThat(aRev2.getId()).isEqualTo(artifact1.getId().toString());
+        assertThat(aRev2.getRev()).isEqualTo(revision + 1);
     }
 
     private org.jboss.pnc.model.Artifact prepareArtifact(String identifier, String checksum) {

--- a/facade/src/test/java/org/jboss/pnc/facade/providers/ArtifactProviderTest.java
+++ b/facade/src/test/java/org/jboss/pnc/facade/providers/ArtifactProviderTest.java
@@ -132,6 +132,7 @@ public class ArtifactProviderTest extends AbstractIntIdProviderTest<org.jboss.pn
                 .username("avibelli")
                 .build();
     }
+
     @Test
     public void testStore() {
         final String identifier = "foo:bar:0.0.1";

--- a/integration-test/src/test/java/org/jboss/pnc/integration_new/endpoint/ArtifactEndpointTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration_new/endpoint/ArtifactEndpointTest.java
@@ -328,8 +328,6 @@ public class ArtifactEndpointTest {
 
         assertThat(revision.getId()).isEqualTo(artifactRest1.getId());
         assertThat(revision.getArtifactQuality()).isEqualTo(artifactRest1.getArtifactQuality());
-        assertThat(revision.getCreationTime()).isEqualTo(artifactRest1.getCreationTime());
-        assertThat(revision.getCreationUser()).isEqualTo(artifactRest1.getCreationUser());
         assertThat(revision.getModificationTime()).isEqualTo(artifactRest1.getModificationTime());
         assertThat(revision.getModificationUser()).isEqualTo(artifactRest1.getModificationUser());
         assertThat(revision.getReason()).isEqualTo(artifactRest1.getReason());

--- a/integration-test/src/test/java/org/jboss/pnc/integration_new/endpoint/ArtifactEndpointTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration_new/endpoint/ArtifactEndpointTest.java
@@ -292,7 +292,7 @@ public class ArtifactEndpointTest {
         Artifact artifact = client.getSpecific(id);
         Artifact updatedArtifact = artifact.toBuilder()
                 .artifactQuality(ArtifactQuality.TESTED)
-                .reason("Preliminary tests passed")
+                .qualityLevelReason("Preliminary tests passed")
                 .build();
         client.update(id, updatedArtifact);
 
@@ -330,7 +330,7 @@ public class ArtifactEndpointTest {
         assertThat(revision.getArtifactQuality()).isEqualTo(artifactRest1.getArtifactQuality());
         assertThat(revision.getModificationTime()).isEqualTo(artifactRest1.getModificationTime());
         assertThat(revision.getModificationUser()).isEqualTo(artifactRest1.getModificationUser());
-        assertThat(revision.getReason()).isEqualTo(artifactRest1.getReason());
+        assertThat(revision.getQualityLevelReason()).isEqualTo(artifactRest1.getQualityLevelReason());
     }
 
     @Test

--- a/mapper/src/main/java/org/jboss/pnc/mapper/AbstractArtifactMapper.java
+++ b/mapper/src/main/java/org/jboss/pnc/mapper/AbstractArtifactMapper.java
@@ -26,11 +26,11 @@ import org.jboss.pnc.dto.Artifact;
 import org.jboss.pnc.dto.ArtifactRef;
 import org.jboss.pnc.enums.RepositoryType;
 import org.jboss.pnc.mapper.api.ArtifactMapper;
-import org.jboss.pnc.mapper.api.BuildConfigurationMapper;
 import org.jboss.pnc.mapper.api.BuildMapper;
 import org.jboss.pnc.mapper.api.MapperCentralConfig;
 import org.jboss.pnc.mapper.api.Reference;
 import org.jboss.pnc.mapper.api.TargetRepositoryMapper;
+import org.jboss.pnc.mapper.api.UserMapper;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.BeforeMapping;
 import org.mapstruct.Mapper;
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.net.MalformedURLException;
 import java.util.function.Consumer;
-import org.jboss.pnc.dto.BuildRef;
 import org.jboss.pnc.mapper.api.IdEntity;
 
 /**
@@ -50,7 +49,8 @@ import org.jboss.pnc.mapper.api.IdEntity;
  */
 @Mapper(
         config = MapperCentralConfig.class,
-        uses = { TargetRepositoryMapper.class, BuildMapper.IDMapper.class, Configuration.class, BuildMapper.class })
+        uses = { TargetRepositoryMapper.class, BuildMapper.IDMapper.class, Configuration.class, BuildMapper.class,
+                UserMapper.class })
 public abstract class AbstractArtifactMapper implements ArtifactMapper {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractArtifactMapper.class);
@@ -63,6 +63,8 @@ public abstract class AbstractArtifactMapper implements ArtifactMapper {
     @Mapping(target = "publicUrl", ignore = true)
     @Mapping(target = "build", source = "buildRecord")
     @Mapping(target = "targetRepository", qualifiedBy = Reference.class)
+    @Mapping(target = "creationUser", qualifiedBy = Reference.class)
+    @Mapping(target = "modificationUser", qualifiedBy = Reference.class)
     @BeanMapping(
             ignoreUnmappedSourceProperties = { "distributedInProductMilestones", "identifierSha256", "built",
                     "imported", "trusted", "descriptiveString", "dependantBuildRecords" })
@@ -74,10 +76,12 @@ public abstract class AbstractArtifactMapper implements ArtifactMapper {
     @BeanMapping(
             ignoreUnmappedSourceProperties = { "targetRepository", "buildRecords", "dependantBuildRecords",
                     "importDate", "distributedInProductMilestones", "identifierSha256", "built", "imported", "trusted",
-                    "descriptiveString" })
+                    "descriptiveString", "creationUser", "modificationUser" })
     public abstract ArtifactRef toRef(org.jboss.pnc.model.Artifact dbEntity);
 
     @Override
+    @Mapping(target = "creationUser", qualifiedBy = IdEntity.class)
+    @Mapping(target = "modificationUser", qualifiedBy = IdEntity.class)
     @Mapping(target = "buildRecord", source = "build", qualifiedBy = IdEntity.class)
     @Mapping(target = "dependantBuildRecords", ignore = true)
     /*

--- a/mapper/src/main/java/org/jboss/pnc/mapper/api/ArtifactRevisionMapper.java
+++ b/mapper/src/main/java/org/jboss/pnc/mapper/api/ArtifactRevisionMapper.java
@@ -33,7 +33,6 @@ import org.mapstruct.Mapping;
 public interface ArtifactRevisionMapper {
 
     @Mapping(target = "id", expression = "java( dbEntity.getId().toString() )")
-    @Mapping(target = "creationUser", qualifiedBy = Reference.class)
     @Mapping(target = "modificationUser", qualifiedBy = Reference.class)
     @BeanMapping(ignoreUnmappedSourceProperties = { "idRev", "artifact" })
     ArtifactRevision toDTO(ArtifactAudited dbEntity);
@@ -42,7 +41,6 @@ public interface ArtifactRevisionMapper {
             target = "idRev",
             expression = "java( new IdRev( Integer.valueOf(dtoEntity.getId()), dtoEntity.getRev() ) )")
     @Mapping(target = "artifact", ignore = true)
-    @Mapping(target = "creationUser", qualifiedBy = IdEntity.class)
     @Mapping(target = "modificationUser", qualifiedBy = IdEntity.class)
     ArtifactAudited toEntity(ArtifactRevision dtoEntity);
 

--- a/mapper/src/main/java/org/jboss/pnc/mapper/api/ArtifactRevisionMapper.java
+++ b/mapper/src/main/java/org/jboss/pnc/mapper/api/ArtifactRevisionMapper.java
@@ -1,0 +1,63 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.mapper.api;
+
+import org.jboss.pnc.dto.ArtifactRevision;
+import org.jboss.pnc.dto.ArtifactRevisionRef;
+import org.jboss.pnc.model.ArtifactAudited;
+import org.jboss.pnc.model.IdRev;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ *
+ * @author Andrea Vibelli &lt;avibelli@redhat.com&gt;
+ */
+@Mapper(config = MapperCentralConfig.class, uses = { UserMapper.class }, imports = IdRev.class)
+public interface ArtifactRevisionMapper {
+
+    @Mapping(target = "id", expression = "java( dbEntity.getId().toString() )")
+    @Mapping(target = "creationUser", qualifiedBy = Reference.class)
+    @Mapping(target = "modificationUser", qualifiedBy = Reference.class)
+    @BeanMapping(ignoreUnmappedSourceProperties = { "idRev", "artifact" })
+    ArtifactRevision toDTO(ArtifactAudited dbEntity);
+
+    @Mapping(
+            target = "idRev",
+            expression = "java( new IdRev( Integer.valueOf(dtoEntity.getId()), dtoEntity.getRev() ) )")
+    @Mapping(target = "artifact", ignore = true)
+    @Mapping(target = "creationUser", qualifiedBy = IdEntity.class)
+    @Mapping(target = "modificationUser", qualifiedBy = IdEntity.class)
+    ArtifactAudited toEntity(ArtifactRevision dtoEntity);
+
+    default ArtifactAudited toIDEntity(ArtifactRevisionRef dtoEntity) {
+        if (dtoEntity == null) {
+            return null;
+        }
+        ArtifactAudited entity = new ArtifactAudited();
+        entity.setId(Integer.valueOf(dtoEntity.getId()));
+        entity.setRev(dtoEntity.getRev());
+        return entity;
+    }
+
+    @Mapping(target = "id", expression = "java( dbEntity.getId().toString() )")
+    @BeanMapping(ignoreUnmappedSourceProperties = { "idRev", "artifact", "creationUser", "modificationUser" })
+    ArtifactRevisionRef toRef(ArtifactAudited dbEntity);
+
+}

--- a/model/src/main/java/org/jboss/pnc/model/Artifact.java
+++ b/model/src/main/java/org/jboss/pnc/model/Artifact.java
@@ -208,11 +208,11 @@ public class Artifact implements GenericEntity<Integer> {
     private Date modificationTime;
 
     /**
-     * Reason for the change of the Quality label
+     * Reason for the setting of the Quality level
      */
     @Size(max = 200)
     @Column(length = 200)
-    private String reason;
+    private String qualityLevelReason;
 
     @Transient
     public IdentifierSha256 getIdentifierSha256() {
@@ -514,17 +514,17 @@ public class Artifact implements GenericEntity<Integer> {
     }
 
     /**
-     * @return the reason
+     * @return the qualityLevelReason
      */
-    public String getReason() {
-        return reason;
+    public String getQualityLevelReason() {
+        return qualityLevelReason;
     }
 
     /**
-     * @param reason The reason why the Quality label of this artifact was modified
+     * @param reason The reason for the Quality level setting (change) of this artifact
      */
-    public void setReason(String reason) {
-        this.reason = StringUtils.nullIfBlank(reason);
+    public void setQualityLevelReason(String qualityLevelReason) {
+        this.qualityLevelReason = StringUtils.nullIfBlank(qualityLevelReason);
     }
 
     @Override
@@ -606,7 +606,7 @@ public class Artifact implements GenericEntity<Integer> {
 
         private Date modificationTime;
 
-        private String reason;
+        private String qualityLevelReason;
 
         private Builder() {
             dependantBuildRecords = new HashSet<>();
@@ -643,7 +643,7 @@ public class Artifact implements GenericEntity<Integer> {
             artifact.setModificationUser(modificationUser);
             artifact.setCreationTime(creationTime);
             artifact.setModificationTime(modificationTime);
-            artifact.setReason(reason);
+            artifact.setQualityLevelReason(qualityLevelReason);
 
             return artifact;
         }
@@ -748,8 +748,8 @@ public class Artifact implements GenericEntity<Integer> {
             return this;
         }
 
-        public Builder reason(String reason) {
-            this.reason = reason;
+        public Builder qualityLevelReason(String qualityLevelReason) {
+            this.qualityLevelReason = qualityLevelReason;
             return this;
         }
 

--- a/model/src/main/java/org/jboss/pnc/model/Artifact.java
+++ b/model/src/main/java/org/jboss/pnc/model/Artifact.java
@@ -212,6 +212,7 @@ public class Artifact implements GenericEntity<Integer> {
     @Size(max = 200)
     @Column(length = 200)
     private String reason;
+
     @Transient
     public IdentifierSha256 getIdentifierSha256() {
         return new IdentifierSha256(identifier, sha256);
@@ -524,6 +525,7 @@ public class Artifact implements GenericEntity<Integer> {
     public void setReason(String reason) {
         this.reason = StringUtils.nullIfBlank(reason);
     }
+
     @Override
     public String toString() {
         return "Artifact [id: " + id + ", identifier=" + identifier + ", quality=" + artifactQuality + ", "

--- a/model/src/main/java/org/jboss/pnc/model/Artifact.java
+++ b/model/src/main/java/org/jboss/pnc/model/Artifact.java
@@ -185,8 +185,8 @@ public class Artifact implements GenericEntity<Integer> {
     /**
      * User who created the artifact (either triggering the build or e.g. creating via Deliverable Analyzer)
      */
+    @NotAudited
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
-    @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
     @ManyToOne
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_artifact_creation_user"), updatable = false)
     private User creationUser;
@@ -200,6 +200,7 @@ public class Artifact implements GenericEntity<Integer> {
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_artifact_modification_user"), updatable = true)
     private User modificationUser;
 
+    @NotAudited
     @Column(columnDefinition = "timestamp with time zone", updatable = false)
     private Date creationTime;
 

--- a/model/src/main/java/org/jboss/pnc/model/ArtifactAudited.java
+++ b/model/src/main/java/org/jboss/pnc/model/ArtifactAudited.java
@@ -46,11 +46,7 @@ public class ArtifactAudited implements GenericEntity<Integer> {
 
     private ArtifactQuality artifactQuality;
 
-    private User creationUser;
-
     private User modificationUser;
-
-    private Date creationTime;
 
     private Date modificationTime;
 
@@ -93,28 +89,12 @@ public class ArtifactAudited implements GenericEntity<Integer> {
         this.artifactQuality = artifactQuality;
     }
 
-    public User getCreationUser() {
-        return creationUser;
-    }
-
-    public void setCreationUser(User creationUser) {
-        this.creationUser = creationUser;
-    }
-
     public User getModificationUser() {
         return modificationUser;
     }
 
     public void setModificationUser(User modificationUser) {
         this.modificationUser = modificationUser;
-    }
-
-    public Date getCreationTime() {
-        return creationTime;
-    }
-
-    public void setCreationTime(Date creationTime) {
-        this.creationTime = creationTime;
     }
 
     public Date getModificationTime() {
@@ -177,8 +157,6 @@ public class ArtifactAudited implements GenericEntity<Integer> {
             artifactAudited.setRev(rev);
             artifactAudited.setIdRev(new IdRev(artifact.getId(), rev));
             artifactAudited.setArtifactQuality(artifact.getArtifactQuality());
-            artifactAudited.setCreationUser(artifact.getCreationUser());
-            artifactAudited.setCreationTime(artifact.getCreationTime());
             artifactAudited.setModificationTime(artifact.getModificationTime());
             artifactAudited.setModificationUser(artifact.getModificationUser());
             artifactAudited.setReason(artifact.getReason());

--- a/model/src/main/java/org/jboss/pnc/model/ArtifactAudited.java
+++ b/model/src/main/java/org/jboss/pnc/model/ArtifactAudited.java
@@ -50,7 +50,7 @@ public class ArtifactAudited implements GenericEntity<Integer> {
 
     private Date modificationTime;
 
-    private String reason;
+    private String qualityLevelReason;
 
     private Artifact artifact;
 
@@ -105,12 +105,12 @@ public class ArtifactAudited implements GenericEntity<Integer> {
         this.modificationTime = modificationTime;
     }
 
-    public String getReason() {
-        return reason;
+    public String getQualityLevelReason() {
+        return qualityLevelReason;
     }
 
-    public void setReason(String reason) {
-        this.reason = reason;
+    public void setQualityLevelReason(String qualityLevelReason) {
+        this.qualityLevelReason = qualityLevelReason;
     }
 
     public Artifact getArtifact() {
@@ -159,7 +159,7 @@ public class ArtifactAudited implements GenericEntity<Integer> {
             artifactAudited.setArtifactQuality(artifact.getArtifactQuality());
             artifactAudited.setModificationTime(artifact.getModificationTime());
             artifactAudited.setModificationUser(artifact.getModificationUser());
-            artifactAudited.setReason(artifact.getReason());
+            artifactAudited.setQualityLevelReason(artifact.getQualityLevelReason());
             artifactAudited.artifact = artifact;
             return artifactAudited;
         }

--- a/model/src/main/java/org/jboss/pnc/model/ArtifactAudited.java
+++ b/model/src/main/java/org/jboss/pnc/model/ArtifactAudited.java
@@ -1,0 +1,204 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.model;
+
+import java.util.Date;
+
+import org.jboss.pnc.enums.ArtifactQuality;
+
+/**
+ * The audited record of an artifact, to keep track of the changes to the Quality label. Each change to the quality
+ * related fields in the artifact table is recorded in the audit table. This class serves to access the data of a
+ * specific version of a build configuration. Keep in mind that it is not managed by JPA and needs to be filled
+ * manually.
+ *
+ */
+public class ArtifactAudited implements GenericEntity<Integer> {
+
+    private static final long serialVersionUID = -1127405380682198904L;
+
+    /**
+     * The id of the artifact this record is associated with
+     */
+    private Integer id;
+
+    /**
+     * The table revision which identifies version of the artifact
+     */
+    private Integer rev;
+
+    private IdRev idRev;
+
+    private ArtifactQuality artifactQuality;
+
+    private User creationUser;
+
+    private User modificationUser;
+
+    private Date creationTime;
+
+    private Date modificationTime;
+
+    private String reason;
+
+    private Artifact artifact;
+
+    public ArtifactAudited() {
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getRev() {
+        return rev;
+    }
+
+    public void setRev(Integer rev) {
+        this.rev = rev;
+    }
+
+    public IdRev getIdRev() {
+        return idRev;
+    }
+
+    public void setIdRev(IdRev idRev) {
+        this.idRev = idRev;
+    }
+
+    public ArtifactQuality getArtifactQuality() {
+        return artifactQuality;
+    }
+
+    public void setArtifactQuality(ArtifactQuality artifactQuality) {
+        this.artifactQuality = artifactQuality;
+    }
+
+    public User getCreationUser() {
+        return creationUser;
+    }
+
+    public void setCreationUser(User creationUser) {
+        this.creationUser = creationUser;
+    }
+
+    public User getModificationUser() {
+        return modificationUser;
+    }
+
+    public void setModificationUser(User modificationUser) {
+        this.modificationUser = modificationUser;
+    }
+
+    public Date getCreationTime() {
+        return creationTime;
+    }
+
+    public void setCreationTime(Date creationTime) {
+        this.creationTime = creationTime;
+    }
+
+    public Date getModificationTime() {
+        return modificationTime;
+    }
+
+    public void setModificationTime(Date modificationTime) {
+        this.modificationTime = modificationTime;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    public Artifact getArtifact() {
+        return artifact;
+    }
+
+    public void setArtifact(Artifact artifact) {
+        this.artifact = artifact;
+    }
+
+    @Override
+    public String toString() {
+        return "ArtifactAudited [artifactQuality=" + artifactQuality + ", id=" + id + ", rev=" + rev + "]";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        ArtifactAudited that = (ArtifactAudited) o;
+
+        return (idRev != null ? idRev.equals(that.idRev) : false);
+    }
+
+    @Override
+    public int hashCode() {
+        return idRev != null ? idRev.hashCode() : 0;
+    }
+
+    public static class Builder {
+        private Artifact artifact;
+        private Integer rev;
+
+        public static Builder newBuilder() {
+            return new Builder();
+        }
+
+        public ArtifactAudited build() {
+            ArtifactAudited artifactAudited = new ArtifactAudited();
+            artifactAudited.setId(artifact.getId());
+            artifactAudited.setRev(rev);
+            artifactAudited.setIdRev(new IdRev(artifact.getId(), rev));
+            artifactAudited.setArtifactQuality(artifact.getArtifactQuality());
+            artifactAudited.setCreationUser(artifact.getCreationUser());
+            artifactAudited.setCreationTime(artifact.getCreationTime());
+            artifactAudited.setModificationTime(artifact.getModificationTime());
+            artifactAudited.setModificationUser(artifact.getModificationUser());
+            artifactAudited.setReason(artifact.getReason());
+            artifactAudited.artifact = artifact;
+            return artifactAudited;
+        }
+
+        public Builder artifact(Artifact artifact) {
+            this.artifact = artifact;
+            return this;
+        }
+
+        public Builder rev(Integer rev) {
+            this.rev = rev;
+            return this;
+        }
+
+    }
+
+    public static ArtifactAudited fromArtifact(Artifact artifact, Integer revision) {
+        return ArtifactAudited.Builder.newBuilder().artifact(artifact).rev(revision).build();
+    }
+}

--- a/model/src/main/resources/db-update/20000-from-1.8.x-to-2.0.0.sql
+++ b/model/src/main/resources/db-update/20000-from-1.8.x-to-2.0.0.sql
@@ -98,7 +98,7 @@ COMMIT;
 -- [NCL-5680] - Update the model related to Artifacts and revision of quality labels change
 BEGIN transaction;
 
-    ALTER TABLE artifact ADD COLUMN reason varchar(200);
+    ALTER TABLE artifact ADD COLUMN qualitylevelreason varchar(200);
     ALTER TABLE artifact ADD COLUMN creationuser_id integer;
     ALTER TABLE artifact ADD COLUMN modificationuser_id integer;
     ALTER TABLE artifact ADD COLUMN creationtime DATA_TYPE timestamp with time zone;
@@ -116,20 +116,15 @@ BEGIN transaction;
        id integer not null,
        rev integer not null,
        revtype SMALLINT,
-       creationuser_id integer,
        modificationuser_id integer,
-       creationtime DATA_TYPE timestamp with time zone.
        modificationtime DATA_TYPE timestamp with time zone,
-       reason varchar(200),
+       qualityLevelReason varchar(200),
        artifactquality varchar(255) not null,
        primary key (id, rev)
     );
 
-    CREATE INDEX idx_artifact_aud_creation_user ON artifact_aud (creationuser_id);
     CREATE INDEX idx_artifact_aud_modification_user ON artifact_aud (modificationuser_id);
 
-    ALTER TABLE artifact_aud ADD CONSTRAINT fk_artifact_aud_creation_user
-    FOREIGN KEY (creationuser_id) REFERENCES usertable(id);
     ALTER TABLE artifact_aud ADD CONSTRAINT fk_artifact_aud_modification_user
     FOREIGN KEY (modificationuser_id) REFERENCES usertable(id);
     ALTER TABLE artifact_aud ADD CONSTRAINT fk_artifact_aud_revinfo

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ArtifactEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ArtifactEndpoint.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.jboss.pnc.dto.Artifact;
+import org.jboss.pnc.dto.ArtifactRevision;
 import org.jboss.pnc.dto.response.ErrorResponse;
 import org.jboss.pnc.dto.response.MilestoneInfo;
 import org.jboss.pnc.dto.response.Page;
@@ -32,6 +33,7 @@ import org.jboss.pnc.processor.annotation.Client;
 import org.jboss.pnc.rest.annotation.RespondWithStatus;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
 import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.ArtifactPage;
+import org.jboss.pnc.rest.api.swagger.response.SwaggerPages.ArtifactRevisionPage;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -73,6 +75,7 @@ import static org.jboss.pnc.rest.configuration.SwaggerConstants.SUCCESS_DESCRIPT
 @Client
 public interface ArtifactEndpoint {
     static final String A_ID = "ID of the artifact";
+    static final String A_REV = "Revision number of the artifact";
 
     static final String GET_ALL_DESC = "Gets all artifacts.";
     static final String FILTER_SHA256_DESC = "Filter by sha256 of the artifact.";
@@ -251,4 +254,60 @@ public interface ArtifactEndpoint {
     Page<MilestoneInfo> getMilestonesInfo(
             @Parameter(description = A_ID) @PathParam("id") String id,
             @BeanParam PaginationParameters pageParams);
+    static final String GET_ARTIFACT_REVISIONS_DESC = "Gets audited revisions of this artifact.";
+
+    /**
+     * {@value GET_ARTIFACT_REVISIONS_DESC}
+     *
+     * @param id {@value A_ID}
+     * @param pageParams
+     * @return
+     */
+    @Operation(
+            summary = GET_ARTIFACT_REVISIONS_DESC,
+            responses = {
+                    @ApiResponse(
+                            responseCode = SUCCESS_CODE,
+                            description = SUCCESS_DESCRIPTION,
+                            content = @Content(schema = @Schema(implementation = ArtifactRevisionPage.class))),
+                    @ApiResponse(
+                            responseCode = INVALID_CODE,
+                            description = INVALID_DESCRIPTION,
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(
+                            responseCode = SERVER_ERROR_CODE,
+                            description = SERVER_ERROR_DESCRIPTION,
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))) })
+    @GET
+    @Path("/{id}/revisions")
+    Page<ArtifactRevision> getRevisions(
+            @Parameter(description = A_ID) @PathParam("id") String id,
+            @Valid @BeanParam PageParameters pageParams);
+
+    static final String GET_ARTIFACT_REVISION_DESC = "Get specific audited revision of this artifact.";
+
+    /**
+     * {@value GET_ARTIFACT_REVISION_DESC}
+     *
+     * @param id {@value A_ID}
+     * @param rev {@value A_REV}
+     * @return
+     */
+    @Operation(
+            summary = GET_ARTIFACT_REVISION_DESC,
+            responses = {
+                    @ApiResponse(
+                            responseCode = SUCCESS_CODE,
+                            description = SUCCESS_DESCRIPTION,
+                            content = @Content(schema = @Schema(implementation = ArtifactRevision.class))),
+                    @ApiResponse(responseCode = NOT_FOUND_CODE, description = NOT_FOUND_DESCRIPTION),
+                    @ApiResponse(
+                            responseCode = SERVER_ERROR_CODE,
+                            description = SERVER_ERROR_DESCRIPTION,
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))) })
+    @GET
+    @Path("/{id}/revisions/{rev}")
+    ArtifactRevision getRevision(
+            @Parameter(description = A_ID) @PathParam("id") String id,
+            @Parameter(description = A_REV) @PathParam("rev") int rev);
 }

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ArtifactEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ArtifactEndpoint.java
@@ -254,6 +254,7 @@ public interface ArtifactEndpoint {
     Page<MilestoneInfo> getMilestonesInfo(
             @Parameter(description = A_ID) @PathParam("id") String id,
             @BeanParam PaginationParameters pageParams);
+
     static final String GET_ARTIFACT_REVISIONS_DESC = "Gets audited revisions of this artifact.";
 
     /**

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/swagger/response/SwaggerPages.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/swagger/response/SwaggerPages.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.rest.api.swagger.response;
 
 import org.jboss.pnc.dto.Artifact;
+import org.jboss.pnc.dto.ArtifactRevision;
 import org.jboss.pnc.dto.Build;
 import org.jboss.pnc.dto.BuildConfiguration;
 import org.jboss.pnc.dto.BuildConfigurationRevision;
@@ -44,6 +45,9 @@ import org.jboss.pnc.dto.response.Page;
  */
 public class SwaggerPages {
     public static class ArtifactPage extends Page<Artifact> {
+    }
+
+    public static class ArtifactRevisionPage extends Page<ArtifactRevision> {
     }
 
     public static class BuildConfigPage extends Page<BuildConfiguration> {

--- a/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/ArtifactEndpointImpl.java
+++ b/rest-new/src/main/java/org/jboss/pnc/rest/endpoints/ArtifactEndpointImpl.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.rest.endpoints;
 
 import org.jboss.pnc.dto.Artifact;
 import org.jboss.pnc.dto.ArtifactRef;
+import org.jboss.pnc.dto.ArtifactRevision;
 import org.jboss.pnc.dto.response.Page;
 import org.jboss.pnc.facade.providers.api.ArtifactProvider;
 import org.jboss.pnc.rest.api.endpoints.ArtifactEndpoint;
@@ -29,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.PostConstruct;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
+import javax.validation.Valid;
 import java.util.Optional;
 import org.jboss.pnc.dto.Build;
 import org.jboss.pnc.dto.response.MilestoneInfo;
@@ -102,5 +104,15 @@ public class ArtifactEndpointImpl implements ArtifactEndpoint {
     public Page<MilestoneInfo> getMilestonesInfo(String id, PaginationParameters pageParams) {
         return productMilestoneProvider
                 .getMilestonesOfArtifact(id, pageParams.getPageIndex(), pageParams.getPageSize());
+    }
+
+    @Override
+    public Page<ArtifactRevision> getRevisions(String id, @Valid PageParameters pageParams) {
+        return artifactProvider.getRevisions(pageParams.getPageIndex(), pageParams.getPageSize(), id);
+    }
+
+    @Override
+    public ArtifactRevision getRevision(String id, int rev) {
+        return artifactProvider.getRevision(id, rev);
     }
 }

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/ArtifactAuditedRepository.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/ArtifactAuditedRepository.java
@@ -1,0 +1,39 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.spi.datastore.repositories;
+
+import java.util.List;
+
+import org.jboss.pnc.model.ArtifactAudited;
+import org.jboss.pnc.model.IdRev;
+
+/**
+ * Interface for manipulating {@link org.jboss.pnc.model.ArtifactAudited} entity.
+ */
+public interface ArtifactAuditedRepository {
+    List<ArtifactAudited> findAllByIdOrderByRevDesc(Integer id);
+
+    /**
+     * Lookups a ArtifactAudited entity
+     *
+     * @param idRev Id and Revision of a desired ArtifactAudited entity
+     * @return ArtifactAudited or null if there is no such entity
+     */
+    ArtifactAudited queryById(IdRev idRev);
+
+}


### PR DESCRIPTION
Created a new ArtifactAudited table, to watch and record changes related to the ArtifactQuality related fields. Added new fields to record the creationTime, creationUser, modificationTime and modificationUser, and the reason why an ArtifactQuality has changed.