### PR TITLE
Schema update for BuildConfigSetRecord

### DIFF
--- a/model/src/main/resources/db-update/20050-from-2.4.0-to-2.5.0.sql
+++ b/model/src/main/resources/db-update/20050-from-2.4.0-to-2.5.0.sql
@@ -16,10 +16,6 @@
 -- limitations under the License.
 --
 
-BEGIN;
-    ALTER TABLE buildconfigsetrecord ALTER COLUMN id SET DATA TYPE bigint;
-COMMIT;
-
 -- ****************************************************************************
 -- Run the script in NCL-7238 to fix duplicate artifact bugs
 -- ****************************************************************************

--- a/model/src/main/resources/db-update/20060-from-2.5.0-to-2.6.0.sql
+++ b/model/src/main/resources/db-update/20060-from-2.5.0-to-2.6.0.sql
@@ -16,8 +16,9 @@
 -- limitations under the License.
 --
 
-
 BEGIN;
+    ALTER TABLE buildconfigsetrecord ALTER COLUMN id SET DATA TYPE bigint;
+
     CREATE TABLE build_configuration_align_strats
     (
         buildconfiguration_id integer                NOT NULL,


### PR DESCRIPTION
The change from int to long in the BuildConfigSetRecord wasn't backproted in 2.5.x and should therefore only be run for the 2.6.0 migration.

### Checklist:

* [ ] Have you added unit tests for your change?
