### PR TITLE
Remove ocp client getServerReadyStatus call

### DIFF
--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -187,7 +187,6 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         client = new ClientBuilder(environmentConfiguration.getRestEndpointUrl())
                 .usingToken(environmentConfiguration.getRestAuthToken())
                 .build();
-        client.getServerReadyStatus(); // make sure client is connected
 
         environmetVariables = new HashMap<>();
 


### PR DESCRIPTION
In OCP 4.6, this call is authenticated and will fail when we call that
method using the current client. The client calls that method
unauthenticated, which is fine on OCP 3.11 but fails on OCP 4.6 due to
the new authentication requirement.

Let's remove it.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
