### PR TITLE
Fix MdcToHeadersFilter issues with OTEL headers

### DIFF
--- a/rest-api/src/main/java/org/jboss/pnc/client/MdcToHeadersFilter.java
+++ b/rest-api/src/main/java/org/jboss/pnc/client/MdcToHeadersFilter.java
@@ -17,7 +17,6 @@
  */
 package org.jboss.pnc.client;
 
-import org.jboss.pnc.common.log.MDCUtils;
 import org.jboss.pnc.common.util.StringUtils;
 import org.slf4j.MDC;
 
@@ -52,7 +51,5 @@ public class MdcToHeadersFilter implements ClientRequestFilter {
                 headers.add(mdcKeyHeaderKey.getValue(), mdcValue);
             }
         }
-        Map<String, String> otelHeaders = MDCUtils.getOtelHeadersFromMDC();
-        otelHeaders.forEach(headers::add);
     }
 }


### PR DESCRIPTION
Fix UnsupportedOperationException thrown when the OTEL headers are re-added to the ClientRequestContext
