### PR TITLE
[NCL-6799] Make sure bpm base url has no trailing slash

### DIFF
--- a/bpm/src/main/java/org/jboss/pnc/bpm/RestConnector.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/RestConnector.java
@@ -238,25 +238,34 @@ public class RestConnector implements Connector {
 
     private static class EndpointUrlResolver {
 
+        /**
+         * Base url of BPM. It shouldn't end with a trailing slash
+         */
         private final String baseUrl;
 
         public EndpointUrlResolver(String baseUrl) {
-            this.baseUrl = baseUrl;
+
+            // Remove trailing slash if present
+            if (baseUrl != null && baseUrl.endsWith("/")) {
+                this.baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+            } else {
+                this.baseUrl = baseUrl;
+            }
         }
 
         public HttpPost startProcessInstance(String deploymentId, String processId) {
-            return new HttpPost(baseUrl + "containers/" + deploymentId + "/processes/" + processId + "/instances");
+            return new HttpPost(baseUrl + "/containers/" + deploymentId + "/processes/" + processId + "/instances");
         }
 
         public HttpPost startProcessInstance(String deploymentId, String processId, String correlationKey) {
             return new HttpPost(
-                    baseUrl + "containers/" + deploymentId + "/processes/" + processId + "/instances/correlation/"
+                    baseUrl + "/containers/" + deploymentId + "/processes/" + processId + "/instances/correlation/"
                             + correlationKey);
         }
 
         public HttpPost processInstanceSignal(String deploymentId, String processInstanceId, String signal) {
             return new HttpPost(
-                    baseUrl + "containers/" + deploymentId + "/processes/instances/" + processInstanceId + "/signal/"
+                    baseUrl + "/containers/" + deploymentId + "/processes/instances/" + processInstanceId + "/signal/"
                             + signal);
         }
 
@@ -271,6 +280,5 @@ public class RestConnector implements Connector {
         public String queryProcessInstances(String processId) {
             return baseUrl + "/queries/processes/" + processId + "/instances";
         }
-
     }
 }

--- a/bpm/src/test/java/org/jboss/pnc/bpm/test/RestConnectorRequestSerializationTest.java
+++ b/bpm/src/test/java/org/jboss/pnc/bpm/test/RestConnectorRequestSerializationTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class RestConnectorRequestSerializationTest {
 
-    private static final String DEPLOYMENT_ID = "/testing";
+    private static final String DEPLOYMENT_ID = "testing";
 
     @Mock
     private BpmModuleConfig bpmConfig;
@@ -69,7 +69,7 @@ public class RestConnectorRequestSerializationTest {
         when(bpmConfig.getBpmNewBaseUrl()).thenReturn(wireMockServer.baseUrl());
         when(bpmConfig.getBpmNewDeploymentId()).thenReturn(DEPLOYMENT_ID);
         wireMockServer.stubFor(
-                post(urlMatching(DEPLOYMENT_ID + ".*")).willReturn(
+                post(urlMatching(".*" + DEPLOYMENT_ID + ".*")).willReturn(
                         aResponse().withStatus(201)
                                 .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
                                 .withBody("1")));


### PR DESCRIPTION
This commit sanitizes the bpm base url so that it doesn't end with a
trailing slash. We can then use the sanitized bpm base url to generate
the other endpoints.

This is needed because of inconsistencies in the generated endpoints in
`RestConnector`. Some of them assumed the base url would end with a
trailing slash, others without. If the generated final endpoint has
address "http://bpm-server//server", the BPM server is likely to get
confused by the double slash.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
