### PR TITLE
[NCL-6965] - Fix running builds search by BuildConfigName

### DIFF
--- a/facade/src/main/java/org/jboss/pnc/facade/providers/BuildProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/BuildProviderImpl.java
@@ -977,11 +977,12 @@ public class BuildProviderImpl extends AbstractUpdatableProvider<Base32LongID, B
         }
 
         if (!StringUtils.isEmpty(pageInfo.getBuildConfigName())) {
-            if (pageInfo.getBuildConfigName().contains("*")) {
+            if (pageInfo.getBuildConfigName().contains("*") || pageInfo.getBuildConfigName().contains("%")) {
                 predicate = predicate.and(
                         t -> t.getBuildConfigurationAudited()
                                 .getName()
-                                .matches(pageInfo.getBuildConfigName().replaceAll("\\*", ".*")));
+                                .matches(
+                                        pageInfo.getBuildConfigName().replaceAll("\\*", ".*").replaceAll("\\%", ".*")));
             } else {
                 predicate = predicate
                         .and(t -> pageInfo.getBuildConfigName().equals(t.getBuildConfigurationAudited().getName()));

--- a/facade/src/test/java/org/jboss/pnc/facade/providers/BuildProviderImplTest.java
+++ b/facade/src/test/java/org/jboss/pnc/facade/providers/BuildProviderImplTest.java
@@ -350,6 +350,43 @@ public class BuildProviderImplTest extends AbstractBase32LongIDProviderTest<Buil
     }
 
     @Test
+    public void testFailFilterLikeRunningBuildsByBuildConfigNameWithWildcard() {
+        // Given
+        mockBuildRecord();
+        mockBuildTask();
+
+        String givenBcName = "VeryLongAndComplicatedBcName";
+        String givenBcNamePattern = "LongAndComplicated%";
+        BuildTask givenBT = mockBuildTask(givenBcName);
+
+        // When
+        BuildPageInfo pageInfo = new BuildPageInfo(0, 2, "", "", false, true, givenBcNamePattern);
+        Page<Build> builds = provider.getBuilds(pageInfo);
+
+        // Then
+        assertEquals(0, builds.getTotalHits());
+    }
+
+    @Test
+    public void testFilterLikeRunningBuildsByBuildConfigNameAsReceivedFromUI() {
+        // Given
+        mockBuildRecord();
+        mockBuildTask();
+
+        String givenBcName = "VeryLongAndComplicatedBcName";
+        // UI filters always append and prepend %
+        String givenBcNamePattern = "%LongAndComplicated*%";
+        BuildTask givenBT = mockBuildTask(givenBcName);
+
+        // When
+        BuildPageInfo pageInfo = new BuildPageInfo(0, 2, "", "", false, true, givenBcNamePattern);
+        Page<Build> builds = provider.getBuilds(pageInfo);
+
+        // Then
+        assertEquals(1, builds.getTotalHits());
+    }
+
+    @Test
     public void testFilterFinishedBuildsByBuildConfigName() {
         // Given
         Base32LongID givenIdAndBcName = new Base32LongID(85792L);


### PR DESCRIPTION
Handle the % wildcard as received from the UI