### PR TITLE
[NCL-6056] Don't eagerly check if group build is NO_REBUILD_REQUIRED

### DIFF
--- a/spi/src/main/java/org/jboss/pnc/spi/coordinator/BuildSetTask.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/coordinator/BuildSetTask.java
@@ -92,16 +92,22 @@ public class BuildSetTask {
             }
             buildConfigSetRecord.ifPresent(r -> r.setStatus(BuildStatus.FAILED));
             finishBuildSetTask();
+        } else if (buildTasks.stream()
+                .allMatch(bt -> bt.getStatus().equals(BuildCoordinationStatus.REJECTED_ALREADY_BUILT))) {
+
+            log.debug(
+                    "Marking build set as NO_REBUILD_REQUIRED as all tasks are rejected already built. BuildSetTask: {}",
+                    this);
+            buildConfigSetRecord.ifPresent(r -> r.setStatus(BuildStatus.NO_REBUILD_REQUIRED));
+
         } else if (buildTasks.stream().allMatch(bt -> bt.getStatus().isCompleted())) {
+
             log.debug("All builds in set completed. BuildSetTask: {}", this);
             buildConfigSetRecord.ifPresent(r -> {
-                if (BuildStatus.NO_REBUILD_REQUIRED.equals(r.getStatus())) {
-                    log.debug("Build set already marked as NO_REBUILD_REQUIRED. BuildSetTask: {}", this);
-                } else {
-                    log.debug("Marking build set as SUCCESS. BuildSetTask: {}", this);
-                    r.setStatus(BuildStatus.SUCCESS);
-                }
+                log.debug("Marking build set as SUCCESS. BuildSetTask: {}", this);
+                r.setStatus(BuildStatus.SUCCESS);
             });
+
             finishBuildSetTask();
         } else {
             if (log.isTraceEnabled()) {


### PR DESCRIPTION
This commit removes the eager check to see if a group build can be
marked as NO_REBUILD_REQUIRED. This is done to avoid the double query to
know if a build requires a rebuild; once on the eager check, and again
when the individual build is processed in the scheduler.

This also reduces the case where the group build is marked as
NO_REBUILD_REQUIRED, but the builds are still in ENQUEUED case, creating
weird behaviours on Bacon PiG feature.

The other reason why this change is required is for the scenario below:

    The group build is updated to the NO_REBUILD_REQUIRED before the list of
    builds are even submitted to the scheduler. So for a window of time, the
    group build is in a final state, and there are also no builds associated
    with the group build. Then the builds are submitted to the scheduler.

    During that window of time, Bacon can ask PNC for the list of builds
    which returns empty. And that causes all kind of issues.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
