### PR TITLE
Bump version of formatter-maven-plugin, byte-buddy, swagger2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <version.kie-services-client>6.2.0.Final</version.kie-services-client>
     <version.keycloak>9.0.3.redhat-00002</version.keycloak>
     <version.shrinkwrap.descriptors>2.0.0</version.shrinkwrap.descriptors>
-    <version.swagger2>2.1.2</version.swagger2>
+    <version.swagger2>2.1.3</version.swagger2>
     <version.buildagent>0.7.0-SNAPSHOT</version.buildagent>
     <version.lombok>1.18.12</version.lombok>
     <version.mapstruct>1.3.1.Final</version.mapstruct>
@@ -918,7 +918,7 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.10.11</version> <!-- force version provided by mockito to override hibernate version -->
+        <version>1.10.13</version> <!-- force version provided by mockito to override hibernate version -->
       </dependency>
       <dependency>
         <groupId>com.googlecode.catch-exception</groupId>
@@ -1677,7 +1677,7 @@
       <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.11.0</version>
+          <version>2.12.0</version>
           <configuration>
               <configFile>../eclipse-codeStyle.xml</configFile>
           </configuration>


### PR DESCRIPTION
formatter-maven-plugin: 2.11.0 -> 2.12.0
byte-buddy: 1.10.11 -> 1.10.13
swagger2: 2.1.2 -> 2.1.3

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
