### PR TITLE
[PSX-303] Add NoHtmlValidator for Hibernate Validator

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -109,6 +109,10 @@
       <groupId>io.opentelemetry.instrumentation</groupId>
       <artifactId>opentelemetry-instrumentation-annotations</artifactId>
     </dependency>
+    <dependency>
+        <groupId>org.jsoup</groupId>
+        <artifactId>jsoup</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/common/src/main/java/org/jboss/pnc/common/validator/NoHtml.java
+++ b/common/src/main/java/org/jboss/pnc/common/validator/NoHtml.java
@@ -1,0 +1,48 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.common.validator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation to add to a method or a field to validate that the String doesn't contain HTML tags. This is useful
+ * to prevent XSS attacks.
+ *
+ * It should work out of the box with Hibernate Validator
+ *
+ * Copied from: https://stackoverflow.com/a/68888601/2907906
+ */
+@Documented
+@Constraint(validatedBy = NoHtmlValidator.class)
+@Target({ METHOD, FIELD })
+@Retention(RUNTIME)
+public @interface NoHtml {
+    String message() default "Unsafe html content";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/common/src/main/java/org/jboss/pnc/common/validator/NoHtmlValidator.java
+++ b/common/src/main/java/org/jboss/pnc/common/validator/NoHtmlValidator.java
@@ -1,0 +1,39 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.common.validator;
+
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Implementation for the annotation NoHtml to verify that the String doesn't contain HTML tags. This is useful
+ * to prevent XSS attacks.
+ *
+ * It should work out of the box with Hibernate Validator
+ *
+ * Copied from: https://stackoverflow.com/a/68888601/2907906
+ */
+public class NoHtmlValidator implements ConstraintValidator<NoHtml, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext ctx) {
+        return value == null || Jsoup.isValid(value, Safelist.none());
+    }
+}

--- a/common/src/test/java/org/jboss/pnc/common/validator/NoHtmlValidatorTest.java
+++ b/common/src/test/java/org/jboss/pnc/common/validator/NoHtmlValidatorTest.java
@@ -1,0 +1,40 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.common.validator;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NoHtmlValidatorTest {
+    @Test
+    public void testValidator() {
+        NoHtmlValidator validator = new NoHtmlValidator();
+        assertThat(validator.isValid("hello", null)).isTrue();
+        assertThat(validator.isValid("<alert>hello</alert>", null)).isFalse();
+        assertThat(validator.isValid("<script>hello</script>", null)).isFalse();
+        assertThat(validator.isValid("<?php hello>", null)).isFalse();
+        assertThat(validator.isValid("hello heya <div>asdf</div>", null)).isFalse();
+        assertThat(validator.isValid("hello heya <a href=\"heloo\" />", null)).isFalse();
+
+        // null has no html!
+        assertThat(validator.isValid(null, null)).isTrue();
+        assertThat(validator.isValid("", null)).isTrue();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@
     <version.arquillian-wildfly>3.0.1.Final</version.arquillian-wildfly>
     <version.logback>1.2.3</version.logback>
     <version.git-commit-id-plugin>4.9.10</version.git-commit-id-plugin>
+    <version.org.jsoup.jsoup>1.16.1</version.org.jsoup.jsoup>
     <version.maven-replacer-plugin>1.4.1</version.maven-replacer-plugin>
 
     <datetime>${timestamp}</datetime>
@@ -1109,7 +1110,11 @@
         <artifactId>infinispan-core</artifactId>
         <version>${version.org.infinispan.infinispan-core}</version>
       </dependency>
-
+      <dependency>
+          <groupId>org.jsoup</groupId>
+          <artifactId>jsoup</artifactId>
+          <version>${version.org.jsoup.jsoup}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This is used to check for HTML tags in DTOs and prevent the user from injecting html tags that could be used for XSS attacks

### Checklist:

* [ ] Have you added unit tests for your change?
