### PR TITLE
[NCL-8156] achieve determinism for build endpoints

### DIFF
--- a/datastore/src/main/java/org/jboss/pnc/datastore/limits/rsql/EmptySortInfo.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/limits/rsql/EmptySortInfo.java
@@ -20,18 +20,19 @@ package org.jboss.pnc.datastore.limits.rsql;
 import org.jboss.pnc.spi.datastore.repositories.api.OrderInfo;
 import org.jboss.pnc.spi.datastore.repositories.api.SortInfo;
 import org.jboss.pnc.spi.datastore.repositories.api.impl.DefaultOrderInfo;
+import org.jboss.pnc.spi.datastore.repositories.api.impl.DefaultSortInfo;
 
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Root;
+import javax.persistence.metamodel.SingularAttribute;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
-public class EmptySortInfo<T> implements SortInfo<T> {
+public class EmptySortInfo<T> extends DefaultSortInfo<T> {
 
-    @Override
-    public List<OrderInfo<T>> orders() {
-        return Collections
-                .singletonList(new DefaultOrderInfo<T>(OrderInfo.SortingDirection.ASC, EmptySortInfo::idOrder));
+    public EmptySortInfo() {
+        super(new DefaultOrderInfo<T>(OrderInfo.SortingDirection.ASC, EmptySortInfo::idOrder));
     }
 
     private static <T> Expression<?> idOrder(Root<T> root) {

--- a/datastore/src/main/java/org/jboss/pnc/datastore/limits/rsql/EmptySortInfo.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/limits/rsql/EmptySortInfo.java
@@ -35,6 +35,12 @@ public class EmptySortInfo<T> extends DefaultSortInfo<T> {
         super(new DefaultOrderInfo<T>(OrderInfo.SortingDirection.ASC, EmptySortInfo::idOrder));
     }
 
+    @Override
+    public DefaultSortInfo<T> thenOrderBy(SingularAttribute<T, ?> attribute, OrderInfo.SortingDirection direction) {
+        // remove default ID sorting on a change of ordering
+        return new DefaultSortInfo<T>().thenOrderBy(attribute, direction);
+    }
+
     private static <T> Expression<?> idOrder(Root<T> root) {
         try {
             return root.get("id");

--- a/datastore/src/main/java/org/jboss/pnc/datastore/limits/rsql/StableEmptySortInfo.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/limits/rsql/StableEmptySortInfo.java
@@ -18,21 +18,17 @@
 package org.jboss.pnc.datastore.limits.rsql;
 
 import org.jboss.pnc.spi.datastore.repositories.api.OrderInfo;
-import org.jboss.pnc.spi.datastore.repositories.api.SortInfo;
 import org.jboss.pnc.spi.datastore.repositories.api.impl.DefaultOrderInfo;
 import org.jboss.pnc.spi.datastore.repositories.api.impl.DefaultSortInfo;
 
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Root;
 import javax.persistence.metamodel.SingularAttribute;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Function;
 
-public class EmptySortInfo<T> extends DefaultSortInfo<T> {
+public class StableEmptySortInfo<T> extends DefaultSortInfo<T> {
 
-    public EmptySortInfo() {
-        super(new DefaultOrderInfo<T>(OrderInfo.SortingDirection.ASC, EmptySortInfo::idOrder));
+    public StableEmptySortInfo() {
+        super(new DefaultOrderInfo<T>(OrderInfo.SortingDirection.ASC, StableEmptySortInfo::idOrder));
     }
 
     @Override

--- a/facade/src/main/java/org/jboss/pnc/facade/rsql/RSQLProducerImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/rsql/RSQLProducerImpl.java
@@ -22,7 +22,7 @@ import cz.jirutka.rsql.parser.RSQLParserException;
 import cz.jirutka.rsql.parser.ast.ComparisonOperator;
 import cz.jirutka.rsql.parser.ast.Node;
 import cz.jirutka.rsql.parser.ast.RSQLOperators;
-import org.jboss.pnc.datastore.limits.rsql.EmptySortInfo;
+import org.jboss.pnc.datastore.limits.rsql.StableEmptySortInfo;
 import org.jboss.pnc.datastore.predicates.rsql.EmptyRSQLPredicate;
 import org.jboss.pnc.facade.rsql.mapper.UniversalRSQLMapper;
 import org.jboss.pnc.model.GenericEntity;
@@ -123,7 +123,7 @@ public class RSQLProducerImpl implements RSQLProducer {
     @Override
     public <DB extends GenericEntity<?>> SortInfo<DB> getSortInfo(Class<DB> type, String rsql) {
         if (rsql == null || rsql.isEmpty()) {
-            return new EmptySortInfo<>();
+            return new StableEmptySortInfo<>();
         }
 
         if (!rsql.startsWith(FIXED_START_OF_SORTING_EXPRESSION)) {

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/api/SortInfo.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/api/SortInfo.java
@@ -23,5 +23,5 @@ import java.util.List;
 public interface SortInfo<T> {
     List<OrderInfo<T>> orders();
 
-    SortInfo<T> thenOrderBy(SingularAttribute<T, ? > attribute, OrderInfo.SortingDirection direction);
+    SortInfo<T> thenOrderBy(SingularAttribute<T, ?> attribute, OrderInfo.SortingDirection direction);
 }

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/api/SortInfo.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/api/SortInfo.java
@@ -17,8 +17,11 @@
  */
 package org.jboss.pnc.spi.datastore.repositories.api;
 
+import javax.persistence.metamodel.SingularAttribute;
 import java.util.List;
 
 public interface SortInfo<T> {
     List<OrderInfo<T>> orders();
+
+    SortInfo<T> thenOrderBy(SingularAttribute<T, ? > attribute, OrderInfo.SortingDirection direction);
 }

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/api/impl/DefaultSortInfo.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/api/impl/DefaultSortInfo.java
@@ -30,11 +30,15 @@ public class DefaultSortInfo<T> implements SortInfo<T> {
     private final List<OrderInfo<T>> order;
 
     public DefaultSortInfo(List<OrderInfo<T>> orderInfo) {
-        this.order = List.copyOf(orderInfo);
+        this.order = new ArrayList<>(orderInfo);
     }
 
     public DefaultSortInfo(OrderInfo<T> orderInfo) {
-        this.order = Collections.singletonList(orderInfo);
+        this(Collections.singletonList(orderInfo));
+    }
+
+    public DefaultSortInfo() {
+        this.order = new ArrayList<>();
     }
 
     public static <T> SortInfo<T> asc(SingularAttribute<T, ?> field) {
@@ -52,39 +56,33 @@ public class DefaultSortInfo<T> implements SortInfo<T> {
     }
 
     public static <T> SortInfo<T> descs(SingularAttribute<T, ?>... fields) {
-        return appendAll(null, OrderInfo.SortingDirection.DESC, fields);
+        return new DefaultSortInfo<T>().appendAll(OrderInfo.SortingDirection.DESC, fields);
     }
 
     public static <T> SortInfo<T> ascs(SingularAttribute<T, ?>... fields) {
-        return appendAll(null, OrderInfo.SortingDirection.ASC, fields);
+        return new DefaultSortInfo<T>().appendAll(OrderInfo.SortingDirection.ASC, fields);
     }
 
-    public static <T> SortInfo<T> appendAll(
-            SortInfo<T> order,
+    private DefaultSortInfo<T> appendAll(
             OrderInfo.SortingDirection dir,
             SingularAttribute<T, ?>... fields) {
-        List<OrderInfo<T>> orders = new ArrayList<>(order == null ? List.of() : order.orders());
-
-        if (fields == null || fields.length == 0) {
-            return order;
+        if (fields != null) {
+            for (SingularAttribute<T, ?> attribute : fields) {
+                order.add(new DefaultOrderInfo<>(dir, root -> root.get(attribute)));
+            }
         }
 
-        for (SingularAttribute<T, ?> attribute : fields) {
-            orders.add(new DefaultOrderInfo<>(dir, root -> root.get(attribute)));
-        }
-
-        return new DefaultSortInfo<>(orders);
+        return this;
     }
 
-    public static <T> SortInfo<T> append(
-            SortInfo<T> sortInfo,
+    public DefaultSortInfo<T> thenOrderBy(
             SingularAttribute<T, ?> attribute,
             OrderInfo.SortingDirection direction) {
-        return appendAll(sortInfo, direction, attribute);
+        return appendAll(direction, attribute);
     }
 
     @Override
     public List<OrderInfo<T>> orders() {
-        return order;
+        return Collections.unmodifiableList(order);
     }
 }

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/api/impl/DefaultSortInfo.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/api/impl/DefaultSortInfo.java
@@ -24,6 +24,7 @@ import javax.persistence.criteria.Root;
 import javax.persistence.metamodel.SingularAttribute;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 public class DefaultSortInfo<T> implements SortInfo<T> {
@@ -74,7 +75,7 @@ public class DefaultSortInfo<T> implements SortInfo<T> {
     }
 
     public DefaultSortInfo<T> thenOrderBy(SingularAttribute<T, ?> attribute, OrderInfo.SortingDirection direction) {
-        return appendAll(direction, attribute);
+        return new DefaultSortInfo<>(orders()).appendAll(direction, attribute);
     }
 
     @Override

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/api/impl/DefaultSortInfo.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/api/impl/DefaultSortInfo.java
@@ -63,9 +63,7 @@ public class DefaultSortInfo<T> implements SortInfo<T> {
         return new DefaultSortInfo<T>().appendAll(OrderInfo.SortingDirection.ASC, fields);
     }
 
-    private DefaultSortInfo<T> appendAll(
-            OrderInfo.SortingDirection dir,
-            SingularAttribute<T, ?>... fields) {
+    private DefaultSortInfo<T> appendAll(OrderInfo.SortingDirection dir, SingularAttribute<T, ?>... fields) {
         if (fields != null) {
             for (SingularAttribute<T, ?> attribute : fields) {
                 order.add(new DefaultOrderInfo<>(dir, root -> root.get(attribute)));
@@ -75,9 +73,7 @@ public class DefaultSortInfo<T> implements SortInfo<T> {
         return this;
     }
 
-    public DefaultSortInfo<T> thenOrderBy(
-            SingularAttribute<T, ?> attribute,
-            OrderInfo.SortingDirection direction) {
+    public DefaultSortInfo<T> thenOrderBy(SingularAttribute<T, ?> attribute, OrderInfo.SortingDirection direction) {
         return appendAll(direction, attribute);
     }
 

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/api/impl/DefaultSortInfo.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/api/impl/DefaultSortInfo.java
@@ -64,7 +64,7 @@ public class DefaultSortInfo<T> implements SortInfo<T> {
         return new DefaultSortInfo<T>().appendAll(OrderInfo.SortingDirection.ASC, fields);
     }
 
-    private DefaultSortInfo<T> appendAll(OrderInfo.SortingDirection dir, SingularAttribute<T, ?>... fields) {
+    protected DefaultSortInfo<T> appendAll(OrderInfo.SortingDirection dir, SingularAttribute<T, ?>... fields) {
         if (fields != null) {
             for (SingularAttribute<T, ?> attribute : fields) {
                 order.add(new DefaultOrderInfo<>(dir, root -> root.get(attribute)));

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/api/impl/DefaultSortInfo.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/api/impl/DefaultSortInfo.java
@@ -22,6 +22,7 @@ import org.jboss.pnc.spi.datastore.repositories.api.SortInfo;
 
 import javax.persistence.criteria.Root;
 import javax.persistence.metamodel.SingularAttribute;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -40,14 +41,46 @@ public class DefaultSortInfo<T> implements SortInfo<T> {
         DefaultOrderInfo<T> orderInfo = new DefaultOrderInfo<>(
                 OrderInfo.SortingDirection.ASC,
                 (Root<T> root) -> root.get(field));
-        return new DefaultSortInfo(orderInfo);
+        return new DefaultSortInfo<>(orderInfo);
     }
 
     public static <T> SortInfo<T> desc(SingularAttribute<T, ?> field) {
         DefaultOrderInfo<T> orderInfo = new DefaultOrderInfo<>(
                 OrderInfo.SortingDirection.DESC,
                 (Root<T> root) -> root.get(field));
-        return new DefaultSortInfo(orderInfo);
+        return new DefaultSortInfo<>(orderInfo);
+    }
+
+    public static <T> SortInfo<T> descs(SingularAttribute<T, ?>... fields) {
+        return appendAll(null, OrderInfo.SortingDirection.DESC, fields);
+    }
+
+    public static <T> SortInfo<T> ascs(SingularAttribute<T, ?>... fields) {
+        return appendAll(null, OrderInfo.SortingDirection.ASC, fields);
+    }
+
+    public static <T> SortInfo<T> appendAll(
+            SortInfo<T> order,
+            OrderInfo.SortingDirection dir,
+            SingularAttribute<T, ?>... fields) {
+        List<OrderInfo<T>> orders = new ArrayList<>(order == null ? List.of() : order.orders());
+
+        if (fields == null || fields.length == 0) {
+            return order;
+        }
+
+        for (SingularAttribute<T, ?> attribute : fields) {
+            orders.add(new DefaultOrderInfo<>(dir, root -> root.get(attribute)));
+        }
+
+        return new DefaultSortInfo<>(orders);
+    }
+
+    public static <T> SortInfo<T> append(
+            SortInfo<T> sortInfo,
+            SingularAttribute<T, ?> attribute,
+            OrderInfo.SortingDirection direction) {
+        return appendAll(sortInfo, direction, attribute);
     }
 
     @Override


### PR DESCRIPTION
### Checklist:

* [ ] Have you added unit tests for your change?

@janinko As more than one endpoint uses `getBuildList(...)` method, the default sort change from `ID asc` to `submitTime desc, ID desc` will also affect default sorting on these endpoints:

- **GET /product-milestones/{{id}}/builds**
- **GET /projects/{{id}}/builds**
- **GET /build-configs/{{id}}/builds**
- **GET /users/{{id}}/builds**
- **GET /group-builds/{{id}}/builds**
- **GET /group-configs/{{id}}/builds**