### PR TITLE
Update the query for getLatestBuildsWithConfigIds

### DIFF
--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/internal/BuildRecordSpringRepository.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/internal/BuildRecordSpringRepository.java
@@ -33,8 +33,13 @@ import java.util.Set;
 public interface BuildRecordSpringRepository
         extends JpaRepository<BuildRecord, Base32LongID>, JpaSpecificationExecutor<BuildRecord> {
 
-    @Query("SELECT br FROM BuildRecord br WHERE br.submitTime = (SELECT max(brr.submitTime) FROM BuildRecord brr"
-            + " WHERE br.buildConfigurationId = brr.buildConfigurationId) AND br.buildConfigurationId IN ?1")
+    @Query(
+            value = "SELECT * FROM buildrecord br" + " INNER JOIN ("
+                    + "   SELECT buildconfiguration_id, max(submittime) AS max_submit" + "   FROM buildrecord"
+                    + "   GROUP BY buildconfiguration_id" + " ) brr"
+                    + " ON  br.buildconfiguration_id = brr.buildconfiguration_id"
+                    + " AND br.submittime = brr.max_submit" + " AND br.buildconfiguration_id IN (?1)",
+            nativeQuery = true)
     List<BuildRecord> getLatestBuildsByBuildConfigIds(List<Integer> configIds);
 
     @Query("select br from BuildRecord br fetch all properties where br.id = ?1")


### PR DESCRIPTION
The updated query has a significant speedup compared to the JPA one for build configs with a lot of builds.

Whereas the previous query took 40 seconds in the worst case scenario, the new query takes 0.02 seconds.

However, we need to use the native query option since it is hard to translate what we want to achieve in JPASQL

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
