### PR TITLE
[NCL-6861] Don't overwrite existing Build when saving it

### DIFF
--- a/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
@@ -141,6 +141,12 @@ public class DefaultDatastore implements Datastore {
             List<Artifact> dependencies) {
         BuildRecord buildRecord = buildRecordBuilder.build(true);
         logger.debug("Storing completed build {}.", buildRecord);
+        BuildRecord previouslySavedBuild = buildRecordRepository.queryById(buildRecord.getId());
+        if (previouslySavedBuild != null) {
+            throw new IllegalStateException(
+                    "When trying to save build " + buildRecord + " previously saved build with status "
+                            + previouslySavedBuild.getStatus() + " was found.");
+        }
         if (logger.isTraceEnabled()) {
             logger.trace("Build Log: {}.", buildRecord.getBuildLog());
         }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/RepositoryMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/RepositoryMock.java
@@ -98,7 +98,7 @@ public abstract class RepositoryMock<ID extends Serializable, EntityType extends
 
     @Override
     public EntityType queryById(ID id) {
-        return getOptionalById(id).orElseThrow(() -> new RuntimeException("Didn't find entity for id: " + id));
+        return getOptionalById(id).orElse(null);
     }
 
     @Override


### PR DESCRIPTION
When the /build-task/<ID>/complete endpoit is called multiple times at
the seme time, it lead to race condition in the
DatastoreAdapter.storeResult and DefaultDatastore.storeCompletedBuild
methods.

The first invocation of storeCompletedBuild could successfully store
the artifacts and build, which lead to conflicts in the simultaneous
calls to that method. These conflicts resulted in exception catched in
storeResult which was handled by marking the build as SYSTEM-ERROR and
trying to save the failed build again. This now overwrote* the first
correctly saved build with the failed build.

* We use Spring CrudRepository.save method which calls em.merge if the
  entity already is in DB.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
