### PR TITLE
[NCL-8047] Stop using user token for other requests

### DIFF
--- a/facade/src/main/java/org/jboss/pnc/facade/deliverables/DeliverableAnalyzerManagerImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/deliverables/DeliverableAnalyzerManagerImpl.java
@@ -31,6 +31,7 @@ import org.jboss.pnc.api.deliverablesanalyzer.dto.MavenArtifact;
 import org.jboss.pnc.api.dto.Request;
 import org.jboss.pnc.api.enums.OperationResult;
 import org.jboss.pnc.api.enums.ProgressStatus;
+import org.jboss.pnc.auth.KeycloakServiceClient;
 import org.jboss.pnc.bpm.Connector;
 import org.jboss.pnc.bpm.model.AnalyzeDeliverablesBpmRequest;
 import org.jboss.pnc.bpm.task.AnalyzeDeliverablesTask;
@@ -114,6 +115,10 @@ public class DeliverableAnalyzerManagerImpl implements org.jboss.pnc.facade.Deli
     private OperationsManager operationsManager;
     @Inject
     private UserService userService;
+
+    @Inject
+    private KeycloakServiceClient keycloakServiceClient;
+
     @Inject
     private BpmModuleConfig bpmConfig;
     @Inject
@@ -411,7 +416,7 @@ public class DeliverableAnalyzerManagerImpl implements org.jboss.pnc.facade.Deli
                     bpmConfig.getAnalyzeDeliverablesBpmProcessId(),
                     analyzeTask,
                     id,
-                    userService.currentUserToken());
+                    keycloakServiceClient.getAuthToken());
 
             DeliverableAnalysisStatusChangedEvent analysisStatusChanged = DefaultDeliverableAnalysisStatusChangedEvent
                     .started(id, milestoneId, deliverablesUrls);

--- a/facade/src/main/java/org/jboss/pnc/facade/impl/BrewPusherImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/impl/BrewPusherImpl.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.facade.impl;
 
 import lombok.extern.slf4j.Slf4j;
+import org.jboss.pnc.auth.KeycloakServiceClient;
 import org.jboss.pnc.bpm.causeway.BuildPushOperation;
 import org.jboss.pnc.bpm.causeway.BuildResultPushManager;
 import org.jboss.pnc.bpm.causeway.InProgress;
@@ -33,7 +34,6 @@ import org.jboss.pnc.enums.ArtifactQuality;
 import org.jboss.pnc.enums.BuildPushStatus;
 import org.jboss.pnc.enums.BuildStatus;
 import org.jboss.pnc.facade.BrewPusher;
-import org.jboss.pnc.facade.util.UserService;
 import org.jboss.pnc.facade.validation.AlreadyRunningException;
 import org.jboss.pnc.facade.validation.EmptyEntityException;
 import org.jboss.pnc.facade.validation.InvalidEntityException;
