### PR TITLE
[v2.1][NCLSUP-393] Use own sort implementation for tasks

### DIFF
--- a/common/src/main/java/org/jboss/pnc/common/util/Quicksort.java
+++ b/common/src/main/java/org/jboss/pnc/common/util/Quicksort.java
@@ -1,0 +1,73 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.common.util;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Quicksort implementation with a Comparator object used for comparison.
+ */
+public class Quicksort<T> {
+
+    /**
+     * Quicksort implementation that takes in a List and a comparator, and sorts the list
+     *
+     * Unlike the default Java implementation (TimSort), it doesn't check if the comparator violates its contract, which
+     * is useful in some cases.
+     *
+     * @param list list to sort
+     * @param comparator comparator to compare data
+     * @param <T> generic type
+     */
+    public static <T> void quicksort(List<T> list, Comparator<T> comparator) {
+        quicksort(list, comparator, 0, list.size() - 1);
+    }
+
+    private static <T> void quicksort(List<T> list, Comparator<T> comparator, int begin, int end) {
+        if (begin < end) {
+            int partitionIndex = partition(list, comparator, begin, end);
+
+            quicksort(list, comparator, begin, partitionIndex - 1);
+            quicksort(list, comparator, partitionIndex + 1, end);
+        }
+    }
+
+    private static <T> int partition(List<T> list, Comparator<T> comparator, int begin, int end) {
+
+        // Choose initial pivot
+        T pivot = list.get(end);
+
+        int i = (begin - 1);
+
+        for (int j = begin; j < end; j++) {
+            if (comparator.compare(list.get(j), pivot) <= 0) {
+                i++;
+                T swapTemp = list.get(i);
+                list.set(i, list.get(j));
+                list.set(j, swapTemp);
+            }
+        }
+
+        T swapTemp = list.get(i + 1);
+        list.set(i + 1, list.get(end));
+        list.set(end, swapTemp);
+
+        return i + 1;
+    }
+}

--- a/common/src/test/java/org/jboss/pnc/common/util/QuicksortTest.java
+++ b/common/src/test/java/org/jboss/pnc/common/util/QuicksortTest.java
@@ -1,0 +1,38 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.common.util;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.util.Lists;
+import org.junit.Test;
+
+import java.util.Comparator;
+import java.util.List;
+
+public class QuicksortTest {
+
+    @Test
+    public void quiksortTest() {
+        List<Integer> toSort = Lists.list(10, -15, 30, 10, 120, -1000);
+        Quicksort.quicksort(toSort, Comparator.naturalOrder());
+
+        for (int a = 0; a < toSort.size() - 1; a++) {
+            Assertions.assertThat(toSort.get(a) < toSort.get(a + 1));
+        }
+    }
+}


### PR DESCRIPTION
The comparison between tasks to put dependants at the beginning is
unfortunately not stable since it allows this scenario:

If task1 depends on task2, and task3 doesn't depend on any tasks, then
this comparator allows for this:

- task1 = task3
- task2 = task3
- task1 < task3

If both task1 and task2 = task3, it would infer that task1 = task3.
Alas, this is not the case for this comparison and it makes Java's
default sort implementation upset (Error is: Comparison method violates
its general contract!)

This commit implements our own Quicksort algorithm that *doesn't* check
if the comparator is stable and sorts the list.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
