### PR TITLE
[v2.0] getInternalEndpointUrl might return null if service not ready

### DIFF
--- a/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
+++ b/openshift-environment-driver/src/main/java/org/jboss/pnc/environment/openshift/OpenshiftStartedEnvironment.java
@@ -605,9 +605,18 @@ public class OpenshiftStartedEnvironment implements StartedEnvironment {
         }
     }
 
+    /**
+     * Endpoint to get the internal DNS endpoint of the builder pod.
+     *
+     * @return String endpoint if present null if service object is not ready yet or null
+     */
     private String getInternalEndpointUrl() {
-        return "http://" + service.getSpec().getClusterIP() + "/" + buildAgentContextPath + "/"
-                + environmentConfiguration.getBuildAgentBindPath();
+        if (service == null || service.getSpec() == null || service.getSpec().getClusterIP() == null) {
+            return null;
+        } else {
+            return "http://" + service.getSpec().getClusterIP() + "/" + buildAgentContextPath + "/"
+                    + environmentConfiguration.getBuildAgentBindPath();
+        }
     }
 
     /**


### PR DESCRIPTION
Without the change, the original check for isInternalServletAvailable throws an NPE which is not caught and makes the first builder pod created to be marked as broken. A second builder pod is then created. This commit fixes this so that we can use the first builder pod.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
