### PR TITLE
[NCL-6799] Remove redundant /server string in bpm

### DIFF
--- a/bpm/src/main/java/org/jboss/pnc/bpm/RestConnector.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/RestConnector.java
@@ -270,11 +270,11 @@ public class RestConnector implements Connector {
         }
 
         public HttpGet queryProcessInstance(String processInstanceId) {
-            return new HttpGet(baseUrl + "/server/queries/processes/instances/" + processInstanceId);
+            return new HttpGet(baseUrl + "/queries/processes/instances/" + processInstanceId);
         }
 
         public HttpGet queryProcessInstanceByCorrelation(String correlationKey) {
-            return new HttpGet(baseUrl + "/server/queries/processes/instance/correlation/" + correlationKey);
+            return new HttpGet(baseUrl + "/queries/processes/instance/correlation/" + correlationKey);
         }
 
         public String queryProcessInstances(String processId) {


### PR DESCRIPTION
It is assumed that the base bpm url is of type:
- <base url>/services/rest/server

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
