### PR TITLE
[NCL-6340] Make '!' operator available in buildConfigName filtering

### DIFF
--- a/facade/src/main/java/org/jboss/pnc/facade/providers/BuildProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/BuildProviderImpl.java
@@ -100,6 +100,7 @@ import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.TreeSet;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -837,11 +838,19 @@ public class BuildProviderImpl extends AbstractUpdatableProvider<Long, BuildReco
     }
 
     private Predicate<BuildRecord> getPredicateWithBuildConfigName(String buildConfigName) {
+        Function<List<IdRev>, Predicate<BuildRecord>> predicateFunction;
+        if (buildConfigName.startsWith("!")) {
+            buildConfigName = buildConfigName.substring(1);
+            predicateFunction = BuildRecordPredicates::exceptBuildConfigurationIdRev;
+        } else {
+            predicateFunction = BuildRecordPredicates::withBuildConfigurationIdRev;
+        }
+
         List<IdRev> buildConfigurationAuditedIdRevs = buildConfigurationAuditedRepository
                 .searchIdRevForBuildConfigurationName(buildConfigName);
 
         if (!buildConfigurationAuditedIdRevs.isEmpty()) {
-            return BuildRecordPredicates.withBuildConfigurationIdRev(buildConfigurationAuditedIdRevs);
+            return predicateFunction.apply(buildConfigurationAuditedIdRevs);
         } else {
             return Predicate.nonMatching();
         }

--- a/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/BuildEndpointTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/BuildEndpointTest.java
@@ -275,6 +275,24 @@ public class BuildEndpointTest {
     }
 
     @Test
+    public void shouldFilterByBuildConfigurationNameNotLike() throws Exception {
+        BuildClient client = new BuildClient(RestClientConfiguration.asAnonymous());
+        String buildConfigName = DatabaseDataInitializer.PNC_PROJECT_BUILD_CFG_ID;
+        BuildsFilterParameters filter = new BuildsFilterParameters();
+        filter.setBuildConfigName("!*" + buildConfigName.substring(1, buildConfigName.length() - 2) + "*");
+
+        List<String> buildConfigNames = client.getAll(filter, null)
+                .getAll()
+                .stream()
+                .map(Build::getBuildConfigRevision)
+                .map(BuildConfigurationRevisionRef::getName)
+                .collect(Collectors.toList());
+
+        assertThat(buildConfigNames).hasSize(2); // from DatabaseDataInitializer
+        assertThat(buildConfigNames).doesNotContain(buildConfigName);
+    }
+
+    @Test
     public void shouldFilterByNotExistingBuildConfigurationName() throws Exception {
         BuildClient client = new BuildClient(RestClientConfiguration.asAnonymous());
         String buildConfigName = "SomeRandomName";

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuildRecordPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuildRecordPredicates.java
@@ -174,6 +174,11 @@ public class BuildRecordPredicates {
         };
     }
 
+    public static Predicate<BuildRecord> exceptBuildConfigurationIdRev(List<IdRev> buildConfigurationsWithIdRevs) {
+        return (root, query, cb) -> cb
+                .not(withBuildConfigurationIdRev(buildConfigurationsWithIdRevs).apply(root, query, cb));
+    }
+
     public static Predicate<BuildRecord> withArtifactDistributedInMilestone(Integer productMilestoneId) {
         return (root, query, cb) -> {
             SetJoin<BuildRecord, Artifact> builtArtifacts = root.join(BuildRecord_.builtArtifacts);


### PR DESCRIPTION
### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
