### PR TITLE
[NCL-6165] Propagate the brewPullActive DTO to BEC

### DIFF
--- a/bpm/src/main/java/org/jboss/pnc/bpm/model/BuildExecutionConfigurationRest.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/model/BuildExecutionConfigurationRest.java
@@ -75,6 +75,8 @@ public class BuildExecutionConfigurationRest {
 
     protected String tempBuildTimestamp;
 
+    protected boolean brewPullActive;
+
     protected String defaultAlignmentParams;
 
     public static BuildExecutionConfigurationRest valueOf(String serialized) throws IOException {
@@ -136,6 +138,7 @@ public class BuildExecutionConfigurationRest {
                 genericParameters,
                 tempBuild,
                 tempBuildTimestamp,
+                brewPullActive,
                 defaultAlignmentParams);
     }
 

--- a/bpm/src/main/java/org/jboss/pnc/bpm/model/BuildExecutionConfigurationWithCallbackRest.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/model/BuildExecutionConfigurationWithCallbackRest.java
@@ -71,6 +71,7 @@ public class BuildExecutionConfigurationWithCallbackRest extends BuildExecutionC
             Map<String, String> genericParameters,
             boolean tempBuild,
             String tempBuildTimestamp,
+            boolean brewPullActive,
             String completionCallbackUrl,
             String defaultAlignmentParams) {
         super(
@@ -93,6 +94,7 @@ public class BuildExecutionConfigurationWithCallbackRest extends BuildExecutionC
                 genericParameters,
                 tempBuild,
                 tempBuildTimestamp,
+                brewPullActive,
                 defaultAlignmentParams);
         this.completionCallbackUrl = completionCallbackUrl;
     }

--- a/bpm/src/main/java/org/jboss/pnc/bpm/task/BpmBuildTask.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/task/BpmBuildTask.java
@@ -95,6 +95,7 @@ public class BpmBuildTask extends BpmTask {
                 TimeUtils.generateTimestamp(
                         buildTask.getBuildOptions().isTimestampAlignment(),
                         buildTask.getBuildSetTask().getStartTime()),
+                buildConfigurationAudited.isBrewPullActive(),
                 buildConfigurationAudited.getDefaultAlignmentParams());
 
         return new BuildExecutionConfigurationRest(buildExecutionConfiguration);

