### PR TITLE
[NCL-8048] Omit the auth in the request for BPM

### DIFF
--- a/bpm/src/main/java/org/jboss/pnc/bpm/RestConnector.java
+++ b/bpm/src/main/java/org/jboss/pnc/bpm/RestConnector.java
@@ -146,7 +146,6 @@ public class RestConnector implements Connector {
             log.debug("Starting new process using http endpoint: {}", request.getURI());
 
             Map<String, Object> processParameters = new HashMap<>();
-            processParameters.put("auth", Collections.singletonMap("token", accessToken));
             processParameters.put("mdc", new MDCParameters());
             processParameters.put("task", requestObject);
 


### PR DESCRIPTION
This isn't needed anymore since BPM will use its own service account

### Checklist:

* [ ] Have you added unit tests for your change?
