### PR TITLE
[NCLSUP-82] Search for temp, successful builds

### DIFF
--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuildRecordPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuildRecordPredicates.java
@@ -94,9 +94,9 @@ public class BuildRecordPredicates {
     /**
      * (related to NCL-5192, NCL-5351)
      *
-     * When (re)building a temporary build: - if there are existing temporary builds having the same idRev, ignore
-     * persistent builds - if there are no existing temporary builds having the same idRev, include also persistent
-     * builds having the same idRev
+     * When (re)building a temporary build: - if there are existing *successful* temporary builds having the same idRev,
+     * ignore persistent builds - if there are no existing temporary builds having the same idRev, include also
+     * persistent builds having the same idRev
      *
      * When (re)building a persistent build: - include only existing persistent builds having the same idRev
      *
@@ -114,6 +114,7 @@ public class BuildRecordPredicates {
                 temporaryCount.where(
                         cb.and(
                                 cb.isTrue(subRoot.get(BuildRecord_.temporaryBuild)),
+                                cb.equal(subRoot.get(BuildRecord_.status), BuildStatus.SUCCESS),
                                 cb.equal(subRoot.get(BuildRecord_.buildConfigurationId), idRev.getId()),
                                 cb.equal(subRoot.get(BuildRecord_.buildConfigurationRev), idRev.getRev())));
 


### PR DESCRIPTION
When deciding whether to only search for temp builds, or to include
permanent builds during implicit dependency check, we need to search for
successful temporary builds.

If only the search for successful temporary builds is empty, should we
consider permanent builds only.

If the extra successful check is not added, we'll also consider the not
successful builds, which is not ok.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
