### PR TITLE
Fix BuildTest::dontRebuildTemporaryBuildWhenThereIsNewerPersistentOnS…

### DIFF
--- a/integration-test-rex/src/test/java/org/jboss/pnc/integrationrex/BuildTest.java
+++ b/integration-test-rex/src/test/java/org/jboss/pnc/integrationrex/BuildTest.java
@@ -351,13 +351,13 @@ public class BuildTest extends RemoteServices {
         updatedParent = buildConfigurationClient.getSpecific(updatedParent.getId());
         assertThat(oldLastModDateParent).isNotEqualTo(updatedParent.getModificationTime());
 
-        Instant oldLastModDateDependency = parent.getModificationTime();
+        Instant oldLastModDateDependency = dependency.getModificationTime();
         BuildConfiguration updatedDependency = dependency.toBuilder()
                 .description("Random Description so it rebuilds")
                 .buildScript("mvn" + "   clean deploy -DskipTests=true")
                 .build();
-        Thread.sleep(11L);
         buildConfigurationClient.update(updatedDependency.getId(), updatedDependency);
+        updatedDependency = buildConfigurationClient.getSpecific(updatedDependency.getId());
         assertThat(oldLastModDateDependency).isNotEqualTo(updatedDependency.getModificationTime());
 
         EnumSet<BuildStatus> isIn = EnumSet.of(BuildStatus.SUCCESS);


### PR DESCRIPTION
…ameRev

This one is for rex!

The test had a few issues:
- we were comparing the parent build configuration's modification time with the dependency modification time
- we weren't updating the 'updatedDependency' object after it was modified

### Checklist:

* [ ] Have you added unit tests for your change?
