### PR TITLE
[NCL-5812] Make sure LazyLoading Proxy is used when accesing fields

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/ArtifactAudited.java
+++ b/model/src/main/java/org/jboss/pnc/model/ArtifactAudited.java
@@ -135,7 +135,7 @@ public class ArtifactAudited implements GenericEntity<Integer> {
 
         ArtifactAudited that = (ArtifactAudited) o;
 
-        return (idRev != null ? idRev.equals(that.idRev) : false);
+        return (idRev != null ? idRev.equals(that.getIdRev()) : false);
     }
 
     @Override

--- a/model/src/main/java/org/jboss/pnc/model/BuildConfigurationAudited.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildConfigurationAudited.java
@@ -229,7 +229,7 @@ public class BuildConfigurationAudited implements GenericEntity<Integer> {
 
         BuildConfigurationAudited that = (BuildConfigurationAudited) o;
 
-        return (idRev != null ? idRev.equals(that.idRev) : false);
+        return (idRev != null ? idRev.equals(that.getIdRev()) : false);
     }
 
     @Override

--- a/model/src/main/java/org/jboss/pnc/model/BuildConfigurationSet.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildConfigurationSet.java
@@ -217,7 +217,7 @@ public class BuildConfigurationSet implements GenericEntity<Integer> {
 
         BuildConfigurationSet that = (BuildConfigurationSet) o;
 
-        return id != null ? id.equals(that.id) : that.id == null;
+        return id != null ? id.equals(that.getId()) : that.getId() == null;
 
     }
 

--- a/model/src/main/java/org/jboss/pnc/model/BuildRecordAttribute.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildRecordAttribute.java
@@ -111,7 +111,7 @@ public class BuildRecordAttribute implements Serializable {
         if (o == null || getClass() != o.getClass())
             return false;
         BuildRecordAttribute that = (BuildRecordAttribute) o;
-        return buildRecord.getId().equals(that.buildRecord.getId()) && key.equals(that.key);
+        return buildRecord.getId().equals(that.getBuildRecord().getId()) && key.equals(that.getKey());
     }
 
     @Override

--- a/model/src/main/java/org/jboss/pnc/model/IdRev.java
+++ b/model/src/main/java/org/jboss/pnc/model/IdRev.java
@@ -89,14 +89,14 @@ public class IdRev implements Serializable {
             return false;
         IdRev other = (IdRev) obj;
         if (id == null) {
-            if (other.id != null)
+            if (other.getId() != null)
                 return false;
-        } else if (!id.equals(other.id))
+        } else if (!id.equals(other.getId()))
             return false;
         if (rev == null) {
-            if (other.rev != null)
+            if (other.getRev() != null)
                 return false;
-        } else if (!rev.equals(other.rev))
+        } else if (!rev.equals(other.getRev()))
             return false;
         return true;
     }

--- a/model/src/main/java/org/jboss/pnc/model/TargetRepository.java
+++ b/model/src/main/java/org/jboss/pnc/model/TargetRepository.java
@@ -189,7 +189,7 @@ public class TargetRepository implements GenericEntity<Integer> {
      * @return true if the artifact url came from a trusted repo, false otherwise
      */
     static boolean isTrusted(String artifactOriginUrl, TargetRepository targetRepository) {
-        if (targetRepository.temporaryRepo) {
+        if (targetRepository.getTemporaryRepo()) {
             return false;
         }
         if (artifactOriginUrl == null || artifactOriginUrl.isEmpty()) {

--- a/model/src/main/java/org/jboss/pnc/model/User.java
+++ b/model/src/main/java/org/jboss/pnc/model/User.java
@@ -248,10 +248,10 @@ public class User implements GenericEntity<Integer> {
         }
         User other = (User) obj;
         if (username == null) {
-            if (other.username != null) {
+            if (other.getUsername() != null) {
                 return false;
             }
-        } else if (!username.equals(other.username)) {
+        } else if (!username.equals(other.getUsername())) {
             return false;
         }
         return true;


### PR DESCRIPTION
When a proxy is loaded, the data is not stored in thr proxy object, but in the
“target” object. The fields in the proxy object will remain null forever (or any
value that they have been initialized with), since all methods invoked on the
proxy will be delegated to the target object. [1]

[1]: https://xebia.com/blog/advanced-hibernate-proxy-pitfalls/

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
