### PR TITLE
Fix: empty IN in SQL throws syntax error

### DIFF
--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/ArtifactPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/ArtifactPredicates.java
@@ -131,6 +131,9 @@ public class ArtifactPredicates {
     }
 
     public static Predicate<Artifact> withIds(Set<Integer> ids) {
+        if (ids.isEmpty()) {
+            return (root, query, cb) -> cb.or();
+        }
         return (root, query, cb) -> root.get(Artifact_.id).in(ids);
     }
 


### PR DESCRIPTION
When IN is empty, we get syntax error at or near ")"

### Checklist:

* [ ] Have you added unit tests for your change?
