### PR TITLE
[NCLSUP-217] Improvements to internal url check for builder pod creation

### DIFF
--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -466,7 +466,7 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         CompletableFuture<RunningEnvironment> runningEnvironmentFuture = allOfOrException(
                 podFuture,
                 serviceFuture,
-                routeFuture).thenApplyAsync(nul -> isBuildAgentUpFuture)
+                routeFuture).thenComposeAsync(nul -> isBuildAgentUpFuture)
                         .thenApplyAsync(
                                 nul -> RunningEnvironment.createInstance(
                                         pod.getName(),


### PR DESCRIPTION
## First commit
This PR fixes an issue where the internal url may not be properly
constructed at the beginning of the
`OpenshiftStartedEnvironment::monitorInitialization` method. When the
method is called, we don't know yet if the service object has been
created with a proper cluster IP yet. The url might look like this in
those cases: 'http:/pnc-ba-1234/', which strangely the 'URL' object
doesn't complain.

This PR tries to get the latest internal url everytime it checks if
the internal url is online.

This PR also sets a read timeout of 2 seconds so that we do not wait
forever for data to be sent back.

## Second commit
The `isBuildAgentFuture` completablefuture checks whether the internal
url of the service can be used to talk to the build agent server. This
establishes the readiness of the pod. The same url is used later on when
uploading the build script to PNC.

Unfortunately, due to Java's confusing completable future chain methods,
the wrong method 'thenApply' is used instead of `thenCompose`.

`thenApply` expects a lambda returning a 'regular' value and
ignores whether the value is a completable future before passing it to the next
chain. The result of `isBuildAgentFuture` is therefore lost in the next
chain.

`thenCompose` expects to receive a lambda returning a completable
future, waits for that completable future to finish, before moving on to
the next chain.

From: https://stackoverflow.com/a/43025751/2907906


### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
