### PR TITLE
[NCL-5895] Auto-close vertx websocket for the advanced clients

### DIFF
--- a/rest-client/src/main/java/org/jboss/pnc/restclient/AdvancedBuildClient.java
+++ b/rest-client/src/main/java/org/jboss/pnc/restclient/AdvancedBuildClient.java
@@ -34,7 +34,13 @@ import java.util.concurrent.TimeoutException;
 import static org.jboss.pnc.restclient.websocket.predicates.BuildPushResultNotificationPredicates.withBuildId;
 import static org.jboss.pnc.restclient.websocket.predicates.BuildPushResultNotificationPredicates.withPushCompleted;
 
-public class AdvancedBuildClient extends BuildClient {
+/**
+ * AdvancedBuildClient that provides additional features to wait for a build to finish.
+ *
+ * It is highly recommended to use the class inside a try-with-resources statement to properly cleanup the websocket
+ * client. Otherwise the program using this class may hang indefinitely
+ */
+public class AdvancedBuildClient extends BuildClient implements AutoCloseable {
 
     private WebSocketClient webSocketClient = new VertxWebSocketClient();
 
@@ -68,6 +74,20 @@ public class AdvancedBuildClient extends BuildClient {
             throw new RuntimeException(e);
         } finally {
             webSocketClient.disconnect();
+        }
+    }
+
+    /**
+     * Run this auto-close to make sure all vertx event loops are closed
+     */
+    @Override
+    public void close() {
+        if (webSocketClient != null) {
+            try {
+                webSocketClient.close();
+            } catch (Exception e) {
+                throw new RuntimeException("Couldn't close websocket", e);
+            }
         }
     }
 }

--- a/rest-client/src/main/java/org/jboss/pnc/restclient/AdvancedBuildConfigurationClient.java
+++ b/rest-client/src/main/java/org/jboss/pnc/restclient/AdvancedBuildConfigurationClient.java
@@ -34,7 +34,13 @@ import org.jboss.pnc.rest.api.parameters.BuildParameters;
 import org.jboss.pnc.restclient.websocket.VertxWebSocketClient;
 import org.jboss.pnc.restclient.websocket.WebSocketClient;
 
-public class AdvancedBuildConfigurationClient extends BuildConfigurationClient {
+/**
+ * AdvancedBuildConfigurationClient that provides additional features to wait for a build to finish.
+ *
+ * It is highly recommended to use the class inside a try-with-resources statement to properly cleanup the websocket
+ * client. Otherwise the program using this class may hang indefinitely
+ */
+public class AdvancedBuildConfigurationClient extends BuildConfigurationClient implements AutoCloseable {
 
     private WebSocketClient webSocketClient = new VertxWebSocketClient();
 
@@ -88,6 +94,20 @@ public class AdvancedBuildConfigurationClient extends BuildConfigurationClient {
             throw new RuntimeException(e);
         } finally {
             webSocketClient.disconnect();
+        }
+    }
+
+    /**
+     * Run this auto-close to make sure all vertx event loops are closed
+     */
+    @Override
+    public void close() {
+        if (webSocketClient != null) {
+            try {
+                webSocketClient.close();
+            } catch (Exception e) {
+                throw new RuntimeException("Couldn't close websocket", e);
+            }
         }
     }
 }

--- a/rest-client/src/main/java/org/jboss/pnc/restclient/AdvancedGroupConfigurationClient.java
+++ b/rest-client/src/main/java/org/jboss/pnc/restclient/AdvancedGroupConfigurationClient.java
@@ -35,7 +35,13 @@ import org.jboss.pnc.rest.api.parameters.GroupBuildParameters;
 import org.jboss.pnc.restclient.websocket.VertxWebSocketClient;
 import org.jboss.pnc.restclient.websocket.WebSocketClient;
 
-public class AdvancedGroupConfigurationClient extends GroupConfigurationClient {
+/**
+ * AdvancedGroupConfigurationClient that provides additional features to wait for a group build to finish
+ *
+ * It is highly recommended to use the class inside a try-with-resources statement to properly cleanup the websocket
+ * client. Otherwise the program using this class may hang indefinitely
+ */
+public class AdvancedGroupConfigurationClient extends GroupConfigurationClient implements AutoCloseable {
 
     private WebSocketClient webSocketClient = new VertxWebSocketClient();
 
@@ -73,4 +79,17 @@ public class AdvancedGroupConfigurationClient extends GroupConfigurationClient {
         }
     }
 
+    /**
+     * Run this auto-close to make sure all vertx event loops are closed
+     */
+    @Override
+    public void close() {
+        if (webSocketClient != null) {
+            try {
+                webSocketClient.close();
+            } catch (Exception e) {
+                throw new RuntimeException("Couldn't close websocket", e);
+            }
+        }
+    }
 }


### PR DESCRIPTION
In some cases, we can use the Advanced* clients without having to use
any websocket listener. In those cases, the websocket client is never
closed / disconnected and the vertx event loop runs forever in the
background, causing the application to never exit properly.

This commit adapts the try-with-resources (AutoCloseable) feature in
those clients so that the websocket clients are properly closed once we
are done with them.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
