### PR TITLE
Base32

### DIFF
--- a/bpm/src/main/java/org/jboss/pnc/bpm/BpmManager.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/BpmManager.java
@@ -200,11 +200,11 @@ public class BpmManager {
      * This method solves backwards compatibility problem. It will be removed soon.
      */
     @Deprecated
-    public Integer getTaskIdByBuildId(long buildId) {
+    public Integer getTaskIdByBuildId(String buildId) {
         List<Integer> result = tasks.values()
                 .stream()
                 .filter(t -> t instanceof BpmBuildTask)
-                .filter(t -> ((BpmBuildTask) t).getBuildTask().getId() == buildId)
+                .filter(t -> ((BpmBuildTask) t).getBuildTask().getId().equals(buildId))
                 .map(BpmTask::getTaskId)
                 .collect(Collectors.toList());
         if (result.size() > 1) {

--- a/bpm/src/main/java/org/jboss/pnc/bpm/causeway/InProgress.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/causeway/InProgress.java
@@ -27,18 +27,20 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import org.jboss.pnc.model.Base32LongID;
+
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
  */
 @ApplicationScoped
 public class InProgress {
-    private Map<Long, Context> inProgress = new ConcurrentHashMap<>();
+    private Map<Base32LongID, Context> inProgress = new ConcurrentHashMap<>();
 
-    public boolean add(Long id, String tagPrefix, String pushResultId) {
+    public boolean add(Base32LongID id, String tagPrefix, String pushResultId) {
         return inProgress.putIfAbsent(id, new Context(id, tagPrefix, pushResultId)) == null;
     }
 
-    public Context remove(Long id) {
+    public Context remove(Base32LongID id) {
         return inProgress.remove(id);
     }
 
@@ -46,14 +48,14 @@ public class InProgress {
         return Collections.unmodifiableSet(inProgress.values().stream().collect(Collectors.toSet()));
     }
 
-    public Context get(Long id) {
+    public Context get(Base32LongID id) {
         return inProgress.get(id);
     }
 
     @Getter
     @AllArgsConstructor
     public class Context {
-        Long id;
+        Base32LongID id;
         String tagPrefix;
         String pushResultId;
     }

--- a/bpm/src/main/java/org/jboss/pnc/bpm/causeway/ProductMilestoneReleaseManager.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/causeway/ProductMilestoneReleaseManager.java
@@ -26,12 +26,15 @@ import org.jboss.pnc.bpm.model.causeway.BuildImportResultRest;
 import org.jboss.pnc.bpm.model.causeway.BuildImportStatus;
 import org.jboss.pnc.bpm.model.causeway.MilestoneReleaseResultRest;
 import org.jboss.pnc.bpm.task.MilestoneReleaseTask;
+import org.jboss.pnc.common.concurrent.Sequence;
 import org.jboss.pnc.common.json.GlobalModuleGroup;
 import org.jboss.pnc.common.json.moduleconfig.BpmModuleConfig;
 import org.jboss.pnc.dto.ProductMilestoneCloseResult;
 import org.jboss.pnc.enums.BuildPushStatus;
 import org.jboss.pnc.enums.MilestoneCloseStatus;
+import org.jboss.pnc.mapper.api.BuildMapper;
 import org.jboss.pnc.mapper.api.ProductMilestoneCloseResultMapper;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.BuildRecordPushResult;
 import org.jboss.pnc.model.ProductMilestone;
@@ -54,7 +57,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Optional;
 import java.util.function.Function;
-import org.jboss.pnc.common.concurrent.Sequence;
 
 import static org.jboss.pnc.common.util.CollectionUtils.ofNullableCollection;
 
@@ -268,7 +270,7 @@ public class ProductMilestoneReleaseManager {
     private void storeBuildRecordPush(
             BuildImportResultRest buildRest,
             ProductMilestoneRelease productMilestoneRelease) {
-        Long recordId = buildRest.getBuildRecordId();
+        Base32LongID recordId = BuildMapper.idMapper.toEntity(buildRest.getBuildRecordId());
         BuildRecord record = buildRecordRepository.queryById(recordId);
         if (record == null) {
             log.error("No record found for record id: {}, skipped saving info: {}", recordId, buildRest);

--- a/bpm/src/main/java/org/jboss/pnc/bpm/model/BuildExecutionConfigurationRest.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/model/BuildExecutionConfigurationRest.java
@@ -88,7 +88,7 @@ public class BuildExecutionConfigurationRest {
     }
 
     public BuildExecutionConfigurationRest(BuildExecutionConfiguration buildExecutionConfiguration) {
-        id = BuildMapper.idMapper.toDto(buildExecutionConfiguration.getId());
+        id = buildExecutionConfiguration.getId();
         buildContentId = buildExecutionConfiguration.getBuildContentId();
         buildScript = buildExecutionConfiguration.getBuildScript();
         name = buildExecutionConfiguration.getName();
@@ -122,7 +122,7 @@ public class BuildExecutionConfigurationRest {
                 .map(ArtifactRepositoryRest::toArtifactRepository)
                 .collect(Collectors.toList());
         return BuildExecutionConfiguration.build(
-                BuildMapper.idMapper.toEntity(id),
+                id,
                 buildContentId,
                 user.getId(),
                 buildScript,

--- a/bpm/src/main/java/org/jboss/pnc/bpm/model/causeway/BuildImportResultRest.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/model/causeway/BuildImportResultRest.java
@@ -35,7 +35,7 @@ public class BuildImportResultRest {
     /**
      * id of pnc build record
      */
-    private Long buildRecordId;
+    private String buildRecordId;
 
     /**
      * build id assigned by brew

--- a/bpm/src/main/java/org/jboss/pnc/bpm/task/BpmBuildTask.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/task/BpmBuildTask.java
@@ -110,11 +110,11 @@ public class BpmBuildTask extends BpmTask {
         }
     }
 
-    public static Optional<BpmTask> getBpmTaskByBuildTaskId(BpmManager bpmManager, Integer buildTaskId) {
+    public static Optional<BpmTask> getBpmTaskByBuildTaskId(BpmManager bpmManager, String buildTaskId) {
         return bpmManager.getActiveTasks().stream().filter(bpmTask -> {
             if (bpmTask instanceof BpmBuildTask) {
-                long buildId = ((BpmBuildTask) bpmTask).getBuildTask().getId();
-                return buildId == buildTaskId.intValue();
+                String buildId = ((BpmBuildTask) bpmTask).getBuildTask().getId();
+                return buildId.equals(buildTaskId);
             } else {
                 return false;
             }

--- a/bpm/src/test/java/org/jboss/pnc/bpm/test/BuildExecutionConfigurationTest.java
+++ b/bpm/src/test/java/org/jboss/pnc/bpm/test/BuildExecutionConfigurationTest.java
@@ -42,7 +42,7 @@ public class BuildExecutionConfigurationTest {
     public void serializeAndDeserializeBuildResult() throws IOException, BuildDriverException {
 
         BuildExecutionConfiguration buildExecutionConfiguration = BuildExecutionConfiguration.build(
-                1,
+                "1",
                 "condent-id",
                 "1",
                 "mvn clean install",

--- a/bpm/src/test/java/org/jboss/pnc/bpm/test/BuildResultPushManagerTest.java
+++ b/bpm/src/test/java/org/jboss/pnc/bpm/test/BuildResultPushManagerTest.java
@@ -31,6 +31,7 @@ import org.jboss.pnc.enums.BuildStatus;
 import org.jboss.pnc.enums.BuildType;
 import org.jboss.pnc.mock.repository.BuildRecordPushResultRepositoryMock;
 import org.jboss.pnc.mock.repository.BuildRecordRepositoryMock;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildConfigurationAudited;
 import org.jboss.pnc.model.BuildEnvironment;
 import org.jboss.pnc.model.BuildRecord;
@@ -163,7 +164,7 @@ public class BuildResultPushManagerTest {
 
     private BuildRecord buildRecord(boolean withExecutionRootName) {
         BuildRecord record = new BuildRecord();
-        record.setId(Sequence.nextId());
+        record.setId(new Base32LongID(Sequence.nextId()));
         record.setStatus(BuildStatus.SUCCESS);
         record.setBuildConfigurationAudited(bca);
         record.setDependencies(Collections.emptySet());

--- a/bpm/src/test/java/org/jboss/pnc/bpm/test/ProductMilestoneReleaseManagerTest.java
+++ b/bpm/src/test/java/org/jboss/pnc/bpm/test/ProductMilestoneReleaseManagerTest.java
@@ -29,6 +29,7 @@ import org.jboss.pnc.dto.ProductMilestoneCloseResult;
 import org.jboss.pnc.enums.BuildPushStatus;
 import org.jboss.pnc.enums.MilestoneCloseStatus;
 import org.jboss.pnc.enums.ReleaseStatus;
+import org.jboss.pnc.mapper.api.BuildMapper;
 import org.jboss.pnc.mapper.api.ProductMilestoneCloseResultMapper;
 import org.jboss.pnc.mock.repository.*;
 import org.jboss.pnc.model.*;
@@ -163,8 +164,11 @@ public class ProductMilestoneReleaseManagerTest {
                 .isEqualTo(MilestoneCloseStatus.FAILED);
     }
 
-    private BuildImportResultRest buildImportResultRest(BuildImportStatus status, Long buildRecordId, Integer brewId) {
-        return new BuildImportResultRest(buildRecordId, brewId, brewUrl(brewId), status, null);
+    private BuildImportResultRest buildImportResultRest(
+            BuildImportStatus status,
+            Base32LongID buildId,
+            Integer brewId) {
+        return new BuildImportResultRest(BuildMapper.idMapper.toDto(buildId), brewId, brewUrl(brewId), status, null);
     }
 
     /**
@@ -196,7 +200,7 @@ public class ProductMilestoneReleaseManagerTest {
         List<BuildImportResultRest> buildResults = new ArrayList<>();
 
         for (int i = 0; i < records.length; i++) {
-            Long recordId = records[i].getId();
+            Base32LongID recordId = records[i].getId();
             buildResults.add(buildImportResultRest(BuildImportStatus.SUCCESSFUL, recordId, brewBuildId + i));
         }
 
@@ -221,7 +225,7 @@ public class ProductMilestoneReleaseManagerTest {
     private BuildRecord buildRecord(ProductMilestone milestone) {
         BuildRecord record = new BuildRecord();
         record.setProductMilestone(milestone);
-        record.setId(Sequence.nextId());
+        record.setId(new Base32LongID(Sequence.nextId()));
         buildRecordRepository.save(record);
         return record;
     }

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/BuildTasksInitializer.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/BuildTasksInitializer.java
@@ -65,7 +65,7 @@ public class BuildTasksInitializer {
             BuildConfigurationAudited buildConfigurationAudited,
             User user,
             BuildOptions buildOptions,
-            Supplier<Long> buildTaskIdProvider,
+            Supplier<String> buildTaskIdProvider,
             Set<BuildTask> submittedBuildTasks) {
 
         BuildSetTask buildSetTask = BuildSetTask.Builder.newBuilder()
@@ -196,7 +196,7 @@ public class BuildTasksInitializer {
             BuildConfigurationSet buildConfigurationSet,
             User user,
             BuildOptions buildOptions,
-            Supplier<Long> buildTaskIdProvider,
+            Supplier<String> buildTaskIdProvider,
             Set<BuildTask> submittedBuildTasks) throws CoreException {
 
         return createBuildSetTask(
@@ -230,7 +230,7 @@ public class BuildTasksInitializer {
             Map<Integer, BuildConfigurationAudited> buildConfigurationAuditedsMap,
             User user,
             BuildOptions buildOptions,
-            Supplier<Long> buildTaskIdProvider,
+            Supplier<String> buildTaskIdProvider,
             Set<BuildTask> submittedBuildTasks) throws CoreException {
         BuildSetTask buildSetTask = initBuildSetTask(buildConfigurationSet, user, buildOptions);
 
@@ -297,7 +297,7 @@ public class BuildTasksInitializer {
     private void fillBuildTaskSet(
             BuildSetTask buildSetTask,
             User user,
-            Supplier<Long> buildTaskIdProvider,
+            Supplier<String> buildTaskIdProvider,
             ProductMilestone productMilestone,
             Set<BuildConfigurationAudited> toBuild,
             Set<BuildTask> alreadySubmittedBuildTasks,
@@ -312,7 +312,7 @@ public class BuildTasksInitializer {
                 buildTask = taskOptional.get();
                 log.debug("Linking BuildConfigurationAudited {} to existing task {}.", buildConfigAudited, buildTask);
             } else {
-                long buildId = buildTaskIdProvider.get();
+                String buildId = buildTaskIdProvider.get();
                 String buildContentId = ContentIdentityManager.getBuildContentId(buildId);
                 // Used only for this operation inside the loop
                 MDCUtils.addBuildContext(

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinator.java
@@ -206,8 +206,8 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
         return build0(user, buildOptions, buildConfigurationAudited);
     }
 
-    private Long buildRecordIdSupplier() {
-        return Sequence.nextId();
+    private String buildRecordIdSupplier() {
+        return Sequence.nextBase32Id();
     }
 
     /**
@@ -399,7 +399,7 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
     }
 
     @Override
-    public boolean cancel(long buildTaskId) throws CoreException {
+    public boolean cancel(String buildTaskId) throws CoreException {
         // Logging MDC must be set before calling
         Optional<BuildTask> taskOptional = getSubmittedBuildTasks().stream()
                 .filter(buildTask -> buildTask.getId() == buildTaskId)
@@ -424,7 +424,7 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
     }
 
     @Override
-    public Optional<BuildTaskContext> getMDCMeta(Long buildTaskId) {
+    public Optional<BuildTaskContext> getMDCMeta(String buildTaskId) {
         return getSubmittedBuildTasks().stream()
                 .filter(buildTask -> buildTaskId.equals(buildTask.getId()))
                 .map(this::getMDCMeta)
@@ -676,7 +676,7 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
     }
 
     public void completeNoBuild(BuildTask buildTask, CompletionStatus completionStatus) {
-        long buildTaskId = buildTask.getId();
+        String buildTaskId = buildTask.getId();
         BuildCoordinationStatus coordinationStatus = BuildCoordinationStatus.SYSTEM_ERROR;
         try {
             if (CompletionStatus.NO_REBUILD_REQUIRED.equals(completionStatus)) {
@@ -709,7 +709,7 @@ public class DefaultBuildCoordinator implements BuildCoordinator {
     }
 
     public void completeBuild(BuildTask buildTask, BuildResult buildResult) {
-        long buildTaskId = buildTask.getId();
+        String buildTaskId = buildTask.getId();
 
         BuildCoordinationStatus coordinationStatus = BuildCoordinationStatus.SYSTEM_ERROR;
         try {

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/datastore/DatastoreAdapter.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/builder/datastore/DatastoreAdapter.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.coordinator.builder.datastore;
 
 import org.jboss.pnc.coordinator.BuildCoordinationException;
 import org.jboss.pnc.model.Artifact;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildConfigSetRecord;
 import org.jboss.pnc.model.BuildConfiguration;
 import org.jboss.pnc.model.BuildConfigurationAudited;
@@ -363,14 +364,19 @@ public class DatastoreAdapter {
             builder.buildConfigSetRecord(buildConfigSetRecord);
         }
 
-        List<Long> dependencies = buildTask.getDependencies()
+        List<Base32LongID> dependencies = buildTask.getDependencies()
                 .stream()
                 .map(BuildTask::getId)
+                .map(Base32LongID::new)
                 .collect(Collectors.toList());
-        builder.dependencyBuildRecordIds(dependencies.toArray(new Long[dependencies.size()]));
+        builder.dependencyBuildRecordIds(dependencies.toArray(new Base32LongID[dependencies.size()]));
 
-        List<Long> dependants = buildTask.getDependants().stream().map(BuildTask::getId).collect(Collectors.toList());
-        builder.dependentBuildRecordIds(dependants.toArray(new Long[dependants.size()]));
+        List<Base32LongID> dependants = buildTask.getDependants()
+                .stream()
+                .map(BuildTask::getId)
+                .map(Base32LongID::new)
+                .collect(Collectors.toList());
+        builder.dependentBuildRecordIds(dependants.toArray(new Base32LongID[dependants.size()]));
 
         return builder;
     }

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/maintenance/TemporaryBuildsCleanerAsyncInvoker.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/maintenance/TemporaryBuildsCleanerAsyncInvoker.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.coordinator.maintenance;
 
 import org.jboss.pnc.common.concurrent.NamedThreadFactory;
 import org.jboss.pnc.enums.ResultStatus;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildConfigSetRecord;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.spi.coordinator.Result;
@@ -75,7 +76,7 @@ public class TemporaryBuildsCleanerAsyncInvoker {
      * @return True if the build exists and deletion started otherwise, false is build doesn't exist
      * @throws ValidationException Thrown when build cannot be deleted
      */
-    public boolean deleteTemporaryBuild(Long buildRecordId, String authToken, Consumer<Result> onComplete)
+    public boolean deleteTemporaryBuild(Base32LongID buildRecordId, String authToken, Consumer<Result> onComplete)
             throws ValidationException {
         BuildRecord buildRecord = buildRecordRepository.findByIdFetchAllProperties(buildRecordId);
         if (buildRecord == null) {

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/notifications/buildTask/BuildCallBack.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/notifications/buildTask/BuildCallBack.java
@@ -26,15 +26,15 @@ import java.util.function.Consumer;
  */
 public class BuildCallBack {
 
-    private final Long buildTaskId;
+    private final String buildTaskId;
     private final Consumer<BuildStatusChangedEvent> callback;
 
-    public BuildCallBack(long buildTaskId, Consumer<BuildStatusChangedEvent> callback) {
+    public BuildCallBack(String buildTaskId, Consumer<BuildStatusChangedEvent> callback) {
         this.buildTaskId = buildTaskId;
         this.callback = callback;
     }
 
-    public Long getBuildTaskId() {
+    public String getBuildTaskId() {
         return buildTaskId;
     }
 

--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/notifications/buildTask/BuildStatusNotifications.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/notifications/buildTask/BuildStatusNotifications.java
@@ -54,7 +54,7 @@ public class BuildStatusNotifications {
         log.debug("Observed new status changed event {}.", event);
         BuildStatusChangedEvent buildStatusChangedEvent = event; // Avoid CDI runtime issue issue NCL-1505
         Predicate<BuildCallBack> filterSubscribersMatchingTaskId = (callBackUrl) -> callBackUrl.getBuildTaskId()
-                .equals(BuildMapper.idMapper.toEntity(buildStatusChangedEvent.getBuild().getId()));
+                .equals(buildStatusChangedEvent.getBuild().getId());
 
         Set<BuildCallBack> matchingTasks = subscribers.stream()
                 .filter(filterSubscribersMatchingTaskId)

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinatorTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/builder/DefaultBuildCoordinatorTest.java
@@ -374,7 +374,7 @@ public class DefaultBuildCoordinatorTest {
                 BuildConfigurationAudited.fromBuildConfiguration(buildConfiguration, 13),
                 buildOptions,
                 MockUser.newTestUser(1),
-                1,
+                "1",
                 null,
                 new Date(),
                 null,

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/AbstractDependentBuildTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/AbstractDependentBuildTest.java
@@ -190,7 +190,7 @@ public abstract class AbstractDependentBuildTest {
                 .iterator()
                 .next();
         return BuildRecord.Builder.newBuilder()
-                .id(Sequence.nextId())
+                .id(Sequence.nextBase32Id())
                 .status(BuildStatus.SUCCESS)
                 .buildConfigurationAudited(configurationAudited)
                 .temporaryBuild(false)
@@ -273,7 +273,7 @@ public abstract class AbstractDependentBuildTest {
         }
     }
 
-    protected BuildTask getBuildTaskById(Long taskId) {
+    protected BuildTask getBuildTaskById(String taskId) {
         Optional<BuildTask> buildTask = builtTasks.stream().filter(bt -> bt.getId() == taskId).findAny();
         if (buildTask.isPresent()) {
             return buildTask.get();

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/CancelledBuildTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/CancelledBuildTest.java
@@ -77,7 +77,7 @@ public class CancelledBuildTest extends ProjectBuilder {
                 CompletableFuture.runAsync(() -> {
                     try {
                         Thread.sleep(250); // wait a bit for build execution to start
-                        coordinator.cancel(BuildMapper.idMapper.toEntity(event.getBuild().getId()));
+                        coordinator.cancel(event.getBuild().getId());
                     } catch (CoreException | InterruptedException e) {
                         log.error("Unable to cancel the build.", e);
                         Assert.fail("Unable to cancel the build.");
@@ -104,7 +104,7 @@ public class CancelledBuildTest extends ProjectBuilder {
         Assert.assertNotNull(buildRecord.getEndTime());
         Assert.assertEquals(BuildStatus.CANCELLED, buildRecord.getStatus());
 
-        Long buildTaskId = buildTask.getId();
+        String buildTaskId = buildTask.getId();
         assertStatusUpdateReceived(receivedStatuses, BuildStatus.BUILDING, buildTaskId);
         assertStatusUpdateReceived(receivedStatuses, BuildStatus.CANCELLED, buildTaskId);
     }
@@ -127,10 +127,7 @@ public class CancelledBuildTest extends ProjectBuilder {
                         Thread.sleep(250); // wait a bit for build execution to start
                         // we need to get buildConfigSet id to cancel BuildGroup, it is not provided by event class
                         // directly, so we need to dit it up from buildTaskId that event provides
-                        coordinator.cancelSet(
-                                getBuildConfigSetId(
-                                        coordinator,
-                                        BuildMapper.idMapper.toEntity(event.getBuild().getId())));
+                        coordinator.cancelSet(getBuildConfigSetId(coordinator, event.getBuild().getId()));
                     } catch (CoreException | InterruptedException e) {
                         log.error("Unable to cancel the build.", e);
                         Assert.fail("Unable to cancel the build.");
@@ -169,7 +166,7 @@ public class CancelledBuildTest extends ProjectBuilder {
 
         // 3 is independent, 2 is dependent on 3, 1 is dependent on 2
         for (BuildTask buildTask : buildSetTask.getBuildTasks()) {
-            Long buildTaskId = buildTask.getId();
+            String buildTaskId = buildTask.getId();
             switch (buildTask.getBuildConfigurationAudited().getId()) {
                 case 1:
                     // Building status is skipped (cancelled before it can start building)
@@ -193,7 +190,7 @@ public class CancelledBuildTest extends ProjectBuilder {
         }
     }
 
-    private Integer getBuildConfigSetId(BuildCoordinator coordinator, Long buildTaskId) {
+    private Integer getBuildConfigSetId(BuildCoordinator coordinator, String buildTaskId) {
         return coordinator.getSubmittedBuildTasks()
                 .stream()
                 .filter(t -> buildTaskId.equals(t.getId()))

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/DatastoreAdapterTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/DatastoreAdapterTest.java
@@ -200,7 +200,7 @@ public class DatastoreAdapterTest {
                 BuildConfigurationAudited.fromBuildConfiguration(buildConfiguration, 13),
                 buildOptions,
                 MockUser.newTestUser(1),
-                123,
+                "123",
                 null,
                 new Date(),
                 null,

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/ProjectBuilder.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/ProjectBuilder.java
@@ -346,7 +346,7 @@ public class ProjectBuilder {
         }
     }
 
-    private void assertAllStatusUpdateReceived(List<BuildStatusChangedEvent> receivedStatuses, Long buildTaskId) {
+    private void assertAllStatusUpdateReceived(List<BuildStatusChangedEvent> receivedStatuses, String buildTaskId) {
         assertStatusUpdateReceived(receivedStatuses, BuildStatus.ENQUEUED, buildTaskId);
         assertStatusUpdateReceived(receivedStatuses, BuildStatus.BUILDING, buildTaskId);
         assertStatusUpdateReceived(receivedStatuses, BuildStatus.SUCCESS, buildTaskId);
@@ -354,7 +354,7 @@ public class ProjectBuilder {
 
     private void assertAllStatusUpdateReceivedForFailedBuild(
             List<BuildStatusChangedEvent> receivedStatuses,
-            Long buildTaskId) {
+            String buildTaskId) {
         assertStatusUpdateReceived(receivedStatuses, BuildStatus.ENQUEUED, buildTaskId);
         assertStatusUpdateReceived(receivedStatuses, BuildStatus.BUILDING, buildTaskId);
         assertStatusUpdateReceived(receivedStatuses, BuildStatus.FAILED, buildTaskId);
@@ -362,17 +362,17 @@ public class ProjectBuilder {
 
     private void assertAllStatusUpdateReceivedForFailedWaitingForDeps(
             List<BuildStatusChangedEvent> receivedStatuses,
-            Long buildTaskId) {
+            String buildTaskId) {
         assertStatusUpdateReceived(receivedStatuses, BuildStatus.REJECTED, buildTaskId);
     }
 
     void assertStatusUpdateReceived(
             List<BuildStatusChangedEvent> receivedStatusEvents,
             BuildStatus status,
-            Long buildTaskId) {
+            String buildTaskId) {
         boolean received = false;
         for (BuildStatusChangedEvent receivedStatusEvent : receivedStatusEvents) {
-            if (receivedStatusEvent.getBuild().getId().equals(BuildMapper.idMapper.toDto(buildTaskId))
+            if (receivedStatusEvent.getBuild().getId().equals(buildTaskId)
                     && receivedStatusEvent.getNewStatus().equals(status)) {
                 received = true;
                 break;

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/ReadDependenciesTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/ReadDependenciesTest.java
@@ -95,7 +95,7 @@ public class ReadDependenciesTest extends ProjectBuilder {
                 buildConfigurationSet,
                 user,
                 buildOptions,
-                () -> Sequence.nextId(),
+                () -> Sequence.nextBase32Id(),
                 buildQueue.getUnfinishedTasks());
     }
 }

--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/WaitForDependencyBuildTest.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/WaitForDependencyBuildTest.java
@@ -111,7 +111,7 @@ public class WaitForDependencyBuildTest extends AbstractDependentBuildTest {
 
     private class MockBuildSchedulerWithManualBuildCompletion implements BuildScheduler {
 
-        Map<Long, Consumer<BuildResult>> scheduledTasks = new HashMap();
+        Map<String, Consumer<BuildResult>> scheduledTasks = new HashMap();
 
         @Override
         public void startBuilding(BuildTask buildTask, Consumer<BuildResult> onComplete)
@@ -120,7 +120,7 @@ public class WaitForDependencyBuildTest extends AbstractDependentBuildTest {
             scheduledTasks.put(buildTask.getId(), onComplete);
         }
 
-        public void completeBuild(long taskId) {
+        public void completeBuild(String taskId) {
             BuildResult result = buildResult();
             Consumer<BuildResult> buildResultConsumer = scheduledTasks.get(taskId);
 

--- a/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionConfiguration.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionConfiguration.java
@@ -31,7 +31,7 @@ import java.util.Map;
  */
 public class DefaultBuildExecutionConfiguration implements BuildExecutionConfiguration {
 
-    private final long id;
+    private final String id;
     private final String buildContentId;
     private final String userId;
     private final String buildScript;
@@ -54,7 +54,7 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
     private final String defaultAlignmentParams;
 
     public DefaultBuildExecutionConfiguration(
-            long id,
+            String id,
             String buildContentId,
             String userId,
             String buildScript,
@@ -100,7 +100,7 @@ public class DefaultBuildExecutionConfiguration implements BuildExecutionConfigu
     }
 
     @Override
-    public long getId() {
+    public String getId() {
         return id;
     }
 

--- a/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionSession.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutionSession.java
@@ -227,7 +227,7 @@ public class DefaultBuildExecutionSession implements BuildExecutionSession {
     }
 
     @Override
-    public Long getId() {
+    public String getId() {
         return getBuildExecutionConfiguration().getId();
     }
 

--- a/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutor.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutor.java
@@ -84,7 +84,7 @@ public class DefaultBuildExecutor implements BuildExecutor {
     private RepositoryManagerFactory repositoryManagerFactory;
     private BuildDriverFactory buildDriverFactory;
     private EnvironmentDriverFactory environmentDriverFactory;
-    private final ConcurrentMap<Long, DefaultBuildExecutionSession> runningExecutions = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, DefaultBuildExecutionSession> runningExecutions = new ConcurrentHashMap<>();
     private KeycloakServiceClient serviceClient;
 
     private SystemConfig systemConfig;
@@ -131,7 +131,7 @@ public class DefaultBuildExecutor implements BuildExecutor {
                 buildExecutionConfiguration,
                 onBuildExecutionStatusChangedEvent);
 
-        long executionConfigurationId = buildExecutionConfiguration.getId();
+        String executionConfigurationId = buildExecutionConfiguration.getId();
         DefaultBuildExecutionSession existing = runningExecutions
                 .putIfAbsent(executionConfigurationId, buildExecutionSession);
         if (existing != null) {
@@ -175,7 +175,7 @@ public class DefaultBuildExecutor implements BuildExecutor {
     }
 
     @Override
-    public void cancel(Long executionConfigurationId) throws ExecutorException {
+    public void cancel(String executionConfigurationId) throws ExecutorException {
         DefaultBuildExecutionSession buildExecutionSession = runningExecutions.get(executionConfigurationId);
         if (buildExecutionSession != null) {
             log.info("Cancelling build {}.", buildExecutionSession.getId());
@@ -216,7 +216,7 @@ public class DefaultBuildExecutor implements BuildExecutor {
     }
 
     @Override
-    public BuildExecutionSession getRunningExecution(long buildExecutionTaskId) {
+    public BuildExecutionSession getRunningExecution(String buildExecutionTaskId) {
         return runningExecutions.get(buildExecutionTaskId);
     }
 
@@ -453,7 +453,7 @@ public class DefaultBuildExecutor implements BuildExecutor {
     }
 
     private Void completeExecution(DefaultBuildExecutionSession buildExecutionSession, Throwable e) {
-        Long buildExecutionId = buildExecutionSession.getId();
+        String buildExecutionId = buildExecutionSession.getId();
         try {
             // Ends when the result is stored by the Orchestrator
             ProcessStageUtils.logProcessStageBegin("FINALIZING_BUILD", "Finalizing build ...");

--- a/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutorStatusChangedEvent.java
+++ b/build-executor/src/main/java/org/jboss/pnc/executor/DefaultBuildExecutorStatusChangedEvent.java
@@ -28,7 +28,7 @@ class DefaultBuildExecutorStatusChangedEvent implements BuildExecutionStatusChan
 
     private final BuildExecutionStatus oldStatus;
     private final BuildExecutionStatus newStatus;
-    private final Long buildTaskId;
+    private final String buildTaskId;
     private final Integer buildConfigurationId;
     private final Optional<BuildResult> buildResult;
 
@@ -37,7 +37,7 @@ class DefaultBuildExecutorStatusChangedEvent implements BuildExecutionStatusChan
     public DefaultBuildExecutorStatusChangedEvent(
             BuildExecutionStatus oldStatus,
             BuildExecutionStatus newStatus,
-            Long buildTaskId,
+            String buildTaskId,
             Integer buildConfigurationId,
             Optional<BuildResult> buildResult,
             boolean isFinal) {
@@ -51,7 +51,7 @@ class DefaultBuildExecutorStatusChangedEvent implements BuildExecutionStatusChan
     }
 
     @Override
-    public Long getBuildTaskId() {
+    public String getBuildTaskId() {
         return buildTaskId;
     }
 

--- a/build-executor/src/test/java/org/jboss/pnc/executor/BuildEnvironmentTest.java
+++ b/build-executor/src/test/java/org/jboss/pnc/executor/BuildEnvironmentTest.java
@@ -157,7 +157,7 @@ public class BuildEnvironmentTest {
         };
 
         BuildExecutionConfiguration buildExecutionConfiguration = new DefaultBuildExecutionConfiguration(
-                1,
+                "1",
                 "build-content-id",
                 "1",
                 buildConfiguration.getBuildScript(),

--- a/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
+++ b/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionBase.java
@@ -142,7 +142,7 @@ class BuildExecutionBase {
         };
 
         BuildExecutionConfiguration buildExecutionConfiguration = new DefaultBuildExecutionConfiguration(
-                1,
+                "1",
                 "build-content-id",
                 "1",
                 buildConfiguration.getBuildScript(),

--- a/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionCancellationTest.java
+++ b/build-executor/src/test/java/org/jboss/pnc/executor/BuildExecutionCancellationTest.java
@@ -94,7 +94,7 @@ public class BuildExecutionCancellationTest extends BuildExecutionBase {
                 try {
                     log.info("Cancelling build ...");
                     Thread.sleep(100);
-                    executor.cancel(Long.valueOf(buildConfiguration.getId()));
+                    executor.cancel(e.getBuildTaskId());
                 } catch (ExecutorException | InterruptedException e0) {
                     e0.printStackTrace();
                 }

--- a/build-executor/src/test/java/org/jboss/pnc/executor/EarlyCancellationTest.java
+++ b/build-executor/src/test/java/org/jboss/pnc/executor/EarlyCancellationTest.java
@@ -139,7 +139,7 @@ public class EarlyCancellationTest extends BuildExecutionBase {
             if (cancelAfter.equals(e.getNewStatus())) {
                 try {
                     log.info("Cancelling build ...");
-                    executor.cancel(1L);
+                    executor.cancel("1");
                 } catch (ExecutorException e0) {
                     e0.printStackTrace();
                 }

--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/BuildConfigurationAuditedRepositoryImpl.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/BuildConfigurationAuditedRepositoryImpl.java
@@ -21,6 +21,7 @@ import org.hibernate.envers.AuditReaderFactory;
 import org.hibernate.envers.DefaultRevisionEntity;
 import org.hibernate.envers.query.AuditEntity;
 import org.hibernate.envers.query.criteria.AuditDisjunction;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildConfiguration;
 import org.jboss.pnc.model.BuildConfigurationAudited;
 import org.jboss.pnc.model.BuildRecord;
@@ -161,14 +162,14 @@ public class BuildConfigurationAuditedRepositoryImpl implements BuildConfigurati
      */
     private List<BuildRecord> getBuildRecords(IdRev idRev) {
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-        CriteriaQuery<Long> query = cb.createQuery(Long.class);
+        CriteriaQuery<Base32LongID> query = cb.createQuery(Base32LongID.class);
         Root<BuildRecord> root = query.from(BuildRecord.class);
         query.select(root.get(BuildRecord_.id));
         query.where(
                 cb.and(
                         cb.equal(root.get(BuildRecord_.buildConfigurationId), idRev.getId()),
                         cb.equal(root.get(BuildRecord_.buildConfigurationRev), idRev.getRev())));
-        List<Long> buildRecordIds = entityManager.createQuery(query).getResultList();
+        List<Base32LongID> buildRecordIds = entityManager.createQuery(query).getResultList();
         return buildRecordIds.stream()
                 .map(id -> BuildRecord.Builder.newBuilder().id(id).build())
                 .collect(Collectors.toList());
@@ -180,11 +181,11 @@ public class BuildConfigurationAuditedRepositoryImpl implements BuildConfigurati
      */
     private List<BuildRecord> getBuildRecords(Integer buildConfigurationId) {
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-        CriteriaQuery<Long> query = cb.createQuery(Long.class);
+        CriteriaQuery<Base32LongID> query = cb.createQuery(Base32LongID.class);
         Root<BuildRecord> root = query.from(BuildRecord.class);
         query.select(root.get(BuildRecord_.id));
         query.where(cb.equal(root.get(BuildRecord_.buildConfigurationId), buildConfigurationId));
-        List<Long> buildRecordIds = entityManager.createQuery(query).getResultList();
+        List<Base32LongID> buildRecordIds = entityManager.createQuery(query).getResultList();
         return buildRecordIds.stream()
                 .map(id -> BuildRecord.Builder.newBuilder().id(id).build())
                 .collect(Collectors.toList());

--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/BuildRecordPushResultRepositoryImpl.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/BuildRecordPushResultRepositoryImpl.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.datastore.repositories;
 
 import org.jboss.pnc.datastore.repositories.internal.AbstractRepository;
 import org.jboss.pnc.datastore.repositories.internal.BuildRecordPushResultSpringRepository;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildRecordPushResult;
 import org.jboss.pnc.spi.datastore.predicates.BuildRecordPushResultPredicates;
 import org.jboss.pnc.spi.datastore.repositories.BuildRecordPushResultRepository;
@@ -40,7 +41,7 @@ public class BuildRecordPushResultRepositoryImpl extends AbstractRepository<Buil
     }
 
     @Override
-    public BuildRecordPushResult getLatestForBuildRecord(Long buildRecordId) {
+    public BuildRecordPushResult getLatestForBuildRecord(Base32LongID buildRecordId) {
         List<BuildRecordPushResult> buildRecordPushResults = queryWithPredicates(
                 BuildRecordPushResultPredicates.forBuildRecordOrderByIdDesc(buildRecordId));
         if (buildRecordPushResults == null || buildRecordPushResults.size() == 0) {
@@ -51,7 +52,7 @@ public class BuildRecordPushResultRepositoryImpl extends AbstractRepository<Buil
     }
 
     @Override
-    public List<BuildRecordPushResult> getAllSuccessfulForBuildRecord(Long buildRecordId) {
+    public List<BuildRecordPushResult> getAllSuccessfulForBuildRecord(Base32LongID buildRecordId) {
         return queryWithPredicates(BuildRecordPushResultPredicates.successForBuildRecord(buildRecordId));
     }
 }

--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/BuildRecordRepositoryImpl.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/BuildRecordRepositoryImpl.java
@@ -21,6 +21,7 @@ import org.jboss.pnc.datastore.repositories.internal.AbstractRepository;
 import org.jboss.pnc.datastore.repositories.internal.BuildRecordSpringRepository;
 import org.jboss.pnc.datastore.repositories.internal.PageableMapper;
 import org.jboss.pnc.datastore.repositories.internal.SpecificationsMapper;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildConfigurationAudited;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.BuildRecord_;
@@ -54,7 +55,8 @@ import static org.jboss.pnc.spi.datastore.predicates.BuildRecordPredicates.witho
 import static org.jboss.pnc.spi.datastore.predicates.BuildRecordPredicates.withoutLinkedNRRRecordOlderThanTimestamp;
 
 @Stateless
-public class BuildRecordRepositoryImpl extends AbstractRepository<BuildRecord, Long> implements BuildRecordRepository {
+public class BuildRecordRepositoryImpl extends AbstractRepository<BuildRecord, Base32LongID>
+        implements BuildRecordRepository {
 
     private static final Logger logger = LoggerFactory.getLogger(BuildRecordRepositoryImpl.class);
 
@@ -79,7 +81,7 @@ public class BuildRecordRepositoryImpl extends AbstractRepository<BuildRecord, L
     }
 
     @Override
-    public BuildRecord findByIdFetchAllProperties(Long id) {
+    public BuildRecord findByIdFetchAllProperties(Base32LongID id) {
         BuildRecord buildRecord = repository.findByIdFetchAllProperties(id);
         if (buildRecord != null) {
             fetchBuildConfigurationAudited(buildRecord);
@@ -88,7 +90,7 @@ public class BuildRecordRepositoryImpl extends AbstractRepository<BuildRecord, L
     }
 
     @Override
-    public BuildRecord findByIdFetchProperties(Long id) {
+    public BuildRecord findByIdFetchProperties(Base32LongID id) {
         BuildRecord buildRecord = repository.findByIdFetchProperties(id);
         if (buildRecord != null) {
             fetchBuildConfigurationAudited(buildRecord);
@@ -177,7 +179,7 @@ public class BuildRecordRepositoryImpl extends AbstractRepository<BuildRecord, L
     }
 
     @Override
-    public List<BuildRecord> getBuildByCausingRecord(Long causingRecordId) {
+    public List<BuildRecord> getBuildByCausingRecord(Base32LongID causingRecordId) {
         return queryWithPredicates(withCausingBuildRecordId(causingRecordId));
     }
 }

--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/internal/BuildRecordSpringRepository.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/internal/BuildRecordSpringRepository.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.datastore.repositories.internal;
 
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -28,18 +29,18 @@ import java.util.Set;
 
 @Dependent
 public interface BuildRecordSpringRepository
-        extends JpaRepository<BuildRecord, Long>, JpaSpecificationExecutor<BuildRecord> {
+        extends JpaRepository<BuildRecord, Base32LongID>, JpaSpecificationExecutor<BuildRecord> {
 
     @Query("SELECT br FROM BuildRecord br WHERE br.submitTime = (SELECT max(brr.submitTime) FROM BuildRecord brr"
             + " WHERE br.buildConfigurationId = brr.buildConfigurationId) AND br.buildConfigurationId IN ?1")
     List<BuildRecord> getLatestBuildsByBuildConfigIds(List<Integer> configIds);
 
     @Query("select br from BuildRecord br fetch all properties where br.id = ?1")
-    BuildRecord findByIdFetchAllProperties(Long id);
+    BuildRecord findByIdFetchAllProperties(Base32LongID id);
 
     @Query("select br from BuildRecord br " + "left join fetch br.productMilestone "
             + "left join fetch br.buildConfigSetRecord " + "left join fetch br.user " + "where br.id = ?1")
-    BuildRecord findByIdFetchProperties(Long id);
+    BuildRecord findByIdFetchProperties(Base32LongID id);
 
     @Query("SELECT DISTINCT br FROM BuildRecord br " + "JOIN br.builtArtifacts builtArtifacts "
             + "WHERE builtArtifacts.id IN (?1)")

--- a/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
+++ b/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
@@ -236,7 +236,7 @@ public class DatastoreTest {
         Assert.assertNotNull(user.getId());
 
         BuildRecord buildRecord = BuildRecord.Builder.newBuilder()
-                .id(Sequence.nextId())
+                .id(Sequence.nextBase32Id())
                 .buildConfigurationAudited(buildConfigAud)
                 .submitTime(Date.from(Instant.now()))
                 .startTime(Date.from(Instant.now()))
@@ -358,7 +358,7 @@ public class DatastoreTest {
         dependencies.add(importedArtifact2);
         dependencies.add(importedDuplicateArtifact);
         BuildRecord.Builder buildRecordBuilder = BuildRecord.Builder.newBuilder()
-                .id(Sequence.nextId())
+                .id(Sequence.nextBase32Id())
                 .buildConfigurationAudited(buildConfigAud)
                 .submitTime(Date.from(Instant.now()))
                 .startTime(Date.from(Instant.now()))

--- a/datastore/src/test/java/org/jboss/pnc/datastore/repositories/BuildRecordRepositoryTest.java
+++ b/datastore/src/test/java/org/jboss/pnc/datastore/repositories/BuildRecordRepositoryTest.java
@@ -88,7 +88,7 @@ public class BuildRecordRepositoryTest {
     public void shouldFindNoneExpiredTemporaryBuilds() {
         // given
         Date now = new Date();
-        BuildRecord givenBr = initBuildRecordBuilder(Sequence.nextId()).endTime(now).temporaryBuild(true).build();
+        BuildRecord givenBr = initBuildRecordBuilder(Sequence.nextBase32Id()).endTime(now).temporaryBuild(true).build();
         buildRecordRepository.save(givenBr);
 
         // when
@@ -103,7 +103,7 @@ public class BuildRecordRepositoryTest {
     @Test
     public void shouldFindExpiredTemporaryBuilds() {
         // given
-        BuildRecord givenBr = initBuildRecordBuilder(Sequence.nextId()).endTime(new Date(0))
+        BuildRecord givenBr = initBuildRecordBuilder(Sequence.nextBase32Id()).endTime(new Date(0))
                 .temporaryBuild(true)
                 .build();
         givenBr = buildRecordRepository.save(givenBr);
@@ -121,14 +121,14 @@ public class BuildRecordRepositoryTest {
     public void shouldGetRecordsWithoutAttributeKey() {
         // given
         Date now = new Date();
-        BuildRecord buildRecord0 = initBuildRecordBuilder(200000L).endTime(now)
+        BuildRecord buildRecord0 = initBuildRecordBuilder("CERBB5D55GARK").endTime(now)
                 .temporaryBuild(true)
                 .attribute("ATTR1", "X")
                 .attribute("TEST", "true") // exclude all other builds
                 .build();
         buildRecordRepository.save(buildRecord0);
 
-        BuildRecord buildRecord1 = initBuildRecordBuilder(200001L).endTime(now)
+        BuildRecord buildRecord1 = initBuildRecordBuilder("200001").endTime(now)
                 .temporaryBuild(true)
                 .attribute("ATTR1", "X")
                 .attribute("ATTR2", "X")
@@ -146,7 +146,7 @@ public class BuildRecordRepositoryTest {
         Assertions.assertThat(result.size()).isEqualTo(1);
     }
 
-    private BuildRecord.Builder initBuildRecordBuilder(Long id) {
+    private BuildRecord.Builder initBuildRecordBuilder(String id) {
         if (user == null) {
             List<User> users = userRepository.queryWithPredicates(UserPredicates.withUserName("demo-user"));
             if (users.size() > 0) {

--- a/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
+++ b/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.demo.data;
 
 import com.google.common.base.Preconditions;
+
 import org.jboss.pnc.common.concurrent.Sequence;
 import org.jboss.pnc.common.json.moduleconfig.DemoDataConfig;
 import org.jboss.pnc.common.json.moduleconfig.SystemConfig;
@@ -648,7 +649,7 @@ public class DatabaseDataInitializer {
                 .queryById(buildConfig1AuditIdRev);
         if (buildConfigAudited1 != null) {
 
-            long nextId = Sequence.nextId();
+            String nextId = Sequence.nextBase32Id();
             log.info("####nextId: " + nextId);
 
             BuildRecord buildRecord1 = BuildRecord.Builder.newBuilder()
@@ -684,7 +685,7 @@ public class DatabaseDataInitializer {
                             + savedBuildRecord1.getBuildConfigurationAuditedIdRev());
             buildRecords.add(buildRecord1);
 
-            nextId = Sequence.nextId();
+            nextId = Sequence.nextBase32Id();
             log.info("####nextId: " + nextId);
 
             BuildRecord tempRecord1 = BuildRecord.Builder.newBuilder()
@@ -778,7 +779,7 @@ public class DatabaseDataInitializer {
                 .queryById(buildConfig2AuditIdRev);
         if (buildConfigAudited2 != null) {
 
-            long nextId = Sequence.nextId();
+            String nextId = Sequence.nextBase32Id();
             log.info("####nextId: " + nextId);
 
             BuildRecord buildRecord2 = BuildRecord.Builder.newBuilder()
@@ -798,7 +799,7 @@ public class DatabaseDataInitializer {
                     .temporaryBuild(false)
                     .build();
 
-            nextId = Sequence.nextId();
+            nextId = Sequence.nextBase32Id();
             log.info("####nextId: " + nextId);
 
             BuildRecord savedBuildRecord2 = buildRecordRepository.save(buildRecord2);

--- a/facade/src/main/java/org/jboss/pnc/facade/BrewPusher.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/BrewPusher.java
@@ -20,6 +20,7 @@ package org.jboss.pnc.facade;
 import org.jboss.pnc.dto.BuildPushResult;
 import org.jboss.pnc.dto.requests.BuildPushParameters;
 import org.jboss.pnc.enums.BuildPushStatus;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.spi.coordinator.ProcessException;
 
 import java.util.Set;
@@ -34,9 +35,9 @@ public interface BrewPusher {
 
     BuildPushResult pushBuild(String id, BuildPushParameters buildPushParameters) throws ProcessException;
 
-    boolean brewPushCancel(long buildId);
+    boolean brewPushCancel(String buildId);
 
-    BuildPushResult brewPushComplete(long buildId, BuildPushResult buildPushResult);
+    BuildPushResult brewPushComplete(String buildId, BuildPushResult buildPushResult);
 
     /**
      * Gets generated in progress brew push result or the latest completed one. If there is one in progress for given
@@ -46,5 +47,5 @@ public interface BrewPusher {
      * @param buildId build record id
      * @return generated or loaded push result, {@code null} in case there is no completed nor in progress
      */
-    BuildPushResult getBrewPushResult(long buildId);
+    BuildPushResult getBrewPushResult(String buildId);
 }

--- a/facade/src/main/java/org/jboss/pnc/facade/BuildTriggerer.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/BuildTriggerer.java
@@ -33,7 +33,7 @@ import java.util.OptionalInt;
  */
 public interface BuildTriggerer {
 
-    long triggerBuild(int buildConfigId, OptionalInt rev, BuildOptions buildOptions)
+    String triggerBuild(int buildConfigId, OptionalInt rev, BuildOptions buildOptions)
             throws BuildConflictException, CoreException;
 
     int triggerGroupBuild(int groupConfigId, Optional<GroupBuildRequest> revs, BuildOptions buildOptions)
@@ -46,8 +46,8 @@ public interface BuildTriggerer {
      * @return True if the cancel request is successfully accepted, false if if there is no running build with such ID
      * @throws CoreException Thrown if cancellation fails due to any internal error
      */
-    boolean cancelBuild(long buildId) throws CoreException;
+    boolean cancelBuild(String buildId) throws CoreException;
 
-    Optional<BuildTaskContext> getMdcMeta(long buildId);
+    Optional<BuildTaskContext> getMdcMeta(String buildId);
 
 }

--- a/facade/src/main/java/org/jboss/pnc/facade/executor/BuildExecutorTriggerer.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/executor/BuildExecutorTriggerer.java
@@ -78,12 +78,12 @@ public class BuildExecutorTriggerer {
         return buildExecutionSession;
     }
 
-    public void cancelBuild(Long buildExecutionConfigId) throws CoreException, ExecutorException {
+    public void cancelBuild(String buildExecutionConfigId) throws CoreException, ExecutorException {
         buildExecutor.cancel(buildExecutionConfigId);
     }
 
     public void buildStatusUpdated(String executionId, TaskStatusUpdateEvent buildStatusUpdated) {
-        BuildExecutionSession runningExecution = buildExecutor.getRunningExecution(Long.parseLong(executionId));
+        BuildExecutionSession runningExecution = buildExecutor.getRunningExecution(executionId);
         if (runningExecution != null) {
             runningExecution.getBuildStatusUpdateConsumer().accept(buildStatusUpdated);
         } else {
@@ -91,7 +91,7 @@ public class BuildExecutorTriggerer {
         }
     }
 
-    public Optional<BuildTaskContext> getMdcMeta(Long buildExecutionConfigId, String userId) {
+    public Optional<BuildTaskContext> getMdcMeta(String buildExecutionConfigId, String userId) {
         BuildExecutionSession runningExecution = buildExecutor.getRunningExecution(buildExecutionConfigId);
         if (runningExecution != null) {
             BuildExecutionConfiguration buildExecutionConfiguration = runningExecution.getBuildExecutionConfiguration();

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/api/BuildProvider.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/api/BuildProvider.java
@@ -26,13 +26,14 @@ import org.jboss.pnc.dto.response.RunningBuildCount;
 import org.jboss.pnc.dto.response.SSHCredentials;
 import org.jboss.pnc.enums.BuildStatus;
 import org.jboss.pnc.facade.validation.EmptyEntityException;
+import org.jboss.pnc.model.Base32LongID;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public interface BuildProvider extends Provider<Long, org.jboss.pnc.model.BuildRecord, Build, BuildRef> {
+public interface BuildProvider extends Provider<Base32LongID, org.jboss.pnc.model.BuildRecord, Build, BuildRef> {
 
     /**
      * Get the internal scm archive link for a build record. If the scm revision is not specified in the build record

--- a/facade/src/main/java/org/jboss/pnc/facade/rsql/RSQLProducerImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/rsql/RSQLProducerImpl.java
@@ -155,7 +155,7 @@ public class RSQLProducerImpl implements RSQLProducer {
                     cb,
                     (BiFunction<From<?, DB>, RSQLSelectorPath, Path>) (from, selector) -> mapper
                             .toPath(type, from, selector),
-                    (Function<Value<? extends GenericEntity, ?>, Comparable<?>>) (value) -> mapper.convertValue(value));
+                    mapper.getConverter());
             return rootNode.accept(visitor);
         };
     }

--- a/facade/src/main/java/org/jboss/pnc/facade/rsql/converter/Base32EncodedLongValueConverter.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/rsql/converter/Base32EncodedLongValueConverter.java
@@ -28,4 +28,9 @@ public class Base32EncodedLongValueConverter implements ValueConverter {
     public Comparable<Long> convert(Value value) {
         return idMapper.toEntity(value.getValue());
     }
+
+    @Override
+    public Comparable<Long> convertComparable(Value value) {
+        return idMapper.toEntity(value.getValue());
+    }
 }

--- a/facade/src/main/java/org/jboss/pnc/facade/rsql/converter/CastValueConverter.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/rsql/converter/CastValueConverter.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.facade.rsql.converter;
 
 import org.jboss.pnc.facade.rsql.RSQLException;
+import org.jboss.pnc.model.GenericEntity;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -28,7 +29,7 @@ import java.util.Date;
 public class CastValueConverter implements ValueConverter {
 
     @Override
-    public <DB, T> Comparable<T> convert(Value<DB, T> value) {
+    public <DB extends GenericEntity<?>, T> Comparable<T> convertComparable(Value<DB, T> value) {
         Class<T> javaType = value.getJavaType();
         String argument = value.getValue();
 
@@ -58,5 +59,10 @@ public class CastValueConverter implements ValueConverter {
             throw new UnsupportedOperationException(
                     "The target type " + javaType + " is not known to the type converter.");
         }
+    }
+
+    @Override
+    public <DB extends GenericEntity<?>, T> T convert(Value<DB, T> value) {
+        return (T) convertComparable(value);
     }
 }

--- a/facade/src/main/java/org/jboss/pnc/facade/rsql/converter/ValueConverter.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/rsql/converter/ValueConverter.java
@@ -17,6 +17,10 @@
  */
 package org.jboss.pnc.facade.rsql.converter;
 
+import org.jboss.pnc.model.GenericEntity;
+
 public interface ValueConverter {
-    <DB, T> Comparable<T> convert(Value<DB, T> value);
+    <DB extends GenericEntity<?>, T> Comparable<T> convertComparable(Value<DB, T> value);
+
+    <DB extends GenericEntity<?>, T> T convert(Value<DB, T> value);
 }

--- a/facade/src/main/java/org/jboss/pnc/facade/rsql/mapper/BuildRSQLMapper.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/rsql/mapper/BuildRSQLMapper.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.facade.rsql.mapper;
 
 import org.jboss.pnc.facade.rsql.converter.Base32EncodedLongValueConverter;
 import org.jboss.pnc.facade.rsql.converter.ValueConverter;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.BuildRecord_;
 import org.jboss.pnc.model.GenericEntity;
@@ -34,7 +35,7 @@ import javax.persistence.metamodel.SingularAttribute;
  * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
  */
 @ApplicationScoped
-public class BuildRSQLMapper extends AbstractRSQLMapper<Long, BuildRecord> {
+public class BuildRSQLMapper extends AbstractRSQLMapper<Base32LongID, BuildRecord> {
 
     private static final Logger logger = LoggerFactory.getLogger(BuildRSQLMapper.class);
 

--- a/facade/src/main/java/org/jboss/pnc/facade/rsql/mapper/UniversalRSQLMapper.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/rsql/mapper/UniversalRSQLMapper.java
@@ -55,8 +55,18 @@ public class UniversalRSQLMapper {
         throw new UnsupportedOperationException("Missing RSQL mapper implementation for " + type);
     }
 
-    public <DB extends GenericEntity<?>, T> Comparable<T> convertValue(Value<DB, T> value) {
-        ValueConverter valueConverter = mapper(value.getModelClass()).getValueConverter(value.getName());
-        return valueConverter.convert(value);
+    public ValueConverter getConverter() {
+        return new UniversalValueConverter();
+    }
+
+    public class UniversalValueConverter implements ValueConverter {
+
+        public <DB extends GenericEntity<?>, T> Comparable<T> convertComparable(Value<DB, T> value) {
+            return mapper(value.getModelClass()).getValueConverter(value.getName()).convertComparable(value);
+        }
+
+        public <DB extends GenericEntity<?>, T> T convert(Value<DB, T> value) {
+            return mapper(value.getModelClass()).getValueConverter(value.getName()).convert(value);
+        }
     }
 }

--- a/facade/src/test/java/org/jboss/pnc/facade/providers/AbstractBase32LongIDProviderTest.java
+++ b/facade/src/test/java/org/jboss/pnc/facade/providers/AbstractBase32LongIDProviderTest.java
@@ -15,24 +15,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.pnc.integration.mock;
+package org.jboss.pnc.facade.providers;
 
-import org.jboss.pnc.coordinator.maintenance.RemoteBuildsCleaner;
-import org.jboss.pnc.enums.ResultStatus;
-import org.jboss.pnc.mapper.api.BuildMapper;
-import org.jboss.pnc.spi.coordinator.Result;
-import org.jboss.pnc.model.BuildRecord;
-
-import javax.enterprise.context.Dependent;
+import org.jboss.pnc.common.concurrent.Sequence;
+import org.jboss.pnc.model.Base32LongID;
+import org.jboss.pnc.model.GenericEntity;
 
 /**
- * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
+ *
+ * @author Honza Brázdil &lt;jbrazdil@redhat.com&gt;
+ * @param <T> tested provider type
  */
-@Dependent
-public class RemoteBuildsCleanerMock implements RemoteBuildsCleaner {
+public abstract class AbstractBase32LongIDProviderTest<T extends GenericEntity<Base32LongID>>
+        extends AbstractProviderTest<Base32LongID, T> {
 
-    @Override
-    public Result deleteRemoteBuilds(BuildRecord buildRecord, String authToken) {
-        return new Result(BuildMapper.idMapper.toDto(buildRecord.getId()), ResultStatus.SUCCESS);
+    protected Base32LongID getNextId() {
+        return new Base32LongID(Sequence.nextId());
     }
+
 }

--- a/facade/src/test/java/org/jboss/pnc/facade/providers/BuildIteratorTest.java
+++ b/facade/src/test/java/org/jboss/pnc/facade/providers/BuildIteratorTest.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.facade.providers;
 
 import org.jboss.pnc.dto.Build;
 import org.jboss.pnc.mapper.api.BuildMapper;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.spi.datastore.repositories.BuildRecordRepository;
 import org.jboss.pnc.spi.datastore.repositories.api.PageInfo;
@@ -37,6 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -64,7 +66,7 @@ public class BuildIteratorTest {
     public void prepareMock() {
         when(mapper.toDTO(any())).thenAnswer((InvocationOnMock invocation) -> {
             BuildRecord build = invocation.getArgument(0);
-            return Build.builder().id(build.getId().toString()).build();
+            return Build.builder().id(BuildMapper.idMapper.toDto(build.getId())).build();
         });
     }
 
@@ -113,14 +115,15 @@ public class BuildIteratorTest {
                 .thenAnswer((InvocationOnMock invocation) -> {
                     PageInfo pageInfo = invocation.getArgument(0);
 
-                    return IntStream.range(pageInfo.getPageOffset(), pageInfo.getPageOffset() + pageInfo.getPageSize())
-                            .mapToObj(BuildIteratorTest::mockBuildRecord)
+                    return LongStream.range(pageInfo.getPageOffset(), pageInfo.getPageOffset() + pageInfo.getPageSize())
+                            .mapToObj(Base32LongID::new)
+                            .map(BuildIteratorTest::mockBuildRecord)
                             .collect(Collectors.toList());
 
                 });
     }
 
-    private static BuildRecord mockBuildRecord(long i) {
+    private static BuildRecord mockBuildRecord(Base32LongID i) {
         BuildRecord br = mock(BuildRecord.class);
         when(br.getId()).thenReturn(i);
         return br;

--- a/indy-repository-manager/src/main/java/org/jboss/pnc/indyrepositorymanager/RepositoryManagerDriver.java
+++ b/indy-repository-manager/src/main/java/org/jboss/pnc/indyrepositorymanager/RepositoryManagerDriver.java
@@ -50,6 +50,7 @@ import org.jboss.pnc.common.util.UrlUtils;
 import org.jboss.pnc.enums.BuildCategory;
 import org.jboss.pnc.enums.BuildType;
 import org.jboss.pnc.enums.RepositoryType;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildConfigurationAudited;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.spi.datastore.repositories.BuildRecordRepository;
@@ -343,8 +344,9 @@ public class RepositoryManagerDriver implements RepositoryManager {
     }
 
     @Override
-    public RepositoryManagerResult collectRepoManagerResult(Long id) throws RepositoryManagerException {
-        BuildRecord br = buildRecordRepository.findByIdFetchProperties(id);
+    public RepositoryManagerResult collectRepoManagerResult(String id) throws RepositoryManagerException {
+        Base32LongID buildId = new Base32LongID(id);
+        BuildRecord br = buildRecordRepository.findByIdFetchProperties(buildId);
         if (br == null) {
             return null;
         }
@@ -395,7 +397,7 @@ public class RepositoryManagerDriver implements RepositoryManager {
             boolean brewPullActive) throws IndyClientException {
 
         String buildContentId = execution.getBuildContentId();
-        long id = execution.getId();
+        String id = execution.getId();
         BuildType buildType = execution.getBuildType();
 
         // if the build-level group doesn't exist, create it.
@@ -480,7 +482,7 @@ public class RepositoryManagerDriver implements RepositoryManager {
     private void addExtraConstituents(
             String packageType,
             List<ArtifactRepository> repositories,
-            long buildId,
+            String buildId,
             String buildContentId,
             Indy indy,
             Group buildGroup) throws IndyClientException {

--- a/indy-repository-manager/src/test/java/org/jboss/pnc/indyrepositorymanager/fixture/TestBuildExecution.java
+++ b/indy-repository-manager/src/test/java/org/jboss/pnc/indyrepositorymanager/fixture/TestBuildExecution.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 public class TestBuildExecution implements BuildExecution {
 
-    private int id = 1;
+    private String id = "1";
 
     private String buildContentId;
 
@@ -47,7 +47,7 @@ public class TestBuildExecution implements BuildExecution {
     }
 
     @Override
-    public long getId() {
+    public String getId() {
         return id;
     }
 

--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildExecutionTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildExecutionTest.java
@@ -102,7 +102,7 @@ public class BuildExecutionTest {
         BuildExecutionSession session = createFakeExectionSession(statusChangeConsumer);
 
         // when
-        long executionId = 11L;
+        String executionId = "11";
         ((BuildExecutorMock) buildExecutor).addRunningExecution(executionId, session);
         HttpClient httpClient = new HttpClient();
 

--- a/integration-test/src/test/java/org/jboss/pnc/integration/TemporaryBuildsCleanerTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/TemporaryBuildsCleanerTest.java
@@ -461,7 +461,7 @@ public class TemporaryBuildsCleanerTest {
 
     private BuildRecord.Builder initBuildRecordBuilder() {
         return BuildRecord.Builder.newBuilder()
-                .id(Sequence.nextId())
+                .id(Sequence.nextBase32Id())
                 .buildConfigurationAudited(this.buildConfigurationAudited)
                 .submitTime(new Date())
                 .user(this.user)

--- a/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/BuildTaskEndpointTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/BuildTaskEndpointTest.java
@@ -90,7 +90,7 @@ public class BuildTaskEndpointTest {
         request.addHeader(Credentials.USER.createAuthHeader(BasicHeader::new));
 
         BuildExecutionConfiguration buildExecutionConfig = BuildExecutionConfiguration.build(
-                1,
+                "1",
                 "test-content-id",
                 "1",
                 "mvn clean install",

--- a/mapper/src/main/java/org/jboss/pnc/mapper/Base32LongIdMapper.java
+++ b/mapper/src/main/java/org/jboss/pnc/mapper/Base32LongIdMapper.java
@@ -15,26 +15,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.pnc.facade.rsql.converter;
+package org.jboss.pnc.mapper;
 
-import org.jboss.pnc.facade.rsql.RSQLException;
+import org.jboss.pnc.mapper.api.IdMapper;
 import org.jboss.pnc.model.Base32LongID;
-import org.jboss.pnc.model.GenericEntity;
 
-public class Base32EncodedLongValueConverter implements ValueConverter {
+public class Base32LongIdMapper implements IdMapper<Base32LongID, String> {
 
     @Override
-    public <DB extends GenericEntity<?>, T> Comparable<T> convertComparable(Value<DB, T> value) {
-        throw new RSQLException("Comparing by id is not supported.");
+    public Base32LongID toEntity(String id) {
+        return new Base32LongID(id);
     }
 
     @Override
-    public <DB extends GenericEntity<?>, T> T convert(Value<DB, T> value) {
-        if (value.getJavaType() != Base32LongID.class) {
-            throw new IllegalArgumentException(
-                    "Expected to get value for type Base32LongID, got value for type " + value.getJavaType());
-        }
-
-        return (T) new Base32LongID(value.getValue());
+    public String toDto(Base32LongID id) {
+        return id.getId();
     }
 }

--- a/mapper/src/main/java/org/jboss/pnc/mapper/api/BuildMapper.java
+++ b/mapper/src/main/java/org/jboss/pnc/mapper/api/BuildMapper.java
@@ -27,9 +27,10 @@ import org.jboss.pnc.enums.BuildProgress;
 import org.jboss.pnc.enums.BuildStatus;
 import org.jboss.pnc.mapper.BrewNameWorkaround;
 import org.jboss.pnc.mapper.BuildBCRevisionFetcher;
-import org.jboss.pnc.mapper.LongBase32IdMapper;
 import org.jboss.pnc.mapper.RefToReferenceMapper;
+import org.jboss.pnc.mapper.Base32LongIdMapper;
 import org.jboss.pnc.mapper.api.BuildMapper.StatusMapper;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.spi.coordinator.BuildTask;
 import org.mapstruct.BeanMapping;
@@ -50,9 +51,9 @@ import java.util.Optional;
                 BrewNameWorkaround.class, GroupBuildMapper.class, BuildBCRevisionFetcher.class,
                 ProductMilestoneMapper.class })
 
-public interface BuildMapper extends UpdatableEntityMapper<Long, BuildRecord, Build, BuildRef> {
+public interface BuildMapper extends UpdatableEntityMapper<Base32LongID, BuildRecord, Build, BuildRef> {
 
-    IdMapper<Long, String> idMapper = new LongBase32IdMapper();
+    Base32LongIdMapper idMapper = new Base32LongIdMapper();
 
     @Override
     @Mapping(target = "id", expression = "java( getIdMapper().toDto(dbEntity.getId()) )")
@@ -167,7 +168,7 @@ public interface BuildMapper extends UpdatableEntityMapper<Long, BuildRecord, Bu
     @Mapping(target = "executionRootVersion", ignore = true)
     public abstract void updateEntity(Build dtoEntity, @MappingTarget BuildRecord target);
 
-    @Mapping(target = "id", expression = "java( getIdMapper().toDto(buildTask.getId()) )")
+    @Mapping(target = "id", expression = "java( buildTask.getId() )")
     @Mapping(target = "project", source = "buildConfigurationAudited.project", resultType = ProjectRef.class)
     @Mapping(
             target = "scmRepository",
@@ -229,7 +230,7 @@ public interface BuildMapper extends UpdatableEntityMapper<Long, BuildRecord, Bu
     }
 
     @Override
-    default IdMapper<Long, String> getIdMapper() {
+    default IdMapper<Base32LongID, String> getIdMapper() {
         return idMapper;
     }
 }

--- a/model/src/main/java/org/jboss/pnc/model/Base32LongID.java
+++ b/model/src/main/java/org/jboss/pnc/model/Base32LongID.java
@@ -1,0 +1,70 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+import org.jboss.pnc.common.pnc.LongBase32IdConverter;
+
+@Embeddable
+public class Base32LongID implements Serializable {
+    @Column(name = "id", nullable = false, updatable = false)
+    private long id;
+
+    private Base32LongID() {
+    }
+
+    public Base32LongID(String id) {
+        this.id = LongBase32IdConverter.toLong(Objects.requireNonNull(id));
+    }
+
+    public Base32LongID(long id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return LongBase32IdConverter.toString(id);
+    }
+
+    public long getLongId() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof Base32LongID))
+            return false;
+        Base32LongID that = (Base32LongID) o;
+        return getLongId() == that.getLongId();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getLongId());
+    }
+
+    @Override
+    public String toString() {
+        return getId();
+    }
+}

--- a/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
+++ b/model/src/main/java/org/jboss/pnc/model/BuildRecord.java
@@ -25,7 +25,6 @@ import org.jboss.pnc.common.security.Md5;
 import org.jboss.pnc.common.security.Sha256;
 import org.jboss.pnc.common.util.StringUtils;
 import org.jboss.pnc.enums.BuildStatus;
-import org.jboss.pnc.common.pnc.LongBase32IdConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,12 +32,12 @@ import javax.persistence.Basic;
 import javax.persistence.Cacheable;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
-import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
@@ -56,6 +55,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -90,7 +90,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
                         columnList = "buildconfiguration_id,buildconfiguration_rev"),
                 @Index(name = "idx_buildrecord_productmilestone", columnList = "productmilestone_id"),
                 @Index(name = "idx_buildrecord_norebuildcause", columnList = "norebuildcause_id") })
-public class BuildRecord implements GenericEntity<Long> {
+public class BuildRecord implements GenericEntity<Base32LongID> {
 
     private static final long serialVersionUID = -5472083609387609797L;
 
@@ -98,8 +98,8 @@ public class BuildRecord implements GenericEntity<Long> {
 
     private static Logger logger = LoggerFactory.getLogger(BuildRecord.class);
 
-    @Id
-    private Long id;
+    @EmbeddedId
+    private Base32LongID id;
 
     /**
      * Contains the settings that were used at the time the build was executed. Hibernate envers identifies each audited
@@ -353,17 +353,8 @@ public class BuildRecord implements GenericEntity<Long> {
      *
      * @return the id
      */
-    public Long getId() {
+    public Base32LongID getId() {
         return id;
-    }
-
-    /**
-     * Gets the id in the base32 encoding.
-     *
-     * @return the id in base32 encoding.
-     */
-    public String getBase32Id() {
-        return LongBase32IdConverter.toString(id);
     }
 
     /**
@@ -372,7 +363,7 @@ public class BuildRecord implements GenericEntity<Long> {
      * @param id the new id
      */
     @Override
-    public void setId(Long id) {
+    public void setId(Base32LongID id) {
         this.id = id;
     }
 
@@ -673,7 +664,7 @@ public class BuildRecord implements GenericEntity<Long> {
     }
 
     public String putAttribute(String key, String value) {
-        if (this.id == null) {
+        if (id == null) {
             throw new PersistenceException("Build record id must be set before adding the attributes.");
         }
         Optional<BuildRecordAttribute> old = getAttributeEntity(key);
@@ -811,25 +802,29 @@ public class BuildRecord implements GenericEntity<Long> {
         buildRecordPushResult.setBuildRecord(null);
     }
 
-    public void setDependentBuildRecordIds(Long[] dependentBuildRecordIds) {
+    public void setDependentBuildRecordIds(Base32LongID[] dependentBuildRecordIds) {
         if (dependentBuildRecordIds != null) {
-            this.dependentBuildRecordIds = StringUtils.serializeLong(dependentBuildRecordIds);
+            Long[] longIds = Arrays.stream(dependentBuildRecordIds).map(Base32LongID::getLongId).toArray(Long[]::new);
+            this.dependentBuildRecordIds = StringUtils.serializeLong(longIds);
         } else {
             this.dependentBuildRecordIds = "";
         }
     }
 
-    public Long[] getDependentBuildRecordIds() {
-        return StringUtils.deserializeLong(dependentBuildRecordIds);
+    public Base32LongID[] getDependentBuildRecordIds() {
+        Long[] longIds = StringUtils.deserializeLong(dependentBuildRecordIds);
+        return Arrays.stream(longIds).map(Base32LongID::new).toArray(Base32LongID[]::new);
     }
 
-    public Long[] getDependencyBuildRecordIds() {
-        return StringUtils.deserializeLong(dependencyBuildRecordIds);
+    public Base32LongID[] getDependencyBuildRecordIds() {
+        Long[] longIds = StringUtils.deserializeLong(dependencyBuildRecordIds);
+        return Arrays.stream(longIds).map(Base32LongID::new).toArray(Base32LongID[]::new);
     }
 
-    public void setDependencyBuildRecordIds(Long[] dependencyBuildRecordIds) {
+    public void setDependencyBuildRecordIds(Base32LongID[] dependencyBuildRecordIds) {
         if (dependencyBuildRecordIds != null) {
-            this.dependencyBuildRecordIds = StringUtils.serializeLong(dependencyBuildRecordIds);
+            Long[] longIds = Arrays.stream(dependencyBuildRecordIds).map(Base32LongID::getLongId).toArray(Long[]::new);
+            this.dependencyBuildRecordIds = StringUtils.serializeLong(longIds);
         } else {
             this.dependencyBuildRecordIds = "";
         }
@@ -879,7 +874,7 @@ public class BuildRecord implements GenericEntity<Long> {
 
     public static class Builder {
 
-        private Long id;
+        private Base32LongID id;
 
         private String buildContentId;
 
@@ -931,9 +926,9 @@ public class BuildRecord implements GenericEntity<Long> {
 
         private Map<String, String> attributes = new HashMap<>();
 
-        private Long[] dependentBuildRecordIds;
+        private Base32LongID[] dependentBuildRecordIds;
 
-        private Long[] dependencyBuildRecordIds;
+        private Base32LongID[] dependencyBuildRecordIds;
 
         private BuildRecord noRebuildCause;
 
@@ -1041,8 +1036,13 @@ public class BuildRecord implements GenericEntity<Long> {
             }
         }
 
-        public Builder id(Long id) {
+        public Builder id(Base32LongID id) {
             this.id = id;
+            return this;
+        }
+
+        public Builder id(String id) {
+            this.id = new Base32LongID(id);
             return this;
         }
 
@@ -1192,12 +1192,12 @@ public class BuildRecord implements GenericEntity<Long> {
             return this;
         }
 
-        public BuildRecord.Builder dependencyBuildRecordIds(Long[] dependencyBuildRecordIds) {
+        public BuildRecord.Builder dependencyBuildRecordIds(Base32LongID[] dependencyBuildRecordIds) {
             this.dependencyBuildRecordIds = dependencyBuildRecordIds;
             return this;
         }
 
-        public BuildRecord.Builder dependentBuildRecordIds(Long[] dependentBuildRecordIds) {
+        public BuildRecord.Builder dependentBuildRecordIds(Base32LongID[] dependentBuildRecordIds) {
             this.dependentBuildRecordIds = dependentBuildRecordIds;
             return this;
         }

--- a/model/src/main/java/org/jboss/pnc/model/utils/ContentIdentityManager.java
+++ b/model/src/main/java/org/jboss/pnc/model/utils/ContentIdentityManager.java
@@ -25,10 +25,10 @@ import org.jboss.pnc.common.pnc.LongBase32IdConverter;
  */
 public class ContentIdentityManager {
 
-    public static String getBuildContentId(Long buildRecordId) {
+    public static String getBuildContentId(String buildRecordId) {
         if (buildRecordId == null)
             throw new IllegalArgumentException("Null is not a valid build record ID");
 
-        return "build-" + LongBase32IdConverter.toString(buildRecordId);
+        return "build-" + buildRecordId;
     }
 }

--- a/model/src/test/java/org/jboss/pnc/model/BasicModelTest.java
+++ b/model/src/test/java/org/jboss/pnc/model/BasicModelTest.java
@@ -146,7 +146,7 @@ public class BasicModelTest extends AbstractModelTest {
         BuildConfigurationAudited buildConfigAud = findBuildConfigurationAudited(em);
 
         BuildRecord buildRecord1 = BuildRecord.Builder.newBuilder()
-                .id(1L)
+                .id("1")
                 .buildConfigurationAudited(buildConfigAud)
                 .buildLog("Build Completed.")
                 .buildContentId("foo")
@@ -218,7 +218,7 @@ public class BasicModelTest extends AbstractModelTest {
         BuildConfigurationAudited buildConfigAud = findBuildConfigurationAudited(em);
 
         BuildRecord buildRecord = BuildRecord.Builder.newBuilder()
-                .id(2L)
+                .id("CERBB5D55GARK")
                 .buildConfigurationAudited(buildConfigAud)
                 .buildLog("Bulid Complete")
                 .buildContentId("foo")

--- a/model/src/test/java/org/jboss/pnc/model/BuildRecordTest.java
+++ b/model/src/test/java/org/jboss/pnc/model/BuildRecordTest.java
@@ -72,7 +72,7 @@ public class BuildRecordTest extends AbstractModelTest {
     @Test
     public void shouldProhibitDeletionOfNonTemporaryBuild() {
         // given
-        long brId = 666;
+        Base32LongID brId = new Base32LongID("666");
         BuildRecord br = prepareBuildRecordBuilder().id(brId).temporaryBuild(false).build();
 
         em.getTransaction().begin();
@@ -88,7 +88,7 @@ public class BuildRecordTest extends AbstractModelTest {
             em.getTransaction().rollback();
             BuildRecord obtainedBr = em.find(BuildRecord.class, brId);
             assertNotNull(obtainedBr);
-            assertEquals(brId, obtainedBr.getId().intValue());
+            assertEquals(brId, obtainedBr.getId());
             return;
         }
         fail("Deletion of the standard BuildRecord should be prohibited.");
@@ -97,7 +97,7 @@ public class BuildRecordTest extends AbstractModelTest {
     @Test
     public void shouldAllowDeletionOfTemporaryBuild() {
         // given
-        long brId = 666;
+        Base32LongID brId = new Base32LongID("CERBB5D55GARK");
         BuildRecord br = prepareBuildRecordBuilder().id(brId).temporaryBuild(true).build();
 
         em.getTransaction().begin();

--- a/notifications/src/main/java/org/jboss/pnc/notification/DefaultNotifier.java
+++ b/notifications/src/main/java/org/jboss/pnc/notification/DefaultNotifier.java
@@ -154,8 +154,7 @@ public class DefaultNotifier implements Notifier {
     @Override
     public void onBpmProcessClientSubscribe(AttachedClient client, String messagesId) {
         if (bpmManager.isPresent()) {
-            Optional<BpmTask> maybeTask = BpmBuildTask
-                    .getBpmTaskByBuildTaskId(bpmManager.get(), Integer.valueOf(messagesId));
+            Optional<BpmTask> maybeTask = BpmBuildTask.getBpmTaskByBuildTaskId(bpmManager.get(), messagesId);
             if (maybeTask.isPresent()) {
                 BpmTask bpmTask = maybeTask.get();
                 Optional<BpmEvent> maybeLastEvent = bpmTask.getEvents().stream().reduce((first, second) -> second);

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/coordinator/BuildCoordinatorMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/coordinator/BuildCoordinatorMock.java
@@ -94,7 +94,7 @@ public class BuildCoordinatorMock implements BuildCoordinator {
     }
 
     @Override
-    public boolean cancel(long buildTaskId) {
+    public boolean cancel(String buildTaskId) {
         return false;
     }
 
@@ -121,7 +121,7 @@ public class BuildCoordinatorMock implements BuildCoordinator {
     }
 
     @Override
-    public Optional<BuildTaskContext> getMDCMeta(Long buildTaskId) {
+    public Optional<BuildTaskContext> getMDCMeta(String buildTaskId) {
         return Optional.empty();
     }
 }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionConfigurationMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionConfigurationMock.java
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 public class BuildExecutionConfigurationMock implements BuildExecutionConfiguration {
 
-    private int id;
+    private String id;
     private String buildContentId;
     private String userId;
     private String buildScript;
@@ -55,7 +55,7 @@ public class BuildExecutionConfigurationMock implements BuildExecutionConfigurat
 
     public static BuildExecutionConfiguration mockConfig() {
         BuildExecutionConfigurationMock mock = new BuildExecutionConfigurationMock();
-        mock.setId(1);
+        mock.setId("1");
         mock.setBuildScript("mvn install");
         mock.setScmRepoURL("http://www.github.com");
         mock.setScmRevision("f18de64523d5054395d82e24d4e28473a05a3880");
@@ -76,11 +76,11 @@ public class BuildExecutionConfigurationMock implements BuildExecutionConfigurat
     }
 
     @Override
-    public long getId() {
+    public String getId() {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(String id) {
         this.id = id;
     }
 

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionSessionMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutionSessionMock.java
@@ -225,7 +225,7 @@ public class BuildExecutionSessionMock implements BuildExecutionSession {
     }
 
     @Override
-    public Long getId() {
+    public String getId() {
         return getBuildExecutionConfiguration().getId();
     }
 

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutorMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutorMock.java
@@ -51,12 +51,12 @@ public class BuildExecutorMock implements BuildExecutor {
 
     private final Logger log = LoggerFactory.getLogger(BuildExecutorMock.class);
 
-    private final Map<Long, BuildExecutionSession> runningExecutions = new HashMap<>();
+    private final Map<String, BuildExecutionSession> runningExecutions = new HashMap<>();
 
     private final ExecutorService executor = MDCExecutors
             .newFixedThreadPool(4, new NamedThreadFactory("build-executor-mock"));
 
-    private final Map<Long, CompletableFuture<Integer>> runningFutures = new HashMap<>();
+    private final Map<String, CompletableFuture<Integer>> runningFutures = new HashMap<>();
     // @Deprecated //CDI workaround
     // public BuildExecutorMock() {
     // }
@@ -156,7 +156,7 @@ public class BuildExecutorMock implements BuildExecutor {
     }
 
     @Override
-    public BuildExecutionSession getRunningExecution(long buildExecutionTaskId) {
+    public BuildExecutionSession getRunningExecution(String buildExecutionTaskId) {
         return runningExecutions.get(buildExecutionTaskId);
     }
 
@@ -166,7 +166,7 @@ public class BuildExecutorMock implements BuildExecutor {
     }
 
     @Override
-    public void cancel(Long executionConfigurationId) throws ExecutorException {
+    public void cancel(String executionConfigurationId) throws ExecutorException {
         BuildExecutionSession buildExecutionSession = runningExecutions.get(executionConfigurationId);
         if (buildExecutionSession == null) {
             log.error("Unable to cancel build {}. The build is not running.", executionConfigurationId);
@@ -178,7 +178,7 @@ public class BuildExecutorMock implements BuildExecutor {
         buildExecutionSession.setBuildDriverResult(driverResult);
     }
 
-    public void addRunningExecution(Long id, BuildExecutionSession session) {
+    public void addRunningExecution(String id, BuildExecutionSession session) {
         runningExecutions.put(id, session);
     }
 }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutorStatusChangedEventMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/executor/BuildExecutorStatusChangedEventMock.java
@@ -28,7 +28,7 @@ class BuildExecutorStatusChangedEventMock implements BuildExecutionStatusChanged
 
     private final BuildExecutionStatus oldStatus;
     private final BuildExecutionStatus newStatus;
-    private final Long buildTaskId;
+    private final String buildTaskId;
     private final Integer buildConfigurationId;
     private final Optional<BuildResult> buildResult;
 
@@ -37,7 +37,7 @@ class BuildExecutorStatusChangedEventMock implements BuildExecutionStatusChanged
     public BuildExecutorStatusChangedEventMock(
             BuildExecutionStatus oldStatus,
             BuildExecutionStatus newStatus,
-            Long buildTaskId,
+            String buildTaskId,
             Integer buildConfigurationId,
             Optional<BuildResult> buildResult,
             boolean isFinal) {
@@ -50,7 +50,7 @@ class BuildExecutorStatusChangedEventMock implements BuildExecutionStatusChanged
     }
 
     @Override
-    public Long getBuildTaskId() {
+    public String getBuildTaskId() {
         return buildTaskId;
     }
 

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/Base32LongIdRepositoryMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/Base32LongIdRepositoryMock.java
@@ -15,26 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.pnc.facade.rsql.converter;
+package org.jboss.pnc.mock.repository;
 
-import org.jboss.pnc.facade.rsql.RSQLException;
+import org.jboss.pnc.common.concurrent.Sequence;
 import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.GenericEntity;
 
-public class Base32EncodedLongValueConverter implements ValueConverter {
+public abstract class Base32LongIdRepositoryMock<EntityType extends GenericEntity<Base32LongID>>
+        extends RepositoryMock<Base32LongID, EntityType> {
 
     @Override
-    public <DB extends GenericEntity<?>, T> Comparable<T> convertComparable(Value<DB, T> value) {
-        throw new RSQLException("Comparing by id is not supported.");
-    }
-
-    @Override
-    public <DB extends GenericEntity<?>, T> T convert(Value<DB, T> value) {
-        if (value.getJavaType() != Base32LongID.class) {
-            throw new IllegalArgumentException(
-                    "Expected to get value for type Base32LongID, got value for type " + value.getJavaType());
-        }
-
-        return (T) new Base32LongID(value.getValue());
+    public Base32LongID getNextId() {
+        return new Base32LongID(Sequence.nextId());
     }
 }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/BuildRecordPushResultRepositoryMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/BuildRecordPushResultRepositoryMock.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.mock.repository;
 
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildRecordPushResult;
 import org.jboss.pnc.spi.datastore.repositories.BuildRecordPushResultRepository;
 
@@ -30,7 +31,7 @@ public class BuildRecordPushResultRepositoryMock extends LongIdRepositoryMock<Bu
         implements BuildRecordPushResultRepository {
 
     @Override
-    public BuildRecordPushResult getLatestForBuildRecord(Long buildRecordId) {
+    public BuildRecordPushResult getLatestForBuildRecord(Base32LongID buildRecordId) {
         return data.stream()
                 .filter(buildRecordPushResult -> buildRecordPushResult.getBuildRecord().getId().equals(buildRecordId))
                 .sorted(Comparator.comparing(BuildRecordPushResult::getId).reversed())
@@ -39,7 +40,7 @@ public class BuildRecordPushResultRepositoryMock extends LongIdRepositoryMock<Bu
     }
 
     @Override
-    public List<BuildRecordPushResult> getAllSuccessfulForBuildRecord(Long buildRecordId) {
+    public List<BuildRecordPushResult> getAllSuccessfulForBuildRecord(Base32LongID buildRecordId) {
         throw new RuntimeException("Not implemented!");
     }
 

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/BuildRecordRepositoryMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/BuildRecordRepositoryMock.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.mock.repository;
 
 import org.jboss.pnc.enums.BuildStatus;
 import org.jboss.pnc.model.Artifact;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.IdRev;
 import org.jboss.pnc.spi.datastore.repositories.BuildRecordRepository;
@@ -39,14 +40,15 @@ import static org.jboss.pnc.common.util.CollectionUtils.ofNullableCollection;
 /**
  * Author: Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com Date: 9/22/16 Time: 12:04 PM
  */
-public class BuildRecordRepositoryMock extends LongIdRepositoryMock<BuildRecord> implements BuildRecordRepository {
+public class BuildRecordRepositoryMock extends Base32LongIdRepositoryMock<BuildRecord>
+        implements BuildRecordRepository {
     @Override
-    public BuildRecord findByIdFetchAllProperties(Long id) {
+    public BuildRecord findByIdFetchAllProperties(Base32LongID id) {
         return queryById(id);
     }
 
     @Override
-    public BuildRecord findByIdFetchProperties(Long id) {
+    public BuildRecord findByIdFetchProperties(Base32LongID id) {
         return queryById(id);
     }
 
@@ -82,7 +84,7 @@ public class BuildRecordRepositoryMock extends LongIdRepositoryMock<BuildRecord>
                 .filter(br -> br.getBuildConfigurationId().equals(configurationId))
                 .filter(br -> br.getStatus().equals(BuildStatus.SUCCESS))
                 .filter(br -> !(!temporaryBuild && br.isTemporaryBuild()))
-                .max(Comparator.comparing(BuildRecord::getId))
+                .max(Comparator.comparing(BuildRecord::getSubmitTime))
                 .orElse(null);
     }
 
@@ -111,7 +113,7 @@ public class BuildRecordRepositoryMock extends LongIdRepositoryMock<BuildRecord>
                 .filter(
                         buildRecord -> buildRecord.getBuildConfigurationAuditedIdRev()
                                 .equals(buildConfigurationAuditedIdRev))
-                .max(Comparator.comparing(BuildRecord::getId));
+                .max(Comparator.comparing(BuildRecord::getSubmitTime));
         return first.orElse(null);
     }
 
@@ -144,7 +146,7 @@ public class BuildRecordRepositoryMock extends LongIdRepositoryMock<BuildRecord>
     }
 
     @Override
-    public List<BuildRecord> getBuildByCausingRecord(Long causingRecordId) {
+    public List<BuildRecord> getBuildByCausingRecord(Base32LongID causingRecordId) {
         return null;
     }
 }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/repositorymanager/RepositoryManagerMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/repositorymanager/RepositoryManagerMock.java
@@ -93,7 +93,7 @@ public class RepositoryManagerMock implements RepositoryManager {
     }
 
     @Override
-    public RepositoryManagerResult collectRepoManagerResult(Long id) throws RepositoryManagerException {
+    public RepositoryManagerResult collectRepoManagerResult(String id) throws RepositoryManagerException {
         return RepositoryManagerResultMock.mockResult(false);
     }
 

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/spi/BuildExecutionConfigurationMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/spi/BuildExecutionConfigurationMock.java
@@ -32,7 +32,7 @@ public class BuildExecutionConfigurationMock {
 
     public static BuildExecutionConfiguration mock() {
         return BuildExecutionConfiguration.build(
-                1,
+                "1",
                 "condent-id",
                 "1",
                 "mvn clean install",

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoints/BuildConfigurationEndpointImpl.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoints/BuildConfigurationEndpointImpl.java
@@ -296,9 +296,9 @@ public class BuildConfigurationEndpointImpl implements BuildConfigurationEndpoin
                     buildParams);
 
             BuildOptions buildOptions = toBuildOptions(buildParams);
-            long buildId = buildTriggerer.triggerBuild(Integer.parseInt(id), rev, buildOptions);
+            String buildId = buildTriggerer.triggerBuild(Integer.parseInt(id), rev, buildOptions);
 
-            return buildProvider.getSpecific(BuildMapper.idMapper.toDto(buildId));
+            return buildProvider.getSpecific(buildId);
         } catch (CoreException ex) {
             throw new RuntimeException(ex);
         }

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoints/BuildEndpointImpl.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoints/BuildEndpointImpl.java
@@ -38,6 +38,7 @@ import org.jboss.pnc.facade.providers.api.ArtifactProvider;
 import org.jboss.pnc.facade.providers.api.BuildPageInfo;
 import org.jboss.pnc.facade.providers.api.BuildProvider;
 import org.jboss.pnc.mapper.api.BuildMapper;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.rest.api.endpoints.BuildEndpoint;
 import org.jboss.pnc.rest.api.parameters.BuildsFilterParameters;
 import org.jboss.pnc.rest.api.parameters.PageParameters;
@@ -97,7 +98,7 @@ public class BuildEndpointImpl implements BuildEndpoint {
     @Inject
     private BrewPusher brewPusher;
 
-    private EndpointHelper<Long, Build, BuildRef> endpointHelper;
+    private EndpointHelper<Base32LongID, Build, BuildRef> endpointHelper;
 
     @PostConstruct
     public void init() {
@@ -227,7 +228,7 @@ public class BuildEndpointImpl implements BuildEndpoint {
 
     @Override
     public BuildPushResult getPushResult(String id) {
-        BuildPushResult brewPushResult = brewPusher.getBrewPushResult(BuildMapper.idMapper.toEntity(id));
+        BuildPushResult brewPushResult = brewPusher.getBrewPushResult(id);
         if (brewPushResult == null) {
             throw new NotFoundException();
         }
@@ -245,12 +246,12 @@ public class BuildEndpointImpl implements BuildEndpoint {
 
     @Override
     public void cancelPush(String id) {
-        brewPusher.brewPushCancel(BuildMapper.idMapper.toEntity(id));
+        brewPusher.brewPushCancel(id);
     }
 
     @Override
     public BuildPushResult completePush(String id, BuildPushResult buildPushResult) {
-        return brewPusher.brewPushComplete(BuildMapper.idMapper.toEntity(id), buildPushResult);
+        return brewPusher.brewPushComplete(id, buildPushResult);
     }
 
     @Override
@@ -263,14 +264,14 @@ public class BuildEndpointImpl implements BuildEndpoint {
         try {
             logger.debug("Received cancel request for buildTaskId: {}.", buildId);
 
-            Optional<BuildTaskContext> mdcMeta = buildTriggerer.getMdcMeta(BuildMapper.idMapper.toEntity(buildId));
+            Optional<BuildTaskContext> mdcMeta = buildTriggerer.getMdcMeta(buildId);
             if (mdcMeta.isPresent()) {
                 MDCUtils.addBuildContext(mdcMeta.get());
             } else {
                 logger.warn("Unable to retrieve MDC meta. There is no running build for buildTaskId: {}.", buildId);
             }
 
-            if (!buildTriggerer.cancelBuild(BuildMapper.idMapper.toEntity(buildId))) {
+            if (!buildTriggerer.cancelBuild(buildId)) {
                 throw new NotFoundException();
             }
             logger.debug("Cancel request for buildTaskId {} successfully processed.", buildId);

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoints/GroupConfigurationEndpointImpl.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoints/GroupConfigurationEndpointImpl.java
@@ -160,7 +160,7 @@ public class GroupConfigurationEndpointImpl implements GroupConfigurationEndpoin
 
             return groupBuildProvider.getSpecific(Integer.toString(groupBuildId));
         } catch (BuildConflictException ex) {
-            throw new ConflictedEntryException(ex.getMessage(), null, BuildMapper.idMapper.toDto(ex.getBuildTaskId()));
+            throw new ConflictedEntryException(ex.getMessage(), null, ex.getBuildTaskId());
         } catch (CoreException ex) {
             throw new RuntimeException(ex);
         }

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoints/internal/BuildMaintenanceEndpointImpl.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoints/internal/BuildMaintenanceEndpointImpl.java
@@ -37,7 +37,7 @@ public class BuildMaintenanceEndpointImpl implements BuildMaintenanceEndpoint {
     private RepositoryManager repositoryManager;
 
     @Override
-    public Response collectRepoManagerResult(Long id) {
+    public Response collectRepoManagerResult(String id) {
         logger.info("Getting repository manager result for build record id {}.", id);
         RepositoryManagerResult result;
         try {

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoints/internal/api/BuildMaintenanceEndpoint.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoints/internal/api/BuildMaintenanceEndpoint.java
@@ -55,6 +55,6 @@ public interface BuildMaintenanceEndpoint {
                     @ApiResponse(responseCode = SERVER_ERROR_CODE, description = SERVER_ERROR_DESCRIPTION) })
     @GET
     @Path("/{id}/repository-manager-result")
-    public Response collectRepoManagerResult(@Parameter(description = "Build record ID.") @PathParam("id") Long id);
+    public Response collectRepoManagerResult(@Parameter(description = "Build record ID.") @PathParam("id") String id);
 
 }

--- a/spi/src/main/java/org/jboss/pnc/spi/coordinator/BuildCoordinator.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/coordinator/BuildCoordinator.java
@@ -64,7 +64,7 @@ public interface BuildCoordinator {
      * @return True if the cancel request is successfully accepted, false if if there is no running build with such ID
      * @throws CoreException Thrown if cancellation fails due to any internal error
      */
-    boolean cancel(long buildTaskId) throws CoreException;
+    boolean cancel(String buildTaskId) throws CoreException;
 
     boolean cancelSet(int buildSetTaskId) throws CoreException;
 
@@ -72,6 +72,6 @@ public interface BuildCoordinator {
 
     void start();
 
-    Optional<BuildTaskContext> getMDCMeta(Long buildTaskId);
+    Optional<BuildTaskContext> getMDCMeta(String buildTaskId);
 
 }

--- a/spi/src/main/java/org/jboss/pnc/spi/coordinator/BuildSetTask.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/coordinator/BuildSetTask.java
@@ -105,11 +105,11 @@ public class BuildSetTask {
             finishBuildSetTask();
         } else {
             if (log.isTraceEnabled()) {
-                List<Long> running = buildTasks.stream()
+                String running = buildTasks.stream()
                         .filter(bt -> !bt.getStatus().isCompleted())
                         .filter(bt -> !bt.getStatus().hasFailed())
                         .map(BuildTask::getId)
-                        .collect(Collectors.toList());
+                        .collect(Collectors.joining(", "));
                 log.trace("There are still running or waiting builds [{}].", running);
             }
         }

--- a/spi/src/main/java/org/jboss/pnc/spi/coordinator/BuildTask.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/coordinator/BuildTask.java
@@ -43,7 +43,7 @@ public class BuildTask {
 
     private static final Logger userLog = LoggerFactory.getLogger("org.jboss.pnc._userlog_.build-task");
 
-    private final long id;
+    private final String id;
     private final BuildConfigurationAudited buildConfigurationAudited; // TODO decouple DB entity
 
     @Getter
@@ -95,7 +95,7 @@ public class BuildTask {
             User user,
             Date submitTime,
             BuildSetTask buildSetTask,
-            long id,
+            String id,
             Integer buildConfigSetRecordId,
             ProductMilestone productMilestone,
             String contentId,
@@ -242,17 +242,8 @@ public class BuildTask {
         this.hasFailed = hasFailed;
     }
 
-    public long getId() {
+    public String getId() {
         return id;
-    }
-
-    /**
-     * Gets the id in the base32 encoding.
-     *
-     * @return the id in base32 encoding.
-     */
-    public String getBase32Id() {
-        return LongBase32IdConverter.toString(id);
     }
 
     public Date getSubmitTime() {
@@ -307,7 +298,7 @@ public class BuildTask {
             BuildConfigurationAudited buildConfigurationAudited,
             BuildOptions buildOptions,
             User user,
-            long buildTaskId,
+            String buildTaskId,
             BuildSetTask buildSetTask,
             Date submitTime,
             ProductMilestone productMilestone,

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/ArtifactPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/ArtifactPredicates.java
@@ -20,6 +20,7 @@ package org.jboss.pnc.spi.datastore.predicates;
 import org.apache.commons.collections.CollectionUtils;
 import org.jboss.pnc.model.Artifact;
 import org.jboss.pnc.model.Artifact_;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.BuildRecord_;
 import org.jboss.pnc.model.ProductMilestone;
@@ -37,11 +38,11 @@ import org.jboss.pnc.model.TargetRepository_;
  */
 public class ArtifactPredicates {
 
-    public static Predicate<Artifact> withBuildRecordId(Long buildRecordId) {
+    public static Predicate<Artifact> withBuildRecordId(Base32LongID buildRecordId) {
         return (root, query, cb) -> cb.equal(root.join(Artifact_.buildRecord).get(BuildRecord_.id), buildRecordId);
     }
 
-    public static Predicate<Artifact> withDependantBuildRecordId(Long buildRecordId) {
+    public static Predicate<Artifact> withDependantBuildRecordId(Base32LongID buildRecordId) {
         return (root, query, cb) -> {
             Join<Artifact, BuildRecord> buildRecords = root.join(Artifact_.dependantBuildRecords);
             return cb.equal(buildRecords.get(BuildRecord_.id), buildRecordId);

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuildRecordPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuildRecordPredicates.java
@@ -20,6 +20,7 @@ package org.jboss.pnc.spi.datastore.predicates;
 import org.jboss.pnc.enums.BuildStatus;
 import org.jboss.pnc.model.Artifact;
 import org.jboss.pnc.model.Artifact_;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildConfigSetRecord;
 import org.jboss.pnc.model.BuildConfigSetRecord_;
 import org.jboss.pnc.model.BuildConfigurationSet;
@@ -263,7 +264,7 @@ public class BuildRecordPredicates {
         return (root, query, cb) -> cb.isTrue(root.get(BuildRecord_.temporaryBuild));
     }
 
-    public static Predicate<BuildRecord> withCausingBuildRecordId(Long buildRecordId) {
+    public static Predicate<BuildRecord> withCausingBuildRecordId(Base32LongID buildRecordId) {
         return (root, query, cb) -> {
             Join<BuildRecord, BuildRecord> join = root.join(BuildRecord_.noRebuildCause);
             return cb.equal(join.get(BuildRecord_.id), buildRecordId);

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuildRecordPushResultPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/BuildRecordPushResultPredicates.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.spi.datastore.predicates;
 
 import org.jboss.pnc.enums.BuildPushStatus;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildRecordPushResult;
 import org.jboss.pnc.model.BuildRecordPushResult_;
 import org.jboss.pnc.model.BuildRecord_;
@@ -28,14 +29,14 @@ import org.jboss.pnc.spi.datastore.repositories.api.Predicate;
  */
 public class BuildRecordPushResultPredicates {
 
-    public static Predicate<BuildRecordPushResult> forBuildRecordOrderByIdDesc(Long buildRecordId) {
+    public static Predicate<BuildRecordPushResult> forBuildRecordOrderByIdDesc(Base32LongID buildRecordId) {
         return (root, query, cb) -> {
             query.orderBy(cb.desc(root.get(BuildRecordPushResult_.id)));
             return cb.equal(root.get(BuildRecordPushResult_.buildRecord).get(BuildRecord_.id), buildRecordId);
         };
     }
 
-    public static Predicate<BuildRecordPushResult> successForBuildRecord(Long buildRecordId) {
+    public static Predicate<BuildRecordPushResult> successForBuildRecord(Base32LongID buildRecordId) {
         return (root, query, cb) -> cb.and(
                 cb.equal(root.get(BuildRecordPushResult_.buildRecord).get(BuildRecord_.id), buildRecordId),
                 cb.equal(root.get(BuildRecordPushResult_.status), BuildPushStatus.SUCCESS));

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/BuildRecordPushResultRepository.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/BuildRecordPushResultRepository.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.spi.datastore.repositories;
 
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildRecordPushResult;
 import org.jboss.pnc.spi.datastore.repositories.api.Repository;
 
@@ -27,7 +28,7 @@ import java.util.List;
  */
 public interface BuildRecordPushResultRepository extends Repository<BuildRecordPushResult, Long> {
 
-    BuildRecordPushResult getLatestForBuildRecord(Long buildRecordId);
+    BuildRecordPushResult getLatestForBuildRecord(Base32LongID buildRecordId);
 
-    List<BuildRecordPushResult> getAllSuccessfulForBuildRecord(Long buildRecordId);
+    List<BuildRecordPushResult> getAllSuccessfulForBuildRecord(Base32LongID buildRecordId);
 }

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/BuildRecordRepository.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/BuildRecordRepository.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.spi.datastore.repositories;
 
 import org.jboss.pnc.enums.BuildStatus;
+import org.jboss.pnc.model.Base32LongID;
 import org.jboss.pnc.model.BuildRecord;
 import org.jboss.pnc.model.IdRev;
 import org.jboss.pnc.spi.datastore.repositories.api.PageInfo;
@@ -33,14 +34,14 @@ import java.util.Set;
 /**
  * Interface for manipulating {@link org.jboss.pnc.model.BuildRecord} entity.
  */
-public interface BuildRecordRepository extends Repository<BuildRecord, Long> {
+public interface BuildRecordRepository extends Repository<BuildRecord, Base32LongID> {
 
-    BuildRecord findByIdFetchAllProperties(Long id);
+    BuildRecord findByIdFetchAllProperties(Base32LongID id);
 
     /**
      * @return null if record is not found.
      */
-    BuildRecord findByIdFetchProperties(Long id);
+    BuildRecord findByIdFetchProperties(Base32LongID id);
 
     List<BuildRecord> queryWithPredicatesUsingCursor(
             PageInfo pageInfo,
@@ -71,7 +72,7 @@ public interface BuildRecordRepository extends Repository<BuildRecord, Long> {
                 .filter(
                         record -> (includeTemporary && record.isTemporaryBuild())
                                 || (includePersistent && !record.isTemporaryBuild()))
-                .max(Comparator.comparing(BuildRecord::getId))
+                .max(Comparator.comparing(BuildRecord::getSubmitTime))
                 .orElse(null);
     }
 
@@ -85,5 +86,5 @@ public interface BuildRecordRepository extends Repository<BuildRecord, Long> {
 
     Set<BuildRecord> findByBuiltArtifacts(Set<Integer> artifactsId);
 
-    List<BuildRecord> getBuildByCausingRecord(Long causingRecordId);
+    List<BuildRecord> getBuildByCausingRecord(Base32LongID causingRecordId);
 }

--- a/spi/src/main/java/org/jboss/pnc/spi/events/BuildExecutionStatusChangedEvent.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/events/BuildExecutionStatusChangedEvent.java
@@ -29,7 +29,7 @@ public interface BuildExecutionStatusChangedEvent {
 
     BuildExecutionStatus getNewStatus();
 
-    Long getBuildTaskId();
+    String getBuildTaskId();
 
     Integer getBuildConfigurationId();
 

--- a/spi/src/main/java/org/jboss/pnc/spi/exception/BuildConflictException.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/exception/BuildConflictException.java
@@ -27,18 +27,18 @@ public class BuildConflictException extends Exception {
     /**
      * The id of the build task which conflicts with the new request
      */
-    private Long buildTaskId;
+    private String buildTaskId;
 
     public BuildConflictException(String message) {
         super(message);
     }
 
-    public BuildConflictException(String message, Long buildTaskId) {
+    public BuildConflictException(String message, String buildTaskId) {
         super(message);
         this.buildTaskId = buildTaskId;
     }
 
-    public Long getBuildTaskId() {
+    public String getBuildTaskId() {
         return buildTaskId;
     }
 }

--- a/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionConfiguration.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionConfiguration.java
@@ -33,7 +33,7 @@ import java.util.Map;
 public interface BuildExecutionConfiguration extends BuildExecution {
 
     @Override
-    long getId();
+    String getId();
 
     String getUserId();
 
@@ -64,7 +64,7 @@ public interface BuildExecutionConfiguration extends BuildExecution {
     String getDefaultAlignmentParams();
 
     static BuildExecutionConfiguration build(
-            Long id,
+            String id,
             String buildContentId,
             String userId,
             String buildScript,
@@ -109,7 +109,7 @@ public interface BuildExecutionConfiguration extends BuildExecution {
     }
 
     static BuildExecutionConfiguration build(
-            long id,
+            String id,
             String buildContentId,
             String userId,
             String buildScript,
@@ -150,7 +150,7 @@ public interface BuildExecutionConfiguration extends BuildExecution {
         return new BuildExecutionConfiguration() {
 
             @Override
-            public long getId() {
+            public String getId() {
                 return id;
             }
 

--- a/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionSession.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutionSession.java
@@ -33,7 +33,7 @@ import java.util.function.Consumer;
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
  */
 public interface BuildExecutionSession {
-    Long getId();
+    String getId();
 
     Optional<URI> getLiveLogsUri();
 

--- a/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutor.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/executor/BuildExecutor.java
@@ -33,10 +33,10 @@ public interface BuildExecutor {
             Consumer<BuildExecutionStatusChangedEvent> onBuildExecutionStatusChangedEvent,
             String accessToken) throws ExecutorException;
 
-    BuildExecutionSession getRunningExecution(long buildExecutionTaskId);
+    BuildExecutionSession getRunningExecution(String buildExecutionTaskId);
 
     void shutdown();
 
-    void cancel(Long executionConfigurationId) throws ExecutorException;
+    void cancel(String executionConfigurationId) throws ExecutorException;
 
 }

--- a/spi/src/main/java/org/jboss/pnc/spi/repositorymanager/BuildExecution.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/repositorymanager/BuildExecution.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public interface BuildExecution {
 
-    long getId();
+    String getId();
 
     String getBuildContentId();
 

--- a/spi/src/main/java/org/jboss/pnc/spi/repositorymanager/RepositoryManager.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/repositorymanager/RepositoryManager.java
@@ -83,7 +83,7 @@ public interface RepositoryManager {
      * @return repository manager result
      * @throws RepositoryManagerException in case of an error when collecting the build artifacts and dependencies
      */
-    RepositoryManagerResult collectRepoManagerResult(Long id) throws RepositoryManagerException;
+    RepositoryManagerResult collectRepoManagerResult(String id) throws RepositoryManagerException;
 
     /**
      * Add the repository containing output associated with the specified {@link BuildRecord} to the membership of the

--- a/termd-build-driver/src/main/java/org/jboss/pnc/termdbuilddriver/TermdBuildDriver.java
+++ b/termd-build-driver/src/main/java/org/jboss/pnc/termdbuilddriver/TermdBuildDriver.java
@@ -147,7 +147,7 @@ public class TermdBuildDriver implements BuildDriver { // TODO rename class
                     terminalUrl,
                     onStatusUpdate,
                     httpCallbackMode,
-                    buildExecutionSession.getId().toString(),
+                    buildExecutionSession.getId(),
                     buildExecutionSession.getAccessToken());
             buildExecutionSession.setBuildStatusUpdateConsumer(remoteInvocation.getClientStatusUpdateConsumer());
 


### PR DESCRIPTION
### Checklist:

The BuildRecord class now uses embedable id Base32LongID which is stored in DB as long, but is able to be constructed from both long and (base 32 encded) string and provides methods to read the ID as both long and string, with preference to the string form.

DB queries are using the new Base32LongID objects, which can be easily created from both String and Long objects.

Orchestrator now internally uses String form of the Build identifier - in Build Task, Build Execution, etc - and only when touching DB is the identifier used in the form of Base32LongID object.

* [x] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [x] Have you added unit tests for your change?
