### PR TITLE
[v2.0][NCL-6653] Revert "Try to ignore nested reference chain bits which ca…

### DIFF
--- a/common/src/main/java/org/jboss/pnc/common/json/JsonOutputConverterMapper.java
+++ b/common/src/main/java/org/jboss/pnc/common/json/JsonOutputConverterMapper.java
@@ -18,7 +18,6 @@
 
 package org.jboss.pnc.common.json;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -50,16 +49,6 @@ public class JsonOutputConverterMapper {
         mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         mapper.disable(SerializationFeature.FAIL_ON_UNWRAPPED_TYPE_IDENTIFIERS);
-
-        try {
-            mapper.addMixIn(
-                    Class.forName("com.openshift.restclient.model.IStatus"),
-                    PNCMixinToIgnoreKubernetesProjectNPE.class);
-        } catch (ClassNotFoundException e) {
-            log.error(
-                    "Could not ignore com.openshift.restclient.model.IStatus on com.openshift.restclient.authorization.ResourceForbiddenException",
-                    e);
-        }
     }
 
     /**
@@ -92,10 +81,6 @@ public class JsonOutputConverterMapper {
 
         @JsonProperty
         private Object value;
-    }
-
-    @JsonIgnoreType
-    static final class PNCMixinToIgnoreKubernetesProjectNPE {
     }
 
     public static ObjectMapper getMapper() {


### PR DESCRIPTION
…uses the NPE"

This reverts commit 3397a5b3adb26570f4726f14673b7b799b19e4ab.

This is because we switched to Fabric8 Openshift libraries instead of
the old one

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
