### PR TITLE
[NCLSUP-988] fix creation of extra TRs during del-analysis

### DIFF
--- a/facade/src/main/java/org/jboss/pnc/facade/deliverables/DeliverableAnalyzerManagerImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/deliverables/DeliverableAnalyzerManagerImpl.java
@@ -586,7 +586,7 @@ public class DeliverableAnalyzerManagerImpl implements org.jboss.pnc.facade.Deli
         }
 
         private String getKojiPath(Build build) {
-            return KOJI_PATH_MAVEN_PREFIX + build.getBrewNVR();
+            return KOJI_PATH_MAVEN_PREFIX + build.getBrewNVR() + '/';
         }
 
         private void assertBrewArtifacts(Artifact artifact) {


### PR DESCRIPTION
### Checklist:

* [ ] Have you added unit tests for your change?

During sustaining, I've found an issue when Orch was creating extra TargetRepositories without ending slash (apparently all should have an ending slash) after DeliverableAnalyzer finishes. 

I am not familiar with the code but I think this should fix it.

Additionally, I think this should be backported to 2.6.X branch.