### PR TITLE
[NCL-6456] Add helper method replaceHostInUrl

### DIFF
--- a/common/src/main/java/org/jboss/pnc/common/util/UrlUtils.java
+++ b/common/src/main/java/org/jboss/pnc/common/util/UrlUtils.java
@@ -181,4 +181,39 @@ public final class UrlUtils {
         return (userInfo == null ? "" : userInfo + "@") + (host == null ? "" : host) + (port == -1 ? "" : ":" + port)
                 + (path == null ? "" : path) + queryAppend + fragmentAppend;
     }
+
+    /**
+     * Substitute the url with a new host (with new scheme and port), leaving the rest unchanged
+     *
+     * @param url Url to change host (e.g http://example.com/booya)
+     * @param newHost the new host (e.g https://localhost:1234)
+     *
+     * @return modified url
+     *
+     * @throws MalformedURLException If urls are malformed
+     */
+    public static String replaceHostInUrl(String url, String newHost) throws MalformedURLException {
+        if (url == null || newHost == null) {
+            return url;
+        }
+
+        URL originalUrl = new URL(url);
+        URL newHostUrl = new URL(newHost);
+
+        boolean hostHasPort = newHost.contains(":");
+
+        int newPort = -1;
+        if (hostHasPort) {
+            newPort = newHostUrl.getPort();
+        }
+
+        // Use implicit port if it's a default port
+        boolean oldIsHttp = originalUrl.getProtocol().equals("http");
+        boolean oldIsHttps = originalUrl.getProtocol().equals("https");
+        boolean useDefaultPort = (newPort == 443 && oldIsHttps) || (newPort == 80 && oldIsHttp);
+
+        newPort = useDefaultPort ? -1 : newPort;
+        URL newURL = new URL(newHostUrl.getProtocol(), newHostUrl.getHost(), newPort, originalUrl.getFile());
+        return newURL.toString();
+    }
 }

--- a/common/src/test/java/org/jboss/pnc/common/test/util/UrlUtilsTest.java
+++ b/common/src/test/java/org/jboss/pnc/common/test/util/UrlUtilsTest.java
@@ -68,4 +68,50 @@ public class UrlUtilsTest {
                 "gitserver.host.com/productization/github.com/jboss-modules.git",
                 UrlUtils.keepHostAndPathOnly(url));
     }
+
+    @Test
+    public void shouldReplaceHostInUrl() throws MalformedURLException {
+        String url = "http://example.com/test?here=no&hi=yes";
+        String host = "https://localhost:8080";
+        Assert.assertEquals("https://localhost:8080/test?here=no&hi=yes", UrlUtils.replaceHostInUrl(url, host));
+
+        url = "https://test.mu";
+        host = "http://localhost:1234";
+        Assert.assertEquals("http://localhost:1234", UrlUtils.replaceHostInUrl(url, host));
+
+        url = "https://test.mu/hi";
+        host = "http://localhost:1234";
+        Assert.assertEquals("http://localhost:1234/hi", UrlUtils.replaceHostInUrl(url, host));
+
+        url = "https://test.mu:1234/hi";
+        host = "http://localhost:81";
+        Assert.assertEquals("http://localhost:81/hi", UrlUtils.replaceHostInUrl(url, host));
+    }
+
+    @Test
+    public void shouldReplaceHostInUrlWithDefaultPort() throws MalformedURLException {
+        String url = "http://example.com/test?here=no&hi=yes";
+        String host = "https://localhost";
+        Assert.assertEquals("https://localhost/test?here=no&hi=yes", UrlUtils.replaceHostInUrl(url, host));
+
+        host = "http://localhost";
+        Assert.assertEquals("http://localhost/test?here=no&hi=yes", UrlUtils.replaceHostInUrl(url, host));
+
+        url = "https://test.mu:1234/hi";
+        host = "http://localhost";
+        Assert.assertEquals("http://localhost/hi", UrlUtils.replaceHostInUrl(url, host));
+    }
+
+    @Test
+    public void shouldThrowExceptionReplaceMalformedHostInUrl() {
+        final String url = "not-a-valid-url";
+        final String host = "https://localhost";
+
+        Assert.assertThrows(MalformedURLException.class, () -> UrlUtils.replaceHostInUrl(url, host));
+
+        final String url2 = "http://example.com:123";
+        final String host2 = "not-a-valid-url";
+        Assert.assertThrows(MalformedURLException.class, () -> UrlUtils.replaceHostInUrl(url2, host2));
+    }
+
 }


### PR DESCRIPTION
This helper method replaces the host in a particular url with a new
host (including the new scheme and port). The new host is in the format:

- `<scheme>://<host>[:<port>]`

where 'port' is optional

If the default ports for http / https are used, then the port
information is omitted.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [x] Have you added unit tests for your change?