@@ -95,7 +95,7 @@ public class BrewPusherImpl implements BrewPusher {
     private BuildPushResultMapper buildPushResultMapper;
 
     @Inject
-    private UserService userService;
+    private KeycloakServiceClient keycloakServiceClient;
 
     private final static EnumSet<ArtifactQuality> ARTIFACT_BAD_QUALITIES = EnumSet.of(DELETED, BLACKLISTED);
 
@@ -199,7 +199,7 @@ public class BrewPusherImpl implements BrewPusher {
                 buildPushParameters.isReimport(),
                 getCompleteCallbackUrlTemplate());
 
-        Result pushResult = buildResultPushManager.push(buildPushOperation, userService.currentUserToken());
+        Result pushResult = buildResultPushManager.push(buildPushOperation, keycloakServiceClient.getAuthToken());
         log.info("Push Result {}.", pushResult);
 
         BuildPushResult result = BuildPushResult.builder()

--- a/facade/src/main/java/org/jboss/pnc/facade/impl/OperationsManagerImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/impl/OperationsManagerImpl.java
@@ -24,6 +24,7 @@ import org.jboss.pnc.api.constants.MDCHeaderKeys;
 import org.jboss.pnc.api.dto.Request;
 import org.jboss.pnc.api.enums.OperationResult;
 import org.jboss.pnc.api.enums.ProgressStatus;
+import org.jboss.pnc.auth.KeycloakServiceClient;
 import org.jboss.pnc.common.concurrent.Sequence;
 import org.jboss.pnc.common.json.GlobalModuleGroup;
 import org.jboss.pnc.common.logging.MDCUtils;
@@ -64,6 +65,10 @@ public class OperationsManagerImpl implements OperationsManager {
     private ProductMilestoneRepository productMilestoneRepository;
     @Inject
     private UserService userService;
+
+    @Inject
+    private KeycloakServiceClient keycloakServiceClient;
+
     @Inject
     private GlobalModuleGroup globalConfig;
     @Inject
@@ -149,7 +154,7 @@ public class OperationsManagerImpl implements OperationsManager {
 
     @Override
     public Request getOperationCallback(Base32LongID operationId) {
-        String accessToken = userService.currentUserToken();
+        String accessToken = keycloakServiceClient.getAuthToken();
         List<Request.Header> headers = new ArrayList<>();
         addCommonHeaders(headers, accessToken);
         addMDCHeaders(headers);

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/ProductMilestoneProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/ProductMilestoneProviderImpl.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.facade.providers;
 
+import org.jboss.pnc.auth.KeycloakServiceClient;
 import org.jboss.pnc.bpm.causeway.ProductMilestoneReleaseManager;
 import org.jboss.pnc.common.concurrent.Sequence;
 import org.jboss.pnc.common.logging.MDCUtils;
@@ -31,7 +32,6 @@ import org.jboss.pnc.dto.response.statistics.ProductMilestoneDeliveredArtifactsS
 import org.jboss.pnc.dto.response.statistics.ProductMilestoneStatistics;
 import org.jboss.pnc.dto.validation.groups.WhenUpdating;
 import org.jboss.pnc.facade.providers.api.ProductMilestoneProvider;
-import org.jboss.pnc.facade.util.UserService;
 import org.jboss.pnc.facade.validation.ConflictedEntryException;
 import org.jboss.pnc.facade.validation.ConflictedEntryValidator;
 import org.jboss.pnc.facade.validation.EmptyEntityException;
@@ -96,7 +96,7 @@ public class ProductMilestoneProviderImpl extends
     private final ProductMilestoneCloseResultMapper milestoneReleaseMapper;
 
     @Inject
-    private UserService userService;
+    private KeycloakServiceClient keycloakServiceClient;
 
     private final ProductMilestoneRepository milestoneRepository;
 
@@ -191,7 +191,7 @@ public class ProductMilestoneProviderImpl extends
                 log.debug("Milestone's 'end date' set; no release of the milestone in progress: will start release");
 
                 ProductMilestoneRelease milestoneReleaseDb = releaseManager
-                        .startRelease(milestoneInDb, userService.currentUserToken(), milestoneReleaseId);
+                        .startRelease(milestoneInDb, keycloakServiceClient.getAuthToken(), milestoneReleaseId);
                 ProductMilestoneCloseResult milestoneCloseResult = milestoneReleaseMapper.toDTO(milestoneReleaseDb);
                 return milestoneCloseResult;
             }
@@ -213,7 +213,7 @@ public class ProductMilestoneProviderImpl extends
                 throw new EmptyEntityException("No running cancel process for given id.");
             } else {
                 userLog.info("Cancelling milestone release process ...");
-                releaseManager.cancel(milestoneInDb, userService.currentUserToken());
+                releaseManager.cancel(milestoneInDb, keycloakServiceClient.getAuthToken());
             }
         }
     }

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/SCMRepositoryProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/SCMRepositoryProviderImpl.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.facade.providers;
 
+import org.jboss.pnc.auth.KeycloakServiceClient;
 import org.jboss.pnc.bpm.BpmEventType;
 import org.jboss.pnc.bpm.Connector;
 import org.jboss.pnc.bpm.model.RepositoryCreationProcess;
