### PR TITLE
[NCLSUP-444] add readDefaultObject and writeDefaultObject

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/Base32LongID.java
+++ b/model/src/main/java/org/jboss/pnc/model/Base32LongID.java
@@ -83,6 +83,7 @@ public class Base32LongID implements Serializable {
      * @throws IOException
      */
     private void writeObject(java.io.ObjectOutputStream stream) throws IOException {
+        stream.defaultWriteObject();
         stream.writeLong(id);
     }
 
@@ -94,7 +95,7 @@ public class Base32LongID implements Serializable {
      * @throws ClassNotFoundException
      */
     private void readObject(java.io.ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
         this.id = stream.readLong();
     }
-
 }


### PR DESCRIPTION
This is a suggestion from Paul Ferraro to ensure that the requisite
class descriptors (as well as any non-transient fields) are written to
the stream (which are required by JBoss Marshalling for
deserialization).

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
