### PR TITLE
[PSX-303] Add @NoHtml validations on string DTOs

### DIFF
--- a/dto/pom.xml
+++ b/dto/pom.xml
@@ -47,6 +47,10 @@
             <groupId>org.jboss.pnc</groupId>
             <artifactId>pnc-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.pnc</groupId>
+            <artifactId>pnc-common</artifactId>
+        </dependency>
         <!-- REST dependencies -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -98,6 +102,14 @@
             <groupId>org.jboss.pnc</groupId>
             <artifactId>test-common</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
         </dependency>
     </dependencies>
 

--- a/dto/src/main/java/org/jboss/pnc/dto/AlignmentStrategy.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/AlignmentStrategy.java
@@ -22,6 +22,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.jackson.Jacksonized;
+import org.jboss.pnc.common.validator.NoHtml;
 
 import java.util.List;
 
@@ -33,6 +34,10 @@ import java.util.List;
 public class AlignmentStrategy {
     private final String dependencyOverride;
     private final List<String> ranks;
+
+    @NoHtml
     private final String denyList;
+
+    @NoHtml
     private final String allowList;
 }

--- a/dto/src/main/java/org/jboss/pnc/dto/ArtifactRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ArtifactRef.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.dto;
 
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import org.jboss.pnc.enums.ArtifactQuality;
@@ -52,6 +53,7 @@ public class ArtifactRef implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**
@@ -60,12 +62,14 @@ public class ArtifactRef implements DTOEntity {
      * type.
      */
     @NotNull(groups = { WhenCreatingNew.class, WhenUpdating.class })
+    @NoHtml
     protected final String identifier;
 
     /**
      * A purl is a URL string with format scheme:type/namespace/name@version?qualifiers#subpath useful to reliably
      * reference the same software package using a simple and expressive syntax and conventions based on familiar URLs
      */
+    @NoHtml
     protected final String purl;
 
     /**
@@ -85,26 +89,31 @@ public class ArtifactRef implements DTOEntity {
     /**
      * MD5 checksum of the artifact.
      */
+    @NoHtml
     protected final String md5;
 
     /**
      * SHA-1 checksum of the artifact.
      */
+    @NoHtml
     protected final String sha1;
 
     /**
      * SHA-256 checksum of the artifact.
      */
+    @NoHtml
     protected final String sha256;
 
     /**
      * Filename of the artifact.
      */
+    @NoHtml
     protected final String filename;
 
     /**
      * Path in the repository where the artifact file is available.
      */
+    @NoHtml
     protected final String deployPath;
 
     /**
@@ -116,6 +125,7 @@ public class ArtifactRef implements DTOEntity {
      * The location from which this artifact was originally downloaded for import. When this artifact was built by PNC
      * the value is null.
      */
+    @NoHtml
     protected final String originUrl;
 
     /**
@@ -126,11 +136,13 @@ public class ArtifactRef implements DTOEntity {
     /**
      * Internal url to the artifact using internal (cloud) network domain.
      */
+    @NoHtml
     protected final String deployUrl;
 
     /**
      * Public url to the artifact using public network domain.
      */
+    @NoHtml
     protected final String publicUrl;
     /**
      * The time when the artifact was created.

--- a/dto/src/main/java/org/jboss/pnc/dto/ArtifactRevisionRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ArtifactRevisionRef.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
 
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import org.jboss.pnc.enums.ArtifactQuality;
@@ -50,6 +51,7 @@ public class ArtifactRevisionRef implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**

--- a/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationRef.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
 
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import org.jboss.pnc.enums.BuildType;
@@ -52,6 +53,7 @@ public class BuildConfigurationRef implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**
@@ -68,6 +70,7 @@ public class BuildConfigurationRef implements DTOEntity {
      * Build config description.
      */
     @PatchSupport({ REPLACE })
+    @NoHtml
     protected final String description;
 
     /**
@@ -80,6 +83,7 @@ public class BuildConfigurationRef implements DTOEntity {
      * SCM revision to build.
      */
     @PatchSupport({ REPLACE })
+    @NoHtml
     protected final String scmRevision;
 
     /**

--- a/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationRevisionRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationRevisionRef.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import org.jboss.pnc.enums.BuildType;
@@ -49,6 +50,7 @@ public class BuildConfigurationRevisionRef implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**
@@ -59,6 +61,7 @@ public class BuildConfigurationRevisionRef implements DTOEntity {
     /**
      * Build config name.
      */
+    @NoHtml
     protected final String name;
 
     /**
@@ -69,6 +72,7 @@ public class BuildConfigurationRevisionRef implements DTOEntity {
     /**
      * SCM revision to build.
      */
+    @NoHtml
     protected final String scmRevision;
 
     /**

--- a/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationWithLatestBuild.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/BuildConfigurationWithLatestBuild.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Data;
 import lombok.ToString;
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.enums.BuildType;
 
 import java.time.Instant;
@@ -45,6 +46,7 @@ public class BuildConfigurationWithLatestBuild extends BuildConfiguration {
     /**
      * Username of the user who ran the last build.
      */
+    @NoHtml
     private final String latestBuildUsername;
 
     @lombok.Builder(builderClassName = "Builder", builderMethodName = "builderWithLatestBuild")

--- a/dto/src/main/java/org/jboss/pnc/dto/BuildPushResultRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/BuildPushResultRef.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import org.jboss.pnc.enums.BuildPushStatus;
@@ -45,12 +46,14 @@ public class BuildPushResultRef implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**
      * ID of the build pushed.
      */
     @NotNull
+    @NoHtml
     protected final String buildId;
 
     /**
@@ -67,11 +70,13 @@ public class BuildPushResultRef implements DTOEntity {
     /**
      * Link to Brew.
      */
+    @NoHtml
     protected final String brewBuildUrl;
 
     /**
      * Identificator of log context. Logs related to this operation will have this log context id set.
      */
+    @NoHtml
     protected final String logContext;
 
     /**

--- a/dto/src/main/java/org/jboss/pnc/dto/BuildRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/BuildRef.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
 import org.jboss.pnc.api.enums.AlignmentPreference;
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import org.jboss.pnc.enums.BuildProgress;
@@ -48,6 +49,7 @@ public class BuildRef implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**
@@ -78,6 +80,7 @@ public class BuildRef implements DTOEntity {
     /**
      * The identifier to use when accessing repository or other content stored via external services.
      */
+    @NoHtml
     protected final String buildContentId;
 
     /**
@@ -93,21 +96,25 @@ public class BuildRef implements DTOEntity {
     /**
      * Url to the SCM repository with the sources being built.
      */
+    @NoHtml
     protected final String scmUrl;
 
     /**
      * The revision number in the SCM repository of the sources being built.
      */
+    @NoHtml
     protected final String scmRevision;
 
     /**
      * The tag in the SCM repository that was built.
      */
+    @NoHtml
     protected final String scmTag;
 
     /**
      * Checksum of build logs. Used to verify the integrity of the logs in the remote storage eg. Elasticsearch.
      */
+    @NoHtml
     protected final String buildOutputChecksum;
 
     /**

--- a/dto/src/main/java/org/jboss/pnc/dto/Environment.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/Environment.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import org.jboss.pnc.enums.SystemImageType;
@@ -49,27 +50,32 @@ public class Environment implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     private final String id;
 
     /**
      * Environment name.
      */
+    @NoHtml
     private final String name;
 
     /**
      * Environment description.
      */
+    @NoHtml
     private final String description;
 
     /**
      * The URL of the repository which contains the build system image.
      */
+    @NoHtml
     private final String systemImageRepositoryUrl;
 
     /**
      * A unique identifier representing the system image, for example a Docker container ID or a checksum of a VM image.
      */
     @NotNull(groups = { WhenCreatingNew.class, WhenUpdating.class })
+    @NoHtml
     private final String systemImageId;
 
     /**

--- a/dto/src/main/java/org/jboss/pnc/dto/GroupBuildRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/GroupBuildRef.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
 import org.jboss.pnc.api.enums.AlignmentPreference;
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import org.jboss.pnc.enums.BuildStatus;
@@ -47,6 +48,7 @@ public class GroupBuildRef implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**

--- a/dto/src/main/java/org/jboss/pnc/dto/GroupConfigurationRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/GroupConfigurationRef.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
 
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import org.jboss.pnc.processor.annotation.PatchSupport;
@@ -50,6 +51,7 @@ public class GroupConfigurationRef implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**
@@ -57,6 +59,7 @@ public class GroupConfigurationRef implements DTOEntity {
      */
     @PatchSupport({ REPLACE })
     @NotBlank(groups = { WhenCreatingNew.class, WhenUpdating.class })
+    @NoHtml
     protected final String name;
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/dto/src/main/java/org/jboss/pnc/dto/OperationRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/OperationRef.java
@@ -31,6 +31,7 @@ import org.jboss.pnc.api.deliverablesanalyzer.dto.MavenArtifact;
 import org.jboss.pnc.api.deliverablesanalyzer.dto.NPMArtifact;
 import org.jboss.pnc.api.enums.OperationResult;
 import org.jboss.pnc.api.enums.ProgressStatus;
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 
@@ -51,6 +52,7 @@ public class OperationRef implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**

--- a/dto/src/main/java/org/jboss/pnc/dto/ProductMilestoneCloseResultRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ProductMilestoneCloseResultRef.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import org.jboss.pnc.enums.MilestoneCloseStatus;
@@ -44,6 +45,7 @@ public class ProductMilestoneCloseResultRef implements DTOEntity {
      * ID of the close attempt.
      */
     @NotNull(groups = { WhenCreatingNew.class, WhenUpdating.class })
+    @NoHtml
     protected final String id;
 
     /**

--- a/dto/src/main/java/org/jboss/pnc/dto/ProductMilestoneRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ProductMilestoneRef.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
 
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.constants.Patterns;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
@@ -55,6 +56,7 @@ public class ProductMilestoneRef implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**

--- a/dto/src/main/java/org/jboss/pnc/dto/ProductRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ProductRef.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
 
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.constants.Patterns;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
@@ -52,6 +53,7 @@ public class ProductRef implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**
@@ -59,12 +61,14 @@ public class ProductRef implements DTOEntity {
      */
     @PatchSupport({ REPLACE })
     @NotBlank(groups = { WhenCreatingNew.class, WhenUpdating.class })
+    @NoHtml
     protected final String name;
 
     /**
      * Product description.
      */
     @PatchSupport({ REPLACE })
+    @NoHtml
     protected final String description;
 
     /**
@@ -75,18 +79,21 @@ public class ProductRef implements DTOEntity {
     @PatchSupport({ REPLACE })
     @NotNull(groups = { WhenCreatingNew.class, WhenUpdating.class })
     @Pattern(regexp = Patterns.PRODUCT_ABBREVIATION, groups = { WhenCreatingNew.class, WhenUpdating.class })
+    @NoHtml
     protected final String abbreviation;
 
     /**
      * Comma separated list of product managers.
      */
     @PatchSupport({ REPLACE })
+    @NoHtml
     protected final String productManagers;
 
     /**
      * The code given to the product by Product Pages.
      */
     @PatchSupport({ REPLACE })
+    @NoHtml
     protected final String productPagesCode;
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/dto/src/main/java/org/jboss/pnc/dto/ProductReleaseRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ProductReleaseRef.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
 
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import org.jboss.pnc.enums.SupportLevel;
@@ -52,12 +53,14 @@ public class ProductReleaseRef implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**
      * Release version.
      */
     @PatchSupport({ REPLACE })
+    @NoHtml
     protected final String version;
 
     /**
@@ -79,12 +82,14 @@ public class ProductReleaseRef implements DTOEntity {
      * products and by the CVE Engine to map errata to containers when grading.
      */
     @PatchSupport({ REPLACE })
+    @NoHtml
     protected final String commonPlatformEnumeration;
 
     /**
      * Code given by the Product Pages to the release.
      */
     @PatchSupport({ REPLACE })
+    @NoHtml
     protected final String productPagesCode;
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/dto/src/main/java/org/jboss/pnc/dto/ProductVersionRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ProductVersionRef.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
 
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.constants.Patterns;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
@@ -54,6 +55,7 @@ public class ProductVersionRef implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**

--- a/dto/src/main/java/org/jboss/pnc/dto/ProjectRef.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/ProjectRef.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
 
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import org.jboss.pnc.processor.annotation.PatchSupport;
@@ -50,6 +51,7 @@ public class ProjectRef implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**
@@ -57,36 +59,42 @@ public class ProjectRef implements DTOEntity {
      */
     @PatchSupport({ REPLACE })
     @NotBlank(groups = { WhenCreatingNew.class, WhenUpdating.class })
+    @NoHtml
     protected final String name;
 
     /**
      * Project description.
      */
     @PatchSupport({ REPLACE })
+    @NoHtml
     protected final String description;
 
     /**
      * URL of the issue tracker for the project.
      */
     @PatchSupport({ REPLACE })
+    @NoHtml
     protected final String issueTrackerUrl;
 
     /**
      * URL of the project.
      */
     @PatchSupport({ REPLACE })
+    @NoHtml
     protected final String projectUrl;
 
     /**
      * The engineering team in charge of the project.
      */
     @PatchSupport({ REPLACE })
+    @NoHtml
     protected final String engineeringTeam;
 
     /**
      * The technical leader of the project.
      */
     @PatchSupport({ REPLACE })
+    @NoHtml
     protected final String technicalLeader;
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/dto/src/main/java/org/jboss/pnc/dto/SCMRepository.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/SCMRepository.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.constraints.SCMUrl;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
@@ -50,6 +51,7 @@ public class SCMRepository implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**
@@ -58,6 +60,7 @@ public class SCMRepository implements DTOEntity {
      */
     @NotBlank(groups = { WhenUpdating.class, WhenCreatingNew.class })
     @SCMUrl(groups = { WhenUpdating.class, WhenCreatingNew.class })
+    @NoHtml
     protected final String internalUrl;
 
     /**
@@ -65,6 +68,7 @@ public class SCMRepository implements DTOEntity {
      */
     @PatchSupport({ REPLACE })
     @SCMUrl(groups = { WhenUpdating.class, WhenCreatingNew.class })
+    @NoHtml
     protected final String externalUrl;
 
     /**

--- a/dto/src/main/java/org/jboss/pnc/dto/TargetRepository.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/TargetRepository.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
 
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import org.jboss.pnc.enums.RepositoryType;
@@ -45,6 +46,7 @@ public class TargetRepository implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**
@@ -57,6 +59,7 @@ public class TargetRepository implements DTOEntity {
      * Identifier to link repository configurations (eg. hostname)
      */
     @NotNull(groups = { WhenUpdating.class, WhenCreatingNew.class })
+    @NoHtml
     protected final String identifier;
 
     /**
@@ -71,6 +74,7 @@ public class TargetRepository implements DTOEntity {
      * for https://repo1.maven.org/maven2/ or "" (empty string) when the repository content starts at root
      */
     @NotNull(groups = { WhenUpdating.class, WhenCreatingNew.class })
+    @NoHtml
     protected final String repositoryPath;
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/dto/src/main/java/org/jboss/pnc/dto/User.java
+++ b/dto/src/main/java/org/jboss/pnc/dto/User.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
+import org.jboss.pnc.common.validator.NoHtml;
 import org.jboss.pnc.dto.validation.groups.WhenCreatingNew;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 
@@ -44,11 +45,13 @@ public class User implements DTOEntity {
      */
     @NotNull(groups = WhenUpdating.class)
     @Null(groups = WhenCreatingNew.class)
+    @NoHtml
     protected final String id;
 
     /**
      * Username of the user.
      */
+    @NoHtml
     protected final String username;
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/dto/src/test/java/org/jboss/pnc/dto/UserTest.java
+++ b/dto/src/test/java/org/jboss/pnc/dto/UserTest.java
@@ -1,0 +1,64 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.dto;
+
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class UserTest {
+
+    private static Validator validator;
+
+    @BeforeClass
+    public static void setUp() {
+        validator = Validation.byDefaultProvider()
+                .configure()
+                .messageInterpolator(new ParameterMessageInterpolator())
+                .buildValidatorFactory()
+                .getValidator();
+    }
+
+    @Test
+    public void testUserNoHtml() {
+        User user = new User("<a href=\"http://topsecret.com\" />", "Jack Ryan");
+        Set<ConstraintViolation<User>> constraintViolations = validator.validate(user);
+        assertEquals(1, constraintViolations.size());
+
+        user = new User("1234", "<blink>hello</blink>");
+        constraintViolations = validator.validate(user);
+        assertEquals(1, constraintViolations.size());
+
+        user = new User("<script>hi</script>", "<blink>hello</blink>");
+        constraintViolations = validator.validate(user);
+        assertEquals(2, constraintViolations.size());
+
+        // should not flag any issues
+        user = new User("1234", "Feist");
+        constraintViolations = validator.validate(user);
+        assertEquals(0, constraintViolations.size());
+
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@
     <version.logback>1.2.3</version.logback>
     <version.git-commit-id-plugin>4.9.10</version.git-commit-id-plugin>
     <version.maven-replacer-plugin>1.4.1</version.maven-replacer-plugin>
+    <version.org.jsoup.jsoup>1.16.1</version.org.jsoup.jsoup>
 
     <datetime>${timestamp}</datetime>
     <pushChanges>true</pushChanges>
@@ -1109,7 +1110,16 @@
         <artifactId>infinispan-core</artifactId>
         <version>${version.org.infinispan.infinispan-core}</version>
       </dependency>
-
+      <dependency>
+        <groupId>org.hibernate.validator</groupId>
+        <artifactId>hibernate-validator</artifactId>
+        <version>${version.org.hibernate.validator}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.jsoup</groupId>
+          <artifactId>jsoup</artifactId>
+          <version>${version.org.jsoup.jsoup}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This is done to prevent any XSS attacks in the PNC-UI, even though the PNC-UI (Angular and React based) already have safety mechanisms to prevent it.

For some scenarios where HTML tags might make sense in the string (like for the build script), there are no `@NoHtml` annotation.

### Checklist:

* [ ] Have you added unit tests for your change?
