### PR TITLE
[NCL-7381] get rid of CVEs 

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -41,6 +41,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.pnc</groupId>
+      <artifactId>common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <scope>provided</scope>
@@ -78,16 +83,7 @@
 
     <dependency>
       <groupId>org.jboss.pnc</groupId>
-      <artifactId>common</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.pnc</groupId>
       <artifactId>moduleconfig</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
     </dependency>
 
     <dependency>
@@ -98,17 +94,6 @@
     <dependency>
       <groupId>org.jboss.pnc</groupId>
       <artifactId>pnc-mock</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss</groupId>
-      <artifactId>jboss-common-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.logging</groupId>
-          <artifactId>jboss-logging-spi</artifactId>
-        </exclusion>
-      </exclusions>
       <scope>test</scope>
     </dependency>
 

--- a/build-coordinator/pom.xml
+++ b/build-coordinator/pom.xml
@@ -216,8 +216,5 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
-
-    <!-- /Test coverage -->
-
   </dependencies>
 </project>

--- a/datastore/pom.xml
+++ b/datastore/pom.xml
@@ -61,10 +61,12 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>cz.jirutka.rsql</groupId>
@@ -237,7 +239,7 @@
           <groupId>org.hsqldb</groupId>
           <artifactId>hsqldb</artifactId>
           <scope>test</scope>
-          <classifier>jdk8debug</classifier>
+          <classifier>debug</classifier>
         </dependency>
       </dependencies>
       <build>
@@ -268,8 +270,7 @@
                 <configuration>
                   <groupId>org.hsqldb</groupId>
                   <artifactId>hsqldb</artifactId>
-                  <classifier>jdk8debug</classifier>
-                  <!--<name>hsqldb-jdk8debug.jar</name>-->
+                  <classifier>debug</classifier>
                 </configuration>
               </execution>
               <execution>
@@ -287,7 +288,7 @@
                         <enabled>true</enabled>
                         <connection-url>jdbc:hsqldb:mem:newcastletestmemdb</connection-url>
                         <driver-class>org.hsqldb.jdbc.JDBCDriver</driver-class>
-                        <driver-name>hsqldb-2.4.1-jdk8debug.jar</driver-name>
+                        <driver-name>hsqldb-2.7.1-debug.jar</driver-name>
                         <user-name>sa</user-name>
                         <password>sa</password>
                       </properties>
@@ -340,6 +341,9 @@
                       </command>
                       <command>
                         /subsystem=logging/logger=org.hibernate.type:add(level=TRACE)
+                      </command>
+                      <command>
+                        /subsystem=logging/logger=org.jboss:add(level=DEBUG)
                       </command-->
                     </commands>
                   </execute-commands>

