### PR TITLE
Migrate to fabric8 client instead of openshift-restclient-java

### DIFF
--- a/openshift-environment-driver/pom.xml
+++ b/openshift-environment-driver/pom.xml
@@ -104,8 +104,8 @@
     </dependency>
 
     <dependency>
-      <groupId>com.openshift</groupId>
-      <artifactId>openshift-restclient-java</artifactId>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-client</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/openshift-environment-driver/src/test/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriverRemoteTest.java
+++ b/openshift-environment-driver/src/test/java/org/jboss/pnc/environment/openshift/OpenshiftEnvironmentDriverRemoteTest.java
@@ -17,7 +17,6 @@
  */
 package org.jboss.pnc.environment.openshift;
 
-import com.openshift.internal.restclient.DefaultClient;
 import org.jboss.pnc.common.json.moduleconfig.OpenshiftEnvironmentDriverModuleConfig;
 import org.jboss.pnc.common.json.moduleconfig.SystemConfig;
 import org.jboss.pnc.common.monitor.PollingMonitor;
@@ -69,8 +68,6 @@ public class OpenshiftEnvironmentDriverRemoteTest {
     private final EnvironmentDriver environmentDriver;
 
     public OpenshiftEnvironmentDriverRemoteTest() throws Exception {
-        // workaround for protected root rest endpoint from where version should be read
-        System.setProperty(DefaultClient.SYSTEM_PROP_OPENSHIFT_API_VERSION, "v1");
 
         SystemConfig systemConfig = Mockito.mock(SystemConfig.class);
         OpenshiftEnvironmentDriverModuleConfig openshiftEnvironmentDriverModuleConfig = Mockito

--- a/pom.xml
+++ b/pom.xml
@@ -779,19 +779,9 @@
       </dependency>
 
       <dependency>
-        <groupId>com.openshift</groupId>
-        <artifactId>openshift-restclient-java</artifactId>
-        <version>5.9.6.Final</version>
-        <exclusions>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-        </exclusions>
+        <groupId>io.fabric8</groupId>
+        <artifactId>openshift-client</artifactId>
+        <version>5.0.1</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This is done to support the latest version of OCP 4.6, which
unfortunately the version we used for openshift-restclient-java does not
support anymore. Since the latter is also deprecated and fabric8 is the
recommended library, let's use this instead

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
