### PR TITLE
[NCLSUP-507] Send revision info to RHPAM when creating build config

### DIFF
--- a/facade/src/main/java/org/jboss/pnc/facade/providers/BuildConfigurationProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/BuildConfigurationProviderImpl.java
@@ -544,9 +544,9 @@ public class BuildConfigurationProviderImpl extends
         BuildConfiguration newBuildConfigurationWithId = buildConfiguration.toBuilder()
                 .id(buildConfigurationId.toString())
                 .build();
-
         RepositoryCreationResponse rcResponse = scmRepositoryProvider.createSCMRepository(
                 request.getScmUrl(),
+                request.getBuildConfig().getScmRevision(),
                 request.getPreBuildSyncEnabled(),
                 JobNotificationType.BUILD_CONFIG_CREATION,
                 // wrap as the callback happens from the Bpm task completion

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/api/SCMRepositoryProvider.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/api/SCMRepositoryProvider.java
@@ -53,10 +53,10 @@ public interface SCMRepositoryProvider
 
     /**
      * Starts the task of creating SCMRepository.If the SCM URL is external, the task creates new internal repository
-     * and does inital synchronization.
+     * and does initial synchronization.
      *
      * @param scmUrl The URL of the SCM repository.
-     * @param preBuildSyncEnabled If the SCM URL is external, this parameter specifies wheather the external repository
+     * @param preBuildSyncEnabled If the SCM URL is external, this parameter specifies whether the external repository
      *        should be synchronized into the internal one before build.
      * @param jobType Type of the job that requested the SCM repository creation (for notification purposes).
      * @param consumer Callback function that is called when SCM repository is created. The callback function takes SCM
@@ -65,6 +65,27 @@ public interface SCMRepositoryProvider
      */
     RepositoryCreationResponse createSCMRepository(
             String scmUrl,
+            Boolean preBuildSyncEnabled,
+            JobNotificationType jobType,
+            Consumer<RepositoryCreated> consumer,
+            Optional<BuildConfiguration> buildConfiguration);
+
+    /**
+     * Starts the task of creating SCMRepository.If the SCM URL is external, the task creates new internal repository
+     * and does initial synchronization.
+     *
+     * @param scmUrl The URL of the SCM repository.
+     * @param revision Revision to sync between the external and internal SCM repository
+     * @param preBuildSyncEnabled If the SCM URL is external, this parameter specifies whether the external repository
+     *        should be synchronized into the internal one before build.
+     * @param jobType Type of the job that requested the SCM repository creation (for notification purposes).
+     * @param consumer Callback function that is called when SCM repository is created. The callback function takes SCM
+     *        repository id as a parameter.
+     * @return id of the created
+     */
+    RepositoryCreationResponse createSCMRepository(
+            String scmUrl,
+            String revision,
             Boolean preBuildSyncEnabled,
             JobNotificationType jobType,
             Consumer<RepositoryCreated> consumer,


### PR DESCRIPTION
On creation of a build configuration, PNC:
1. creates a repository configuration (via RHPAM)
2. creates the build configuration with the repository configuration info

In step 1, the external scm repository is synced to the internal scm repository.
If a revision is specified, then we should only sync that revision. This
is already implemented in Repour, but the revision information is not
being sent to Repour.

To do so, we need to pass the information of the revision from PNC to
RHPAM. This commit is the implementation of this.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