--- a/datastore/src/main/java/org/jboss/pnc/datastore/limits/CursoredPageRequest.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/limits/CursoredPageRequest.java
@@ -20,6 +20,8 @@ package org.jboss.pnc.datastore.limits;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import java.util.Objects;
+
 /**
  * Pageable implementation that supports cursored (offset / limit based) pagination rather than the index / size based.
  *
@@ -27,11 +29,11 @@ import org.springframework.data.domain.Sort;
  */
 public class CursoredPageRequest implements Pageable {
 
-    private final int offset;
+    private final long offset;
     private final int limit;
     private final Sort sort;
 
-    public CursoredPageRequest(int offset, int limit, Sort sort) {
+    public CursoredPageRequest(long offset, int limit, Sort sort) {
         if (offset < 0) {
             throw new IllegalArgumentException("Offset must not be less than zero!");
         }
@@ -46,7 +48,7 @@ public class CursoredPageRequest implements Pageable {
     }
 
     @Override
-    public int getOffset() {
+    public long getOffset() {
         return offset;
     }
 
@@ -77,7 +79,7 @@ public class CursoredPageRequest implements Pageable {
 
     @Override
     public Pageable previousOrFirst() {
-        int newOffset;
+        long newOffset;
 
         if (offset < limit) {
             newOffset = 0;
@@ -112,10 +114,7 @@ public class CursoredPageRequest implements Pageable {
 
     @Override
     public int hashCode() {
-        int result = offset;
-        result = 31 * result + limit;
-        result = 31 * result + (sort != null ? sort.hashCode() : 0);
-        return result;
+        return Objects.hash(offset, limit, sort);
     }
 
     @Override

--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/internal/AbstractRepository.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/internal/AbstractRepository.java
@@ -65,7 +65,7 @@ public class AbstractRepository<T extends GenericEntity<ID>, ID extends Serializ
 
     @Override
     public void delete(ID id) {
-        springRepository.delete(id);
+        springRepository.deleteById(id);
     }
 
     @Override
@@ -86,12 +86,12 @@ public class AbstractRepository<T extends GenericEntity<ID>, ID extends Serializ
 
     @Override
     public T queryById(ID id) {
-        return springRepository.findOne(id);
+        return springRepository.findById(id).orElse(null);
     }
 
     @Override
     public T queryByPredicates(Predicate<T>... predicates) {
-        return springSpecificationsExecutor.findOne(SpecificationsMapper.map(predicates));
+        return springSpecificationsExecutor.findOne(SpecificationsMapper.map(predicates)).orElse(null);
     }
 
     @Override

--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/internal/PageableMapper.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/internal/PageableMapper.java
@@ -28,7 +28,7 @@ import org.springframework.data.domain.Sort;
 public class PageableMapper {
 
     public static PageRequest map(PageInfo pageInfo, SortInfo sortInfo) {
-        return new PageRequest(getPageOffset(pageInfo), getPageSize(pageInfo), getSort(sortInfo));
+        return PageRequest.of(getPageOffset(pageInfo), getPageSize(pageInfo), getSort(sortInfo));
     }
 
     public static CursoredPageRequest mapCursored(PageInfo pageInfo, SortInfo sortInfo) {
@@ -41,7 +41,7 @@ public class PageableMapper {
         }
         Sort.Direction direction = sortInfo.getDirection() == SortInfo.SortingDirection.ASC ? Sort.Direction.ASC
                 : Sort.Direction.DESC;
-        return new Sort(direction, sortInfo.getFields());
+        return Sort.by(direction, sortInfo.getFields().toArray(new String[] {}));
     }
 
     private static int getPageOffset(PageInfo pageInfo) {

--- a/dto/pom.xml
+++ b/dto/pom.xml
@@ -71,7 +71,7 @@
             <artifactId>commons-validator</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.fge</groupId>
+            <groupId>com.github.java-json-tools</groupId>
             <artifactId>json-patch</artifactId>
             <exclusions>
                 <exclusion>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -173,7 +173,7 @@
       <artifactId>lombok</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.fge</groupId>
+      <groupId>com.github.java-json-tools</groupId>
       <artifactId>json-patch</artifactId>
       <exclusions>
         <exclusion>
@@ -314,7 +314,7 @@
           <groupId>org.hsqldb</groupId>
           <artifactId>hsqldb</artifactId>
           <scope>compile</scope>
-          <classifier>jdk8debug</classifier>
+          <classifier>debug</classifier>
         </dependency>
       </dependencies>
       <build>
@@ -346,8 +346,7 @@
                 <configuration>
                   <groupId>org.hsqldb</groupId>
                   <artifactId>hsqldb</artifactId>
-                  <classifier>jdk8debug</classifier>
-                  <!--<name>hsqldb-jdk8debug.jar</name>-->
+                  <classifier>debug</classifier>
                 </configuration>
               </execution>
               <execution>
@@ -365,7 +364,7 @@
                         <enabled>true</enabled>
                         <connection-url>jdbc:hsqldb:mem:newcastletestmemdb</connection-url>
                         <driver-class>org.hsqldb.jdbc.JDBCDriver</driver-class>
-                        <driver-name>hsqldb-2.4.1-jdk8debug.jar</driver-name>
+                        <driver-name>hsqldb-2.7.1-debug.jar</driver-name>
                         <user-name>sa</user-name>
                         <password>sa</password>
                       </properties>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -113,7 +113,7 @@
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <scope>test</scope>
-      <classifier>jdk8debug</classifier>
+      <classifier>debug</classifier>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>

--- a/moduleconfig/pom.xml
+++ b/moduleconfig/pom.xml
@@ -84,16 +84,9 @@
       <artifactId>common</artifactId>
     </dependency>
 
-
     <dependency>
       <groupId>org.jboss.pnc</groupId>
       <artifactId>test-common</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.commonjava.indy</groupId>
-      <artifactId>indy-model-core-java</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -96,40 +96,58 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.min.version>3.2</maven.min.version>
+
     <!--<version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.2.Final-redhat-1</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>-->
     <version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>
     <atlasVersion>1.1.0</atlasVersion>
     <indyVersion>2.5.4</indyVersion>
-    <version.assertj-core>3.18.1</version.assertj-core>
-    <version.mockito>3.8.0</version.mockito>
-    <version.catch-exception>1.2.0</version.catch-exception>
-    <version.jbpm>6.2.0.Final</version.jbpm>
-    <version.keycloak>9.0.3.redhat-00002</version.keycloak>
-    <version.shrinkwrap.descriptors>2.0.0</version.shrinkwrap.descriptors>
-    <version.swagger2>2.1.4</version.swagger2>
+    <!-- If you are changing this, change also version.keycloak!-->
+    <version.rh-sso-adapter>7.4.8.GA</version.rh-sso-adapter>
+    <version.keycloak>9.0.14.redhat-00001</version.keycloak>
+    <version.swagger2>2.2.8</version.swagger2>
+    <version.buildagent>1.0.0</version.buildagent>
     <version.lombok>1.18.22</version.lombok>
     <version.mapstruct>1.4.2.Final</version.mapstruct>
-    <version.junit>4.13.1</version.junit>
-    <version.org.glassfish.javax.el-impl>3.0.1.b08-redhat-1</version.org.glassfish.javax.el-impl>
-    <version.vertx.core>3.8.5</version.vertx.core>
+    <version.pncmetrics>1.1.3</version.pncmetrics>
     <version.pnc-api>2.4.5-SNAPSHOT</version.pnc-api>
     <version.pnc-common>2.2.1-SNAPSHOT</version.pnc-common>
     <version.rex-api>1.0.0-SNAPSHOT</version.rex-api>
-
+    <version.spring>2.3.9.RELEASE</version.spring>
+    <version.apicurio-registry>1.3.2.Final</version.apicurio-registry>
+    <version.vertx-core>3.9.14</version.vertx-core>
     <!-- same base version (no -redhat) as version.org.apache.httpcomponents.httpclient from the eap BOM-->
-    <version.org.apache.httpcomponents.fluent-hc>4.5.4</version.org.apache.httpcomponents.fluent-hc>
-
+    <version.org.apache.httpcomponents.fluent-hc>4.5.14</version.org.apache.httpcomponents.fluent-hc>
     <!-- -redhat version is missing some packages -->
-    <version.com.github.fge>1.9</version.com.github.fge>
-
-    <!-- Package URL -->
-    <version.com.github.package-url>1.3.1</version.com.github.package-url>
+    <version.com.github.json-patch>1.13</version.com.github.json-patch>
+    <!-- SYNC commons-* with EAP provided versions (they can be found in eap-runtime-artifacts pom) -->
+    <version.commons-lang>2.6</version.commons-lang>
+    <version.commons-logging>1.2</version.commons-logging>
+    <version.commons-collections>3.2.2</version.commons-collections>
+    <version.commons-validator>1.7</version.commons-validator>
+    <version.commons-beanutils>1.9.4</version.commons-beanutils>
 
     <!-- OTEL Dependencies for Instrumentation -->
     <version.io.opentelemetry.instrumentation>1.22.0</version.io.opentelemetry.instrumentation>
     <version.com.redhat.resilience.otel>1.3.0</version.com.redhat.resilience.otel>
 
-    <version.apicurio-registry>1.3.2.Final</version.apicurio-registry>
+    <!-- TEST Dependency properties (CVEs not critical) -->
+    <version.junit>4.13.1</version.junit>
+    <version.assertj-core>3.18.1</version.assertj-core>
+    <version.mockito>3.8.0</version.mockito>
+    <version.wiremock>2.27.2</version.wiremock>
+    <version.dbunit>2.7.0</version.dbunit>
+    <version.hsqldb>2.7.1</version.hsqldb>
+    <version.rest-assured>4.3.1</version.rest-assured>
+    <version.weld-in-tests>3.1.4.Final</version.weld-in-tests>
+    <version.org.glassfish.javax.el-impl>3.0.1.b08-redhat-1</version.org.glassfish.javax.el-impl>
+    <version.shrinkwrap.descriptors>2.0.0</version.shrinkwrap.descriptors>
+    <version.shrinkwrap.resolver.bom>3.1.4</version.shrinkwrap.resolver.bom>
+    <version.arquillian-bom>1.6.0.Final</version.arquillian-bom>
+    <version.arquillian-weld>1.0.0.Final</version.arquillian-weld>
+    <version.arquillian-jacoco>1.1.0</version.arquillian-jacoco>
+    <version.arquillian-transactions>1.0.5</version.arquillian-transactions>
+    <version.arquillian-wildfly>3.0.1.Final</version.arquillian-wildfly>
+    <version.logback>1.2.3</version.logback>
 
     <datetime>${timestamp}</datetime>
     <pushChanges>true</pushChanges>
@@ -149,7 +167,6 @@
     <!-- Integration tests -->
     <app.server>jboss-eap</app.server>
     <jboss.version>7.4</jboss.version>
-    <awaitility.version>4.2.0</awaitility.version>
     <default.management.port>9999</default.management.port>
     <test.server.unpack.dir>${project.basedir}/target</test.server.unpack.dir>
     <test.server.build.dir>${test.server.unpack.dir}/${app.server}-${jboss.version}</test.server.build.dir>
@@ -196,28 +213,28 @@
       <dependency>
         <groupId>org.jboss.arquillian.extension</groupId>
         <artifactId>arquillian-transaction-bom</artifactId>
-        <version>1.0.5</version>
+        <version>${version.arquillian-transactions}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.jboss.shrinkwrap.resolver</groupId>
         <artifactId>shrinkwrap-resolver-bom</artifactId>
-        <version>3.1.4</version>
+        <version>${version.shrinkwrap.resolver.bom}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.jboss.arquillian</groupId>
         <artifactId>arquillian-bom</artifactId>
-        <version>1.6.0.Final</version>
+        <version>${version.arquillian-bom}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.redhat.bom.rh-sso</groupId>
         <artifactId>rh-sso-adapter-bom</artifactId>
-        <version>7.4.0.GA</version> <!-- If you are changing this, change also version.keycloak!-->
+        <version>${version.rh-sso-adapter}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -273,12 +290,6 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-xc</artifactId>
-        <version>${version.org.codehaus.jackson}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>${version.commons-io}</version>
@@ -309,39 +320,21 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>net.jcip</groupId>
-        <artifactId>jcip-annotations</artifactId>
-        <version>1.0.0.redhat-8</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.jcraft</groupId>
-        <artifactId>jsch</artifactId>
-        <version>${version.com.jcraft.jsch}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs</artifactId>
         <version>${version.org.jboss.resteasy}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>org.yaml</groupId>
-        <artifactId>snakeyaml</artifactId>
-        <version>1.27</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>org.wildfly.common</groupId>
         <artifactId>wildfly-common</artifactId>
-        <version>1.5.1.Final-redhat-00001</version>
+        <version>${version.org.wildfly.common}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.wildfly.client</groupId>
         <artifactId>wildfly-client-config</artifactId>
-        <version>1.0.1.Final-redhat-00001</version>
+        <version>${version.org.wildfly.client}</version>
         <scope>provided</scope>
       </dependency>
 
@@ -471,7 +464,7 @@
       <dependency>
         <groupId>org.jboss.pnc.metrics</groupId>
         <artifactId>pncmetrics</artifactId>
-        <version>1.1.3</version>
+        <version>${version.pncmetrics}</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.spec.javax.ejb</groupId>
@@ -633,11 +626,6 @@
            by the BOM and are needed by indy-embedder dependency -->
       <dependency>
         <groupId>org.keycloak</groupId>
-        <artifactId>keycloak-common</artifactId>
-        <version>${version.keycloak}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.keycloak</groupId>
         <artifactId>keycloak-undertow-adapter-spi</artifactId>
         <version>${version.keycloak}</version>
       </dependency>
@@ -682,18 +670,6 @@
             <artifactId>javax.el-api</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency> <!-- required by indy-repository-manager tests -->
-        <groupId>org.glassfish.web</groupId>
-        <artifactId>javax.el</artifactId>
-        <version>2.2.6</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jsoup</groupId>
-        <artifactId>jsoup</artifactId>
-        <version>1.8.3</version> <!-- version required by indy-repository-manager tests -->
-        <scope>test</scope>
       </dependency>
 
       <dependency>
@@ -748,69 +724,52 @@
       <dependency>
         <groupId>org.jboss.arquillian.container</groupId>
         <artifactId>arquillian-weld-se-embedded-1.1</artifactId>
-        <version>1.0.0.Final</version>
+        <version>${version.arquillian-weld}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.wildfly.arquillian</groupId>
         <artifactId>wildfly-arquillian-container-managed</artifactId>
-        <version>3.0.1.Final</version>
+        <version>${version.arquillian-wildfly}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jboss.arquillian.extension</groupId>
         <artifactId>arquillian-jacoco</artifactId>
-        <version>1.1.0</version>
+        <version>${version.arquillian-jacoco}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
         <artifactId>wiremock-jre8</artifactId>
-        <version>2.27.2</version>
+        <version>${version.wiremock}</version>
         <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-impl</artifactId>
-        <version>3.1.4.Final</version>
+        <version>${version.weld-in-tests}</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.2.3</version>
+        <version>${version.logback}</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>org.springframework.data</groupId>
         <artifactId>spring-data-jpa</artifactId>
-        <version>1.11.23.RELEASE</version>
+        <version>${version.spring}</version>
       </dependency>
 
       <dependency>
         <groupId>org.springframework.data</groupId>
         <artifactId>spring-data-commons</artifactId>
-        <version>1.13.23.RELEASE</version>
-      </dependency>
-
-      <!-- retries for completable futures -->
-      <dependency>
-        <groupId>net.jodah</groupId>
-        <artifactId>failsafe</artifactId>
-        <version>2.4.0</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.fabric8</groupId>
-        <artifactId>openshift-client</artifactId>
-        <version>5.0.1</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jbpm</groupId>
-        <artifactId>jbpm-test</artifactId>
-        <version>${version.jbpm}</version>
+        <version>${version.spring}</version>
       </dependency>
 
       <dependency>
@@ -828,12 +787,6 @@
       </dependency>
 
       <dependency>
-          <groupId>com.github.package-url</groupId>
-          <artifactId>packageurl-java</artifactId>
-          <version>${version.com.github.package-url}</version>
-      </dependency>
-
-      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${version.junit}</version>
@@ -841,23 +794,9 @@
       </dependency>
 
       <dependency>
-        <groupId>org.awaitility</groupId>
-        <artifactId>awaitility</artifactId>
-        <version>${awaitility.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
         <groupId>org.dbunit</groupId>
         <artifactId>dbunit</artifactId>
-        <version>2.7.0</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jboss.weld.se</groupId>
-        <artifactId>weld-se</artifactId>
-        <version>2.4.8.Final</version>
+        <version>${version.dbunit}</version>
         <scope>test</scope>
       </dependency>
 
@@ -882,26 +821,9 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.10.18</version> <!-- force version provided by mockito to override hibernate version -->
-      </dependency>
-      <dependency>
-        <groupId>com.googlecode.catch-exception</groupId>
-        <artifactId>catch-exception</artifactId>
-        <version>${version.catch-exception}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.30</version>
-        <scope>test</scope>
+        <version>1.10.20</version> <!-- force version provided by mockito to override hibernate version -->
       </dependency>
 
-      <dependency>
-        <groupId>org.commonjava.indy</groupId>
-        <artifactId>indy-model-core-java</artifactId>
-        <version>${indyVersion}</version>
-      </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-promote-client-java</artifactId>
@@ -924,50 +846,11 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <dependency>
-        <groupId>org.commonjava.indy</groupId>
-        <artifactId>indy-client-core-java</artifactId>
-        <version>${indyVersion}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.commonjava.indy.embed</groupId>
-        <artifactId>indy-embedder</artifactId>
-        <version>${indyVersion}</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.commonjava.indy</groupId>
-        <artifactId>indy-test-fixtures-core</artifactId>
-        <version>${indyVersion}</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>org.commonjava.indy.boot</groupId>
-            <artifactId>indy-booter-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
 
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>4.3.1</version>
+        <version>${version.rest-assured}</version>
         <scope>test</scope>
       </dependency>
 
@@ -993,28 +876,28 @@
       <dependency>
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
-        <version>2.6</version>
+        <version>${version.commons-lang}</version>
         <scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
-        <version>1.9.4</version>
+        <version>${version.commons-beanutils}</version>
         <scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.2</version>
+        <version>${version.commons-logging}</version>
         <scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
-        <version>3.2.2</version>
+        <version>${version.commons-collections}</version>
         <scope>provided</scope>
       </dependency>
 
@@ -1099,23 +982,17 @@
       </dependency>
 
       <dependency>
-        <groupId>org.json</groupId>
-        <artifactId>json</artifactId>
-        <version>${version.org.json}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.hsqldb</groupId>
         <artifactId>hsqldb</artifactId>
-        <version>2.4.1</version>
+        <version>${version.hsqldb}</version>
+        <classifier>debug</classifier>
         <scope>test</scope>
-        <classifier>jdk8debug</classifier>
       </dependency>
 
       <dependency>
         <groupId>commons-validator</groupId>
         <artifactId>commons-validator</artifactId>
-        <version>1.7</version>
+        <version>${version.commons-validator}</version>
       </dependency>
       <dependency>
         <groupId>com.squareup</groupId>
@@ -1130,12 +1007,6 @@
         <scope>provided</scope>
       </dependency>
 
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-core</artifactId>
-        <version>${version.vertx.core}</version>
-      </dependency>
-
       <!-- Second level cache required for tests -->
       <dependency>
         <groupId>org.infinispan</groupId>
@@ -1144,9 +1015,9 @@
       </dependency>
 
       <dependency>
-        <groupId>com.github.fge</groupId>
+        <groupId>com.github.java-json-tools</groupId>
         <artifactId>json-patch</artifactId>
-        <version>${version.com.github.fge}</version>
+        <version>${version.com.github.json-patch}</version>
       </dependency>
 
       <!-- Cluster eventing -->
@@ -1227,7 +1098,7 @@
                     <checkProfiles>true</checkProfiles>
                     <failOnViolation>true</failOnViolation>
                     <regexIgnored>
-                        <regexIgnored>[{]</regexIgnored>
+                        <regexIgnored>[{vertx\-core}]</regexIgnored>
                     </regexIgnored>
                   </requireManagedDeps>
                 </rules>
@@ -1697,6 +1568,22 @@
                   </goals>
               </execution>
           </executions>
+      </plugin>
+      <!-- Reports CVEs in each module in target/dependency-check.html-->
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>8.0.1</version>
+        <configuration>
+          <name>cve-list</name>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>aggregate</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/remote-build-coordinator/pom.xml
+++ b/remote-build-coordinator/pom.xml
@@ -209,11 +209,6 @@
       <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <!-- Test coverage -->
     <dependency>

--- a/remote-build-coordinator/src/test/java/org/jboss/pnc/remotecoordinator/test/MockBuildScheduler.java
+++ b/remote-build-coordinator/src/test/java/org/jboss/pnc/remotecoordinator/test/MockBuildScheduler.java
@@ -80,7 +80,6 @@ public class MockBuildScheduler implements RexBuildScheduler {
         }
     }
 
-    @NotNull
     private static BuildResult mockBuildResult(BuildCoordinationStatus status) {
         BuildResult result;
         switch (status) {

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -43,9 +43,11 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
     </dependency>
+    <!-- Unmanaged depencency (to avoid having a dependency on vertx in parent)-->
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
+      <version>${version.vertx-core}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -79,7 +81,7 @@
       <classifier>patch-builders</classifier>
     </dependency>
     <dependency>
-      <groupId>com.github.fge</groupId>
+      <groupId>com.github.java-json-tools</groupId>
       <artifactId>json-patch</artifactId>
       <exclusions>
         <exclusion>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -116,7 +116,11 @@
             <artifactId>swagger-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <!-- OTEL dependencies -->
         <dependency>
             <groupId>com.redhat.resilience.otel</groupId>


### PR DESCRIPTION
### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/pnc/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?

Summary (I may have missed some dependency changes):

changed: 
rh-sso-adapter: 7.4.0.GA -> 7.4.8.GA
keycloak: 9.0.3.redhat-00002 -> 9.0.14.redhat-00001
byte-buddy: 1.10.18 -> 1.10.20
hsqldb: 2.4.1-jdk8 -> 2.7.1-jdk11
spring-data-jpa 1.11.23.RELEASE -> 2.3.9.RELEASE
spring-data-commons 1.13.23.RELEASE -> 2.3.9.RELEASE
fluent-hc: 4.5.4-> 4.5.14
vertx: 3.8.5 -> 3.9.14
swagger2: 2.1.4 -> 2.2.8

gav-changed:
com.github.fge:json-patch:1.9 -> com.github.java-json-tools:1.13

removed:
jbpm-test: 6.2.0
jackson-xc
jcip-annotations: 1.0.0.redhat-8
jsch:
jsoup:1.8.3
packageurl-java:
awaitility: 4.2.0
snakeyaml: 1.27
org.glassfish.web:javax.el: 2.2.6
net.joday:failsafe: 2.4.0
io.fabric8:openshift-client: 5.0.1
indy-model-core-java
indy-embedder
indy-client-core-java
indy-text-fixtures-core
slf4j-log4j12: 1.7.30
org.json:json

- extracted versions into properties
- organized properties to seperate test-only dependencies
- added a CVE dependency check
- general cleanup
- spring API adjustments