### PR TITLE
Return relevant error in case of BuildConflictException

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/endpoints/BuildConfigurationEndpointImpl.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoints/BuildConfigurationEndpointImpl.java
@@ -35,6 +35,7 @@ import org.jboss.pnc.facade.providers.api.BuildConfigurationSupportedGenericPara
 import org.jboss.pnc.facade.providers.api.BuildPageInfo;
 import org.jboss.pnc.facade.providers.api.BuildProvider;
 import org.jboss.pnc.facade.providers.api.GroupConfigurationProvider;
+import org.jboss.pnc.facade.validation.AlreadyRunningException;
 import org.jboss.pnc.facade.validation.InvalidEntityException;
 import org.jboss.pnc.mapper.api.BuildMapper;
 import org.jboss.pnc.facade.validation.ValidationBuilder;
@@ -119,7 +120,11 @@ public class BuildConfigurationEndpointImpl implements BuildConfigurationEndpoin
 
     @Override
     public Build trigger(String id, BuildParameters buildParams) {
-        return triggerBuild(id, OptionalInt.empty(), buildParams);
+        try {
+            return triggerBuild(id, OptionalInt.empty(), buildParams);
+        } catch (BuildConflictException ex) {
+            throw new AlreadyRunningException(ex, ex.getBuildTaskId());
+        }
     }
 
     @Override
@@ -191,7 +196,11 @@ public class BuildConfigurationEndpointImpl implements BuildConfigurationEndpoin
 
     @Override
     public Build triggerRevision(String id, int rev, BuildParameters buildParams) {
-        return triggerBuild(id, OptionalInt.of(rev), buildParams);
+        try {
+            return triggerBuild(id, OptionalInt.of(rev), buildParams);
+        } catch (BuildConflictException ex) {
+            throw new AlreadyRunningException(ex, ex.getBuildTaskId());
+        }
     }
 
     @Override
@@ -238,7 +247,7 @@ public class BuildConfigurationEndpointImpl implements BuildConfigurationEndpoin
         return new AlignmentParameters(buildType, alignmentConfig.getAlignmentParameters().get(buildType));
     }
 
-    private Build triggerBuild(String id, OptionalInt rev, BuildParameters buildParams) {
+    private Build triggerBuild(String id, OptionalInt rev, BuildParameters buildParams) throws BuildConflictException {
         try {
             logger.debug(
                     "Endpoint /build requested for buildConfigurationId: {}, revision: {}, parameters: {}",
@@ -250,7 +259,7 @@ public class BuildConfigurationEndpointImpl implements BuildConfigurationEndpoin
             long buildId = buildTriggerer.triggerBuild(Integer.parseInt(id), rev, buildOptions);
 
             return buildProvider.getSpecific(BuildMapper.idMapper.toDto(buildId));
-        } catch (BuildConflictException | CoreException ex) {
+        } catch (CoreException ex) {
             throw new RuntimeException(ex);
         }
     }


### PR DESCRIPTION
Error handling enhancement. When a build trigger failed because of a
conflicting build already running, it got thrown as a RuntimeException.
Switched that to AlreadyRunningException with conflicting task ID as
the response object.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
