### PR TITLE
[NCL-6066] WARNING instead of ERROR when retring to create BuildEnv

### DIFF
--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -515,7 +515,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
                                 onError.accept(new Exception(throwable));
                             } else {
                                 if (!cancelRequested) {
-                                    logger.error(
+                                    logger.warn(
                                             "Creating build environment failed with error '{}'! Retrying ({} retries left)...",
                                             throwable,
                                             retries);


### PR DESCRIPTION
### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
