### PR TITLE
Bump versions: jakartaee8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.jboss.bom</groupId> <!-- Use BOM as parent to have access to the properties -->
     <artifactId>jboss-eap-jakartaee8</artifactId>
-    <version>7.3.0.GA</version>
+    <version>7.3.1.GA</version>
   </parent>
 
   <groupId>org.jboss.pnc</groupId>
@@ -329,7 +329,7 @@
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>1.24</version>
+        <version>1.26</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -772,7 +772,7 @@
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
         <artifactId>wiremock-jre8</artifactId>
-        <version>2.26.3</version>
+        <version>2.27.1</version>
         <scope>test</scope>
       </dependency>
 
@@ -1003,7 +1003,7 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>4.3.0</version>
+        <version>4.3.1</version>
         <scope>test</scope>
       </dependency>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -120,7 +120,7 @@
             <plugin>
                 <groupId>io.openapitools.swagger</groupId>
                 <artifactId>swagger-maven-plugin</artifactId>
-                <version>2.1.2</version>
+                <version>2.1.3</version>
                 <configuration>
                     <resourcePackages>
                         <resourcePackage>org.jboss.pnc.rest.api.endpoints</resourcePackage>


### PR DESCRIPTION
Bump versions:
- jboss-eap-jakartaee8 from 7.3.0 to 7.3.1
- swagger-maven-plguin from 2.1.2 to 2.1.3
- wiremock-jre8 from 2.26.3 to 2.27.1
- rest-assured from 4.3.0 to 4.3.1
- snakeyaml from 1.24 to 1.26

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