--- a/bpm/src/test/java/org/jboss/pnc/bpm/test/BuildExecutionConfigurationTest.java
+++ b/bpm/src/test/java/org/jboss/pnc/bpm/test/BuildExecutionConfigurationTest.java
@@ -61,6 +61,7 @@ public class BuildExecutionConfigurationTest {
                 new HashMap<>(),
                 false,
                 null,
+                false,
                 "-DdependencySource=REST -DrepoRemovalBackup=repositories-backup.xml -DversionSuffixStrip= -DreportNonAligned=true");
         BuildExecutionConfigurationRest buildExecutionConfigurationREST = new BuildExecutionConfigurationRest(
                 buildExecutionConfiguration);

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/local/LocalBuildScheduler.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/local/LocalBuildScheduler.java
@@ -97,6 +97,7 @@ public class LocalBuildScheduler implements BuildScheduler {
                 TimeUtils.generateTimestamp(
                         buildTask.getBuildOptions().isTimestampAlignment(),
                         buildTask.getBuildSetTask().getStartTime()),
+                configuration.isBrewPullActive(),
                 configuration.getDefaultAlignmentParams());
 
         try {

--- a/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionConfiguration.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionConfiguration.java
@@ -50,6 +50,7 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
     private final Map<String, String> genericParameters;
     private final boolean tempBuild;
     private final String tempBuildTimestamp;
+    private final boolean brewPullActive;
     private final String defaultAlignmentParams;
 
     public DefaultBuildExecutionConfiguration(
@@ -72,6 +73,7 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
             Map<String, String> genericParameters,
             boolean tempBuild,
             String tempBuildTimestamp,
+            boolean brewPullActive,
             String defaultAlignmentParams) {
 
         this.id = id;
@@ -93,6 +95,7 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
         this.genericParameters = genericParameters;
         this.tempBuild = tempBuild;
         this.tempBuildTimestamp = tempBuildTimestamp;
+        this.brewPullActive = brewPullActive;
         this.defaultAlignmentParams = defaultAlignmentParams;
     }
 
@@ -189,6 +192,11 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
     @Override
     public String getTempBuildTimestamp() {
         return tempBuildTimestamp;
+    }
+
+    @Override
+    public boolean isBrewPullActive() {
+        return brewPullActive;
     }
 
     @Override

--- a/build-executor/src/test/java/org/jboss/pnc/executor/BuildEnvironmentTest.java
+++ b/build-executor/src/test/java/org/jboss/pnc/executor/BuildEnvironmentTest.java
@@ -176,6 +176,7 @@ public class BuildEnvironmentTest {
                 buildConfiguration.getGenericParameters(),
                 false,
                 null,
+                buildConfiguration.isBrewPullActive(),
                 buildConfiguration.getDefaultAlignmentParams());
 
         executor.startBuilding(buildExecutionConfiguration, onBuildExecutionStatusChangedEvent, "");

--- a/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
+++ b/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
@@ -161,6 +161,7 @@ class BuildExecutionBase {
                 buildConfiguration.getGenericParameters(),
                 false,
                 null,
+                buildConfiguration.isBrewPullActive(),
                 buildConfiguration.getDefaultAlignmentParams());
 
         executor.startBuilding(buildExecutionConfiguration, onBuildExecutionStatusChangedEvent, "");

--- a/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationRevision.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationRevision.java
@@ -89,7 +89,8 @@ public class BuildConfigurationRevision extends BuildConfigurationRevisionRef {
             BuildType buildType,
             User creationUser,
             User modificationUser,
-            String defaultAlignmentParams) {
+            String defaultAlignmentParams,
+            boolean brewPullActive) {
         super(
                 id,
                 rev,
@@ -99,7 +100,8 @@ public class BuildConfigurationRevision extends BuildConfigurationRevisionRef {
                 creationTime,
                 modificationTime,
                 buildType,
-                defaultAlignmentParams);
+                defaultAlignmentParams,
+                brewPullActive);
         this.scmRepository = scmRepository;
         this.project = project;
         this.environment = environment;

--- a/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationRevisionRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationRevisionRef.java
@@ -91,6 +91,11 @@ public class BuildConfigurationRevisionRef implements DTOEntity {
      */
     protected final String defaultAlignmentParams;
 
+    /**
+     * Whether brew pull active is on or off
+     */
+    protected final boolean brewPullActive;
+
     @JsonPOJOBuilder(withPrefix = "")
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {

--- a/indy-repository-manager/src/test/java/org/jboss/pnc/indyrepositorymanager/fixture/TestBuildExecution.java
+++ b/indy-repository-manager/src/test/java/org/jboss/pnc/indyrepositorymanager/fixture/TestBuildExecution.java
@@ -71,6 +71,11 @@ public class TestBuildExecution implements BuildExecution {
     }
 
     @Override
+    public boolean isBrewPullActive() {
+        return false;
+    }
+
+    @Override
     public String getTempBuildTimestamp() {
         return null;
     }
@@ -79,5 +84,4 @@ public class TestBuildExecution implements BuildExecution {
     public BuildType getBuildType() {
         return buildType;
     }
-
 }

--- a/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/BuildTaskEndpointTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/BuildTaskEndpointTest.java
@@ -109,6 +109,7 @@ public class BuildTaskEndpointTest {
                 new HashMap<>(),
                 false,
                 null,
+                false,
                 "-DdependencySource=REST -DrepoRemovalBackup=repositories-backup.xml -DversionSuffixStrip= -DreportNonAligned=true");
 
         BuildExecutionConfigurationRest buildExecutionConfigurationRest = new BuildExecutionConfigurationRest(

--- a/model/src/main/java/org/jboss/pnc/model/BuildConfigurationAudited.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildConfigurationAudited.java
@@ -72,6 +72,8 @@ public class BuildConfigurationAudited implements GenericEntity<Integer> {
 
     private BuildConfiguration buildConfiguration;
 
+    private boolean brewPullActive;
+
     /**
      * Instantiates a new project build configuration.
      */
@@ -216,6 +218,14 @@ public class BuildConfigurationAudited implements GenericEntity<Integer> {
         this.defaultAlignmentParams = defaultAlignmentParams;
     }
 
+    public boolean isBrewPullActive() {
+        return brewPullActive;
+    }
+
+    public void setBrewPullActive(boolean brewPullActive) {
+        this.brewPullActive = brewPullActive;
+    }
+
     @Override
     public String toString() {
         return "BuildConfigurationAudit [project=" + project + ", name=" + name + ", id=" + id + ", rev=" + rev + "]";
@@ -262,6 +272,7 @@ public class BuildConfigurationAudited implements GenericEntity<Integer> {
             configurationAudited.setLastModificationUser(buildConfiguration.getLastModificationUser());
             configurationAudited.setDefaultAlignmentParams(buildConfiguration.getDefaultAlignmentParams());
             configurationAudited.buildConfiguration = buildConfiguration;
+            configurationAudited.brewPullActive = buildConfiguration.isBrewPullActive();
             return configurationAudited;
         }
 

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionConfigurationMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionConfigurationMock.java
@@ -49,6 +49,7 @@ public class BuildExecutionConfigurationMock implements BuildExecutionConfigurat
     private List<ArtifactRepository> artifactRepositories;
     private Map<String, String> genericParameters;
     private boolean tempBuild;
+    private boolean brewPullActive;
     private String tempBuildTimestamp;
     private String defaultAlignmentParams;
 
@@ -230,6 +231,15 @@ public class BuildExecutionConfigurationMock implements BuildExecutionConfigurat
 
     public void setTempBuild(boolean tempBuild) {
         this.tempBuild = tempBuild;
+    }
+
+    @Override
+    public boolean isBrewPullActive() {
+        return brewPullActive;
+    }
+
+    public void setBrewPullActive(boolean brewPullActive) {
+        this.brewPullActive = brewPullActive;
     }
 
     @Override

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/spi/BuildExecutionConfigurationMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/spi/BuildExecutionConfigurationMock.java
@@ -51,6 +51,7 @@ public class BuildExecutionConfigurationMock {
                 new HashMap<>(),
                 false,
                 null,
+                false,
                 "-DdependencySource=REST -DrepoRemovalBackup=repositories-backup.xml -DversionSuffixStrip= -DreportNonAligned=true");
     }
 }

--- a/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionConfiguration.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionConfiguration.java
@@ -82,6 +82,7 @@ public interface BuildExecutionConfiguration extends BuildExecution {
             Map<String, String> genericParameters,
             boolean tempBuild,
             String tempBuildTimestamp,
+            boolean brewPullActive,
             String defaultAlignmentParams) {
         return build(
                 id,
@@ -103,6 +104,7 @@ public interface BuildExecutionConfiguration extends BuildExecution {
                 genericParameters,
                 tempBuild,
                 tempBuildTimestamp,
+                brewPullActive,
                 defaultAlignmentParams);
     }
 
@@ -126,6 +128,7 @@ public interface BuildExecutionConfiguration extends BuildExecution {
             Map<String, String> genericParameters,
             boolean tempBuild,
             String tempBuildTimestamp,
+            boolean brewPullActive,
             String defaultAlignmentParams) {
 
         List<ArtifactRepository> builtRepositories;
@@ -234,6 +237,11 @@ public interface BuildExecutionConfiguration extends BuildExecution {
             @Override
             public boolean isTempBuild() {
                 return tempBuild;
+            }
+
+            @Override
+            public boolean isBrewPullActive() {
+                return brewPullActive;
             }
 
             @Override

--- a/spi/src/main/java/org/jboss/pnc/spi/repositorymanager/BuildExecution.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/repositorymanager/BuildExecution.java
@@ -29,6 +29,8 @@ public interface BuildExecution {
 
     boolean isTempBuild();
 
+    boolean isBrewPullActive();
+
     BuildType getBuildType();
 
     String getTempBuildTimestamp();


### PR DESCRIPTION
BEC = BuildExecutionConfiguration

We use BEC as our DTO (or one of) to submit build requests to Maitai.
Adding `brewPullActive` there created this chain of other objects that
needed to be adjusted to propagate that value. If you're asking
yourself: "Why did he change that object?", it's because I had to
propagate it, otherwise the compiler gets upset at me.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
