### PR TITLE
Bumping version of deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,9 +104,9 @@
     <!--<version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.2.Final-redhat-1</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>-->
     <version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>
     <atlasVersion>1.1.0</atlasVersion>
-    <indyVersion>2.2.0</indyVersion>
+    <indyVersion>2.4.1</indyVersion>
     <version.assertj-core>3.16.1</version.assertj-core>
-    <version.mockito>3.4.0</version.mockito>
+    <version.mockito>3.5.9</version.mockito>
     <version.catch-exception>1.2.0</version.catch-exception>
     <version.jbpm>6.2.0.Final</version.jbpm>
     <version.kie-services-client>6.5.0.Final</version.kie-services-client>
@@ -1135,7 +1135,7 @@
       <dependency>
         <groupId>commons-validator</groupId>
         <artifactId>commons-validator</artifactId>
-        <version>1.6</version>
+        <version>1.7</version>
       </dependency>
       <dependency>
         <groupId>com.squareup</groupId>
@@ -1310,7 +1310,7 @@
             <dependency>
               <groupId>org.codehaus.groovy</groupId>
               <artifactId>groovy-all</artifactId>
-              <version>2.4.19</version>
+              <version>2.4.20</version>
               <scope>runtime</scope>
             </dependency>
           </dependencies>
@@ -1690,7 +1690,7 @@
       <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.12.1</version>
+          <version>2.12.2</version>
           <configuration>
               <configFile>../eclipse-codeStyle.xml</configFile>
           </configuration>


### PR DESCRIPTION
Dependencies:
- indy from 2.2.0 to 2.4.1
- mockito from 3.4.0 to 3.5.9
- commons-validator from 1.6 to 1.7
- groovy-all from 2.4.19 to 2.4.20
- formatter-maven-plugin from 2.12.1 to 2.12.2

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
