### PR TITLE
[NCLSUP-864] Optimize withIdentifierAndSha256 artifact search

### DIFF
--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/ArtifactRepositoryImpl.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/ArtifactRepositoryImpl.java
@@ -35,24 +35,6 @@ public class ArtifactRepositoryImpl extends AbstractRepository<Artifact, Integer
     }
 
     @Override
-    public Set<Artifact> withIdentifierAndSha256s(Set<Artifact.IdentifierSha256> identifierSha256s) {
-        Set<String> sha256s = identifierSha256s.stream()
-                .map(Artifact.IdentifierSha256::getSha256)
-                .collect(Collectors.toSet());
-
-        List<Artifact> artifacts = queryWithPredicates(ArtifactPredicates.withSha256In(sha256s));
-
-        // make sure the identifier matches too
-        Set<Artifact> artifactsMatchingIdentifier = artifacts.stream()
-                .filter(
-                        a -> identifierSha256s
-                                .contains(new Artifact.IdentifierSha256(a.getIdentifier(), a.getSha256())))
-                .collect(Collectors.toSet());
-
-        return artifactsMatchingIdentifier;
-    }
-
-    @Override
     public Artifact withPurl(String purl) {
 
         List<Artifact> artifacts = queryWithPredicates(ArtifactPredicates.withPurl(purl));

--- a/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
+++ b/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
@@ -30,6 +30,7 @@ import org.jboss.pnc.enums.SystemImageType;
 import org.jboss.pnc.mock.repository.SequenceHandlerRepositoryMock;
 import org.jboss.pnc.model.*;
 import org.jboss.pnc.spi.datastore.Datastore;
+import org.jboss.pnc.spi.datastore.predicates.ArtifactPredicates;
 import org.jboss.pnc.spi.datastore.predicates.RepositoryConfigurationPredicates;
 import org.jboss.pnc.spi.datastore.repositories.*;
 import org.jboss.pnc.spi.datastore.repositories.api.Predicate;
@@ -376,7 +377,8 @@ public class DatastoreTest {
                 new Artifact.IdentifierSha256(
                         importedDuplicateArtifact.getIdentifier(),
                         importedDuplicateArtifact.getSha256()));
-        Set<Artifact> artifactsFromDb = artifactRepository.withIdentifierAndSha256s(identifiersAndSha);
+        List<Artifact> artifactsFromDb = artifactRepository
+                .queryWithPredicates(ArtifactPredicates.withIdentifierAndSha256(identifiersAndSha));
         Assert.assertEquals(1, artifactsFromDb.size());
         Assert.assertEquals(
                 buildsUntestedRepoPath,

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/ArtifactRepositoryMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/ArtifactRepositoryMock.java
@@ -20,17 +20,10 @@ package org.jboss.pnc.mock.repository;
 import org.jboss.pnc.model.Artifact;
 import org.jboss.pnc.spi.datastore.repositories.ArtifactRepository;
 
-import java.util.Set;
-
 /**
  * Author: Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com Date: 9/22/16 Time: 12:05 PM
  */
 public class ArtifactRepositoryMock extends IntIdRepositoryMock<Artifact> implements ArtifactRepository {
-
-    @Override
-    public Set<Artifact> withIdentifierAndSha256s(Set<Artifact.IdentifierSha256> identifierSha256s) {
-        throw new UnsupportedOperationException();
-    }
 
     @Override
     public Artifact withPurl(String purl) {

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/ArtifactPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/ArtifactPredicates.java
@@ -31,6 +31,8 @@ import org.jboss.pnc.model.ProductMilestone_;
 import org.jboss.pnc.spi.datastore.repositories.api.Predicate;
 
 import javax.persistence.criteria.Join;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -139,6 +141,19 @@ public class ArtifactPredicates {
     public static Predicate<Artifact> withSha256(Optional<String> sha256) {
         return ((root, query, cb) -> sha256.isPresent() ? cb.equal(root.get(Artifact_.sha256), sha256.get())
                 : cb.and());
+    }
+
+    public static Predicate<Artifact> withIdentifierAndSha256(Set<Artifact.IdentifierSha256> identifierSha256Set) {
+        return ((root, query, cb) -> {
+            List<javax.persistence.criteria.Predicate> predicates = new ArrayList<>();
+            for (Artifact.IdentifierSha256 identifierSha256 : identifierSha256Set) {
+                predicates.add(
+                        cb.and(
+                                cb.equal(root.get(Artifact_.identifier), identifierSha256.getIdentifier()),
+                                cb.equal(root.get(Artifact_.sha256), identifierSha256.getSha256())));
+            }
+            return cb.or(predicates.toArray(new javax.persistence.criteria.Predicate[0]));
+        });
     }
 
     public static Predicate<Artifact> withMd5(Optional<String> md5) {

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/ArtifactRepository.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/ArtifactRepository.java
@@ -27,7 +27,5 @@ import java.util.Set;
  */
 public interface ArtifactRepository extends Repository<Artifact, Integer> {
 
-    Set<Artifact> withIdentifierAndSha256s(Set<Artifact.IdentifierSha256> identifierSha256s);
-
     Artifact withPurl(String purl);
 }


### PR DESCRIPTION
Current implementation in one case   took over 30 s for 387 checksums and returned 217548 artifacts. This implementation returns only 387 artifacts and seems to be faster (can't tell exaclty how, because the DB was warmed up, butt it's still at least 1 second).