@@ -41,7 +42,6 @@ import org.jboss.pnc.enums.JobNotificationType;
 import org.jboss.pnc.facade.providers.api.BuildConfigurationProvider;
 import org.jboss.pnc.facade.providers.api.SCMRepositoryProvider;
 import org.jboss.pnc.facade.util.RepourClient;
-import org.jboss.pnc.facade.util.UserService;
 import org.jboss.pnc.facade.validation.ConflictedEntryException;
 import org.jboss.pnc.facade.validation.InvalidEntityException;
 import org.jboss.pnc.mapper.api.SCMRepositoryMapper;
@@ -90,7 +90,7 @@ public class SCMRepositoryProviderImpl
     private RepositoryConfigurationRepository repositoryConfigurationRepository;
 
     @Inject
-    private UserService userService;
+    private KeycloakServiceClient keycloakServiceClient;
 
     @Inject
     private Notifier notifier;
@@ -361,7 +361,7 @@ public class SCMRepositoryProviderImpl
             boolean preBuildSyncEnabled,
             JobNotificationType jobType,
             Optional<BuildConfiguration> buildConfiguration) {
-        String userToken = userService.currentUserToken();
+        String authToken = keycloakServiceClient.getAuthToken();
 
         org.jboss.pnc.bpm.model.RepositoryConfiguration repositoryConfiguration = org.jboss.pnc.bpm.model.RepositoryConfiguration
                 .builder()
@@ -383,7 +383,7 @@ public class SCMRepositoryProviderImpl
             Map<String, Serializable> parameters = new HashMap<>();
             parameters.put("processParameters", task.getProcessParameters());
             parameters.put("taskId", id);
-            connector.startProcess(bpmConfig.getNewBcCreationProcessId(), parameters, Objects.toString(id), userToken);
+            connector.startProcess(bpmConfig.getNewBcCreationProcessId(), parameters, Objects.toString(id), authToken);
         } catch (CoreException e) {
             throw new RuntimeException("Could not get process parameters: " + task, e);
         } catch (ProcessManagerException e) {

--- a/facade/src/test/java/org/jboss/pnc/facade/providers/ProductMilestoneProviderTest.java
+++ b/facade/src/test/java/org/jboss/pnc/facade/providers/ProductMilestoneProviderTest.java
@@ -17,10 +17,10 @@
  */
 package org.jboss.pnc.facade.providers;
 
+import org.jboss.pnc.auth.KeycloakServiceClient;
 import org.jboss.pnc.bpm.causeway.ProductMilestoneReleaseManager;
 import org.jboss.pnc.common.json.moduleconfig.BpmModuleConfig;
 import org.jboss.pnc.dto.response.Page;
-import org.jboss.pnc.facade.util.UserService;
 import org.jboss.pnc.facade.validation.ConflictedEntryException;
 import org.jboss.pnc.facade.validation.EmptyEntityException;
 import org.jboss.pnc.facade.validation.InvalidEntityException;
@@ -58,7 +58,7 @@ public class ProductMilestoneProviderTest extends AbstractIntIdProviderTest<Prod
     private ProductMilestoneReleaseManager releaseManager;
 
     @Mock
-    private UserService userService;
+    private KeycloakServiceClient keycloakServiceClient;
 
     @Mock
     private BpmModuleConfig bpmModuleConfig;
@@ -72,7 +72,7 @@ public class ProductMilestoneProviderTest extends AbstractIntIdProviderTest<Prod
 
     @Before
     public void setup() {
-        when(userService.currentUserToken()).thenReturn("eyUserToken");
+        when(keycloakServiceClient.getAuthToken()).thenReturn("eyUserToken");
 
         ProductMilestoneFactory.getInstance().setIdSupplier(() -> entityId.getAndIncrement());
 


### PR DESCRIPTION
We need to stop using the user token to send other requests to other services.

Instead we'll use our service account.

This is done because we do not know when the user token will expire and should therefore use a service account token that we can control and renew.

Moreover, the user token may not have the appropriate roles to submit requests to other applications.

### Checklist:

* [ ] Have you added unit tests for your change?
