### PR TITLE
[NCL-7933] Use FQN for swagger class names

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/JaxRsActivatorNew.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/JaxRsActivatorNew.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.rest;
 
+import io.swagger.v3.core.jackson.TypeNameResolver;
 import io.swagger.v3.jaxrs2.integration.JaxrsOpenApiContextBuilder;
 import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
 import io.swagger.v3.oas.integration.OpenApiConfigurationException;
@@ -137,6 +138,7 @@ public class JaxRsActivatorNew extends Application {
     }
 
     private void configureSwagger() {
+        TypeNameResolver.std.setUseFqn(true);
         OpenAPI oas = new OpenAPI();
         Info info = new Info().title("PNC")
                 .description("PNC build system")


### PR DESCRIPTION
Swagger can't deal with duplicate class names (like Build in 3 different classes), so switiching to FQN should fix the openapi

### Checklist:

* [ ] Have you added unit tests for your change?
