### PR TITLE
Add AdvancedSCMRepositoryClient for websocket notifications

### DIFF
--- a/dto/src/main/java/org/jboss/pnc/dto/notification/SCMRepositoryCreationSuccess.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/notification/SCMRepositoryCreationSuccess.java
@@ -46,7 +46,7 @@ import static org.jboss.pnc.enums.JobNotificationProgress.IN_PROGRESS;
 @Data
 public class SCMRepositoryCreationSuccess extends Notification {
 
-    private static final String BC_CREATION_SUCCESS = "SCMR_CREATION_SUCCESS";
+    public static final String BC_CREATION_SUCCESS = "SCMR_CREATION_SUCCESS";
 
     /**
      * The created SCM Repository.

--- a/rest-client/src/main/java/org/jboss/pnc/restclient/AdvancedSCMRepositoryClient.java
+++ b/rest-client/src/main/java/org/jboss/pnc/restclient/AdvancedSCMRepositoryClient.java
@@ -1,0 +1,133 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.restclient;
+
+import org.jboss.pnc.client.ClientException;
+import org.jboss.pnc.client.Configuration;
+import org.jboss.pnc.client.RemoteResourceException;
+import org.jboss.pnc.client.SCMRepositoryClient;
+import org.jboss.pnc.dto.notification.RepositoryCreationFailure;
+import org.jboss.pnc.dto.notification.SCMRepositoryCreationSuccess;
+import org.jboss.pnc.dto.requests.CreateAndSyncSCMRequest;
+import org.jboss.pnc.dto.response.RepositoryCreationResponse;
+import org.jboss.pnc.restclient.websocket.VertxWebSocketClient;
+import org.jboss.pnc.restclient.websocket.WebSocketClient;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.jboss.pnc.restclient.websocket.predicates.SCMRepositoryNotificationPredicates.withFailedTaskId;
+import static org.jboss.pnc.restclient.websocket.predicates.SCMRepositoryNotificationPredicates.withSuccessTaskId;
+
+public class AdvancedSCMRepositoryClient extends SCMRepositoryClient {
+
+    public AdvancedSCMRepositoryClient(Configuration configuration) {
+        super(configuration);
+    }
+
+    private CompletableFuture<RepositoryCreationFailure> waitForScmCreationFailure(
+            WebSocketClient webSocketClient,
+            String taskId) {
+        return webSocketClient.catchRepositoryCreationFailure(withFailedTaskId(taskId));
+    }
+
+    private CompletableFuture<SCMRepositoryCreationSuccess> waitForScmCreationSuccess(
+            WebSocketClient webSocketClient,
+            String taskId) {
+
+        return webSocketClient.catchSCMRepositoryCreationSuccess(withSuccessTaskId(taskId));
+    }
+
+    /**
+     * If the scm repository is already created and present in the Orch database, a RemoteResourceException is thrown.
+     * It's recommended that you check the presence of the repository before creating it.
+     *
+     * @param request scm to create
+     * @return CompletableFuture of the result, whether it was successful or not
+     * @throws RemoteResourceException Most likely thrown if repository already exists
+     * @throws ClientException if the response from the server is strange: both task id and scm repository is null
+     */
+    public CompletableFuture<SCMCreationResult> createNewAndWait(CreateAndSyncSCMRequest request)
+            throws RemoteResourceException, ClientException {
+
+        WebSocketClient webSocketClient = new VertxWebSocketClient();
+        webSocketClient.connect("ws://" + configuration.getHost() + "/pnc-rest-new/notifications").join();
+
+        RepositoryCreationResponse response = super.createNew(request);
+
+        if (response.getTaskId() == null) {
+
+            if (response.getRepository() != null) {
+                // if repository is internal, it'll get created immediately. Just wrap the results into the
+                // CompletableFuture
+                SCMRepositoryCreationSuccess dto = new SCMRepositoryCreationSuccess(response.getRepository(), null);
+                return CompletableFuture.completedFuture(new SCMCreationResult(true, dto, null));
+            } else {
+                throw new ClientException(
+                        "Something went wrong on creation of repository. task id and repository are both null");
+            }
+        }
+
+        // if bpm task called, listen to either creation or failure events
+        return CompletableFuture
+                .anyOf(
+                        waitForScmCreationFailure(webSocketClient, response.getTaskId().toString()),
+                        waitForScmCreationSuccess(webSocketClient, response.getTaskId().toString()))
+                .thenApply(a -> {
+                    if (a instanceof SCMRepositoryCreationSuccess) {
+                        return new SCMCreationResult(true, (SCMRepositoryCreationSuccess) a, null);
+                    } else if (a instanceof RepositoryCreationFailure) {
+                        return new SCMCreationResult(false, null, (RepositoryCreationFailure) a);
+                    } else {
+                        return new SCMCreationResult(false, null, null);
+                    }
+                })
+                .whenCompleteAsync((x, y) -> webSocketClient.disconnect());
+    }
+
+    /**
+     * DTO object to hold the final result of scm creation, whether it's successful or not
+     */
+    public static class SCMCreationResult {
+
+        private final boolean success;
+        private final SCMRepositoryCreationSuccess scmRepositoryCreationSuccess;
+        private final RepositoryCreationFailure repositoryCreationFailure;
+
+        public SCMCreationResult(
+                boolean success,
+                SCMRepositoryCreationSuccess scmRepositoryCreationSuccess,
+                RepositoryCreationFailure repositoryCreationFailure) {
+
+            this.success = success;
+            this.scmRepositoryCreationSuccess = scmRepositoryCreationSuccess;
+            this.repositoryCreationFailure = repositoryCreationFailure;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public SCMRepositoryCreationSuccess getScmRepositoryCreationSuccess() {
+            return scmRepositoryCreationSuccess;
+        }
+
+        public RepositoryCreationFailure getRepositoryCreationFailure() {
+            return repositoryCreationFailure;
+        }
+    }
+}

--- a/rest-client/src/main/java/org/jboss/pnc/restclient/websocket/VertxWebSocketClient.java
+++ b/rest-client/src/main/java/org/jboss/pnc/restclient/websocket/VertxWebSocketClient.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.WebSocket;
+import io.vertx.core.impl.ConcurrentHashSet;
 import org.jboss.pnc.common.json.JsonOutputConverterMapper;
 import org.jboss.pnc.dto.notification.BuildChangedNotification;
 import org.jboss.pnc.dto.notification.BuildConfigurationCreation;
@@ -38,6 +39,7 @@ import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -56,9 +58,10 @@ public class VertxWebSocketClient implements WebSocketClient, AutoCloseable {
 
     private WebSocket webSocketConnection;
 
-    private Set<Dispatcher> dispatchers = new HashSet<>();
+    // use concurrent version since we may modify that list concurrently
+    private Set<Dispatcher> dispatchers = ConcurrentHashMap.newKeySet();
 
-    private Set<CompletableFuture<Notification>> singleNotificationFutures = new HashSet<>();
+    private Set<CompletableFuture<Notification>> singleNotificationFutures = ConcurrentHashMap.newKeySet();
 
     /**
      * number of attempted retries before client throws an exception

--- a/rest-client/src/main/java/org/jboss/pnc/restclient/websocket/predicates/SCMRepositoryNotificationPredicates.java
+++ b/rest-client/src/main/java/org/jboss/pnc/restclient/websocket/predicates/SCMRepositoryNotificationPredicates.java
@@ -1,0 +1,68 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.restclient.websocket.predicates;
+
+import org.jboss.pnc.dto.notification.RepositoryCreationFailure;
+import org.jboss.pnc.dto.notification.SCMRepositoryCreationSuccess;
+import org.jboss.pnc.enums.JobNotificationProgress;
+import org.jboss.pnc.enums.JobNotificationType;
+
+import java.util.function.Predicate;
+
+public class SCMRepositoryNotificationPredicates {
+
+    public SCMRepositoryNotificationPredicates() {
+    }
+
+    /**
+     * Filter for notifications that say that the repository creation process failed
+     *
+     * withFailedTaskId and withSuccessTaskId may run in parallel. So it's important to be very specific in the
+     * filtering so that we don't accidentally consider a successful notification as a failed one.
+     *
+     * We consider a notification for a task id as failed if the job notification has 'ERROR' in it. This applies for:
+     * RC_REPO_CLONE_ERROR, RC_REPO_CREATION_ERROR, RC_CREATION_ERROR
+     *
+     * We also want to make sure that the final progress state is 'FINISHED'
+     *
+     * @param taskId task id to listen for events
+     * @return predicate
+     */
+    public static Predicate<RepositoryCreationFailure> withFailedTaskId(String taskId) {
+        return (notification) -> notification.getTaskId().equals(taskId)
+                && JobNotificationProgress.FINISHED.equals(notification.getProgress())
+                && notification.getNotificationType().toString().contains("ERROR");
+    }
+
+    /**
+     * Filter for notifications where the scm repository creation is a success!
+     *
+     * withFailedTaskId and withSuccessTaskId may run in parallel. So it's important to be very specific in the
+     * filtering so that we don't accidentally consider a successful notification as a failed one.
+     *
+     * @param taskId task id to listen for events
+     * @return predicate
+     */
+    public static Predicate<SCMRepositoryCreationSuccess> withSuccessTaskId(String taskId) {
+        return (notification) -> notification.getTaskId().equals(taskId)
+                && JobNotificationProgress.FINISHED.equals(notification.getProgress())
+                && notification.getScmRepository() != null
+                && notification.getJob().equals(JobNotificationType.SCM_REPOSITORY_CREATION)
+                && notification.getNotificationType().equals(SCMRepositoryCreationSuccess.BC_CREATION_SUCCESS);
+    }
+}


### PR DESCRIPTION
This will handle websocket notifications for both success and failures
of scm creation

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
