### PR TITLE
RenameSuggestion

### DIFF
--- a/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
+++ b/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
@@ -269,7 +269,7 @@ public class DatabaseDataInitializer {
     }
 
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
-    public void initiliazeProjectProductData() {
+    public void initializeProjectProductData() {
 
         BuildEnvironment environment1Unsaved = BuildEnvironment.Builder.newBuilder()
                 .name("Demo Environment 1")
@@ -619,7 +619,7 @@ public class DatabaseDataInitializer {
      * set.
      */
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
-    public void initiliazeBuildRecordDemoData() {
+    public void initializeBuildRecordDemoData() {
 
         TargetRepository targetRepository = TargetRepository.newBuilder()
                 .repositoryType(RepositoryType.MAVEN)

--- a/demo-data/src/main/java/org/jboss/pnc/demo/data/DemoDataInitializer.java
+++ b/demo-data/src/main/java/org/jboss/pnc/demo/data/DemoDataInitializer.java
@@ -69,8 +69,8 @@ public class DemoDataInitializer {
             logger.info("There are >0 ({}) projects in DB. Skipping initialization." + numberOfProjectInDB);
         } else {
             logger.info("Initializing DEMO data");
-            dbDataInitializer.initiliazeProjectProductData();
-            dbDataInitializer.initiliazeBuildRecordDemoData();
+            dbDataInitializer.initializeProjectProductData();
+            dbDataInitializer.initializeBuildRecordDemoData();
             dbDataInitializer.verifyData();
             logger.info("Finished initializing DEMO data");
         }

--- a/remote-build-coordinator/src/main/java/org/jboss/pnc/remotecoordinator/builder/RemoteBuildCoordinator.java
+++ b/remote-build-coordinator/src/main/java/org/jboss/pnc/remotecoordinator/builder/RemoteBuildCoordinator.java
@@ -215,7 +215,7 @@ public class RemoteBuildCoordinator implements BuildCoordinator {
                     buildConfigurationAudited,
                     null,
                     null,
-                    findTaskIdForCongifId(scheduleResult.buildGraph, buildConfigurationAudited.getId()),
+                    findTaskIdForConfigId(scheduleResult.buildGraph, buildConfigurationAudited.getId()),
                     null,
                     null,
                     null,
@@ -791,7 +791,7 @@ public class RemoteBuildCoordinator implements BuildCoordinator {
         }
     }
 
-    private String findTaskIdForCongifId(Graph<RemoteBuildTask> buildGraph, Integer id) {
+    private String findTaskIdForConfigId(Graph<RemoteBuildTask> buildGraph, Integer id) {
         return GraphUtils.unwrap(buildGraph.getVerticies())
                 .stream()
                 .filter(rbt -> rbt.getBuildConfigurationAudited().getId().equals(id))


### PR DESCRIPTION
### Renaming Suggestion of Method Names to Make Them More Descriptive
---
**Description**
---

We have developed a tool (**NameSpotter**) for identifying non-descriptive method names, and using this tool we find several non-descriptive method names in your repository:

```java
/* Non-descriptive Method Name in demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java */
    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
    public void initiliazeProjectProductData() {

        BuildEnvironment environment1Unsaved = BuildEnvironment.Builder.newBuilder()
                .name("Demo Environment 1")
                .description("Basic Java and Maven Environment")
                .attribute("JDK", "1.7.0")
                .attribute("OS", "Linux")
                .systemImageId("12345678")
                .systemImageRepositoryUrl("my.registry/newcastle")
                .systemImageType(SystemImageType.DOCKER_IMAGE)
                .deprecated(false)
                .build();
        BuildEnvironment environment1 = environmentRepository.save(environment1Unsaved);

        BuildEnvironment environment2Unsaved = BuildEnvironment.Builder.newBuilder()
                .name("Demo Environment 2")
                .description("Basic Java and Maven Environment")
                .attribute("JDK", "1.7.0")
                .attribute("OS", "Linux")
                .systemImageId("12345679")
                .systemImageRepositoryUrl("my.registry/newcastle")
                .systemImageType(SystemImageType.DOCKER_IMAGE)
                .deprecated(true)
                .build();
        BuildEnvironment environment2 = environmentRepository.save(environment2Unsaved);
		
		……

        buildConfigurationSetRepository.save(buildConfigurationSet1);
        buildConfigurationSetRepository.save(buildConfigurationSet2);
        demoUser = userRepository.save(demoUser);
        pncAdminUser = userRepository.save(pncAdminUser);

    }
```
We consider "initiliazeProjectProductData" as non-descriptive because it contains a typo, i.e., "initiliaze" should be "initialize".

```java
/* Non-descriptive Method Name in remote-build-coordinator/src/main/java/org/jboss/pnc/remotecoordinator/builder/RemoteBuildCoordinator.java*/
    private String findTaskIdForCongifId(Graph<RemoteBuildTask> buildGraph, Integer id) {
        return GraphUtils.unwrap(buildGraph.getVerticies())
                .stream()
                .filter(rbt -> rbt.getBuildConfigurationAudited().getId().equals(id))
                .findFirst()
                .get()
                .getId();
    }
```

We consider "findTaskIdForCongifId" as non-descriptive because it contains a typo, i.e., "Congif" should be "Config".

We have corrected them (including all the occurrences in other file) and submitted a pull request.

Do you agree with the judgment? 

- If not, could you please leave your valuable opinion?

- If you do agree, the relevant modification has been submitted as a PR, and thanks for your precious time to consider it.