### PR TITLE
[NCLSUP-912] Partition artifact query to avoid stackoverflow

### DIFF
--- a/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
@@ -47,6 +47,7 @@ import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.inject.Inject;
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -223,7 +224,7 @@ public class DefaultDatastore implements Datastore {
             // [NCLSUP-912] partition the constraints in maximum size to avoid a stackoverflow in Hibernate
             // We use the Guava Lists.partition, which requires a List. Hence we have to convert it also
             List<List<Artifact.IdentifierSha256>> partitionedList = Lists
-                    .partition(new ArrayList(artifactConstraints)), QUERY_ARTIFACT_PARITION_SIZE);
+                    .partition(new ArrayList<>(artifactConstraints), QUERY_ARTIFACT_PARITION_SIZE);
             for (List<Artifact.IdentifierSha256> partition : partitionedList) {
                 List<Artifact> artifactsInDb = artifactRepository
                         .queryWithPredicates(ArtifactPredicates.withIdentifierAndSha256(partition));

--- a/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
@@ -223,7 +223,7 @@ public class DefaultDatastore implements Datastore {
             // [NCLSUP-912] partition the constraints in maximum size to avoid a stackoverflow in Hibernate
             // We use the Guava Lists.partition, which requires a List. Hence we have to convert it also
             List<List<Artifact.IdentifierSha256>> partitionedList = Lists
-                    .partition(artifactConstraints.stream().collect(Collectors.toList()), QUERY_ARTIFACT_PARITION_SIZE);
+                    .partition(new ArrayList(artifactConstraints)), QUERY_ARTIFACT_PARITION_SIZE);
             for (List<Artifact.IdentifierSha256> partition : partitionedList) {
                 List<Artifact> artifactsInDb = artifactRepository
                         .queryWithPredicates(ArtifactPredicates.withIdentifierAndSha256(partition));

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/ArtifactPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/ArtifactPredicates.java
@@ -143,7 +143,7 @@ public class ArtifactPredicates {
                 : cb.and());
     }
 
-    public static Predicate<Artifact> withIdentifierAndSha256(Set<Artifact.IdentifierSha256> identifierSha256Set) {
+    public static Predicate<Artifact> withIdentifierAndSha256(Iterable<Artifact.IdentifierSha256> identifierSha256Set) {
         return ((root, query, cb) -> {
             List<javax.persistence.criteria.Predicate> predicates = new ArrayList<>();
             for (Artifact.IdentifierSha256 identifierSha256 : identifierSha256Set) {


### PR DESCRIPTION
We noticed a StackOverflow error for builds which have a huge list of dependencies (> 7800).

We generate our query to search for artifacts by generating a statement that is of nature:
```
SELECT *
FROM artifacts
WHERE (identifier = <identifier1> AND sha256 = <sha2561>) OR
      (identifier = <identifier2> AND sha256 = <sha2562>) OR
         ...
      (identifier = <identifierN> AND sha256 = <sha256N>);
```
Hibernate struggles to generate that query for more than 7800 artifacts (I don't really know the real number) since it is using recursion to generate that query and we eventually hit the StackOverflow error.

We try to workaround the issue by partitioning the artifacts we query at once to QUERY_ARTIFACT_PARITION_SIZE (set to 1000, since we know it'll succeed with those sizes). This avoids the StackOverflow error at the expense of having to do more queries.

### Checklist:

* [ ] Have you added unit tests for your change?
