### PR TITLE
[NCL-8152] Use fine-grained roles for PNC endpoints

### DIFF
--- a/facade/src/main/java/org/jboss/pnc/facade/deliverables/DeliverableAnalyzerManagerImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/deliverables/DeliverableAnalyzerManagerImpl.java
@@ -85,7 +85,7 @@ import java.util.stream.Stream;
 
 import static org.jboss.pnc.constants.ReposiotryIdentifier.DISTRIBUTION_ARCHIVE;
 import static org.jboss.pnc.constants.ReposiotryIdentifier.INDY_MAVEN;
-import static org.jboss.pnc.facade.providers.api.UserRoles.SYSTEM_USER;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_ADMIN;
 
 /**
  *
@@ -234,7 +234,7 @@ public class DeliverableAnalyzerManagerImpl implements org.jboss.pnc.facade.Deli
     }
 
     @Override
-    @RolesAllowed(SYSTEM_USER)
+    @RolesAllowed(USERS_ADMIN)
     @Transactional
     public void clear(int id) {
         ProductMilestone milestone = milestoneRepository.queryById(id);

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/ArtifactProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/ArtifactProviderImpl.java
@@ -84,7 +84,9 @@ import static java.util.stream.Collectors.*;
 import static java.util.stream.Collectors.mapping;
 import static org.jboss.pnc.api.enums.Qualifier.*;
 import static org.jboss.pnc.common.util.StreamHelper.nullableStreamOf;
-import static org.jboss.pnc.facade.providers.api.UserRoles.SYSTEM_USER;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_ADMIN;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_ARTIFACT_ADMIN;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_BUILD_ADMIN;
 import static org.jboss.pnc.spi.datastore.predicates.ArtifactPredicates.withBuildRecordId;
 import static org.jboss.pnc.spi.datastore.predicates.ArtifactPredicates.withDependantBuildRecordId;
 import static org.jboss.pnc.spi.datastore.predicates.ArtifactPredicates.withDeliveredInProductMilestone;
@@ -242,7 +244,7 @@ public class ArtifactProviderImpl
     }
 
     @Override
-    @RolesAllowed(SYSTEM_USER)
+    @RolesAllowed({ USERS_ARTIFACT_ADMIN, USERS_ADMIN })
     public org.jboss.pnc.dto.Artifact store(org.jboss.pnc.dto.Artifact restEntity) throws DTOValidationException {
         org.jboss.pnc.model.User currentUser = userService.currentUser();
         User user = userMapper.toDTO(currentUser);
@@ -275,7 +277,11 @@ public class ArtifactProviderImpl
     public ArtifactRevision createQualityLevelRevision(String id, String quality, String reason)
             throws DTOValidationException {
 
-        boolean isLoggedInUserSystemUser = userService.hasLoggedInUserRole(SYSTEM_USER);
+        boolean isLoggedInUserAdmin = userService.hasLoggedInUserRole(USERS_ADMIN);
+        boolean isLoggedInUserArtifactAdmin = userService.hasLoggedInUserRole(USERS_ARTIFACT_ADMIN);
+        boolean isLoggedInBuildAdmin = userService.hasLoggedInUserRole(USERS_BUILD_ADMIN);
+
+        boolean isLoggedInUserSystemUser = isLoggedInUserAdmin || isLoggedInUserArtifactAdmin || isLoggedInBuildAdmin;
 
         ArtifactQuality newQuality = validateProvidedArtifactQuality(quality, isLoggedInUserSystemUser);
 

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/BuildProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/BuildProviderImpl.java
@@ -119,7 +119,9 @@ import java.util.stream.StreamSupport;
 
 import static java.lang.Math.min;
 import static org.jboss.pnc.common.util.StreamHelper.nullableStreamOf;
-import static org.jboss.pnc.facade.providers.api.UserRoles.SYSTEM_USER;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_ADMIN;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_BUILD_ADMIN;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_BUILD_DELETE;
 import static org.jboss.pnc.spi.datastore.predicates.ArtifactPredicates.withIds;
 import static org.jboss.pnc.spi.datastore.predicates.BuildConfigurationPredicates.withProjectId;
 import static org.jboss.pnc.spi.datastore.predicates.BuildRecordPredicates.buildFinishedBefore;
@@ -202,13 +204,13 @@ public class BuildProviderImpl extends AbstractUpdatableProvider<Base32LongID, B
         throw new UnsupportedOperationException("Direct build creation is not available.");
     }
 
-    @RolesAllowed(SYSTEM_USER)
+    @RolesAllowed({ USERS_BUILD_ADMIN, USERS_ADMIN })
     @Override
     public void delete(String id) {
         throw new UnsupportedOperationException("Deleting persistent builds is never allowed");
     }
 
-    @RolesAllowed(SYSTEM_USER)
+    @RolesAllowed({ USERS_BUILD_ADMIN, USERS_ADMIN })
     @Override
     public Build update(String buildId, Build restEntity) {
         Base32LongID id = parseId(buildId);
@@ -219,7 +221,7 @@ public class BuildProviderImpl extends AbstractUpdatableProvider<Base32LongID, B
         return mapper.toDTO(entityInDB);
     }
 
-    @RolesAllowed(SYSTEM_USER)
+    @RolesAllowed({ USERS_BUILD_DELETE, USERS_BUILD_ADMIN, USERS_ADMIN })
     @Override
     public boolean delete(String buildId, String callback) {
 
@@ -642,7 +644,7 @@ public class BuildProviderImpl extends AbstractUpdatableProvider<Base32LongID, B
                 BuildRecordPredicates.withBuildLogContains(search));
     }
 
-    @RolesAllowed(SYSTEM_USER)
+    @RolesAllowed({ USERS_BUILD_ADMIN, USERS_ADMIN })
     @Override
     public void setBuiltArtifacts(String buildId, List<String> artifactIds) {
         Set<Integer> ids = artifactIds.stream().map(Integer::valueOf).collect(Collectors.toSet());
@@ -676,7 +678,7 @@ public class BuildProviderImpl extends AbstractUpdatableProvider<Base32LongID, B
                 .collect(Collectors.toSet());
     }
 
-    @RolesAllowed(SYSTEM_USER)
+    @RolesAllowed({ USERS_BUILD_ADMIN, USERS_ADMIN })
     @Override
     public void setDependentArtifacts(String buildId, List<String> artifactIds) {
         BuildRecord buildRecord = repository.queryById(parseId(buildId));

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/EnvironmentProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/EnvironmentProviderImpl.java
@@ -17,7 +17,8 @@
  */
 package org.jboss.pnc.facade.providers;
 
-import static org.jboss.pnc.facade.providers.api.UserRoles.SYSTEM_USER;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_ADMIN;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_ENVIRONMENT_ADMIN;
 import static org.jboss.pnc.spi.datastore.predicates.EnvironmentPredicates.replacedBy;
 import static org.jboss.pnc.spi.datastore.predicates.EnvironmentPredicates.withEnvironmentNameAndActive;
 
@@ -50,7 +51,7 @@ public class EnvironmentProviderImpl extends AbstractProvider<Integer, BuildEnvi
     }
 
     @Override
-    @RolesAllowed(SYSTEM_USER)
+    @RolesAllowed({ USERS_ENVIRONMENT_ADMIN, USERS_ADMIN })
     public Environment store(Environment restEntity) throws DTOValidationException {
         Environment storedEntity = super.store(restEntity);
         deprecateActiveEnvironmentsWithSameName(storedEntity);
@@ -92,7 +93,7 @@ public class EnvironmentProviderImpl extends AbstractProvider<Integer, BuildEnvi
     }
 
     @Override
-    @RolesAllowed(SYSTEM_USER)
+    @RolesAllowed({ USERS_ENVIRONMENT_ADMIN, USERS_ADMIN })
     public Environment deprecateEnvironment(String id, String replacementId) {
         BuildEnvironment deprecatedEnvironment = repository.queryById(mapper.getIdMapper().toEntity(id));
         if (deprecatedEnvironment == null) {

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/GenericSettingProvider.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/GenericSettingProvider.java
@@ -28,7 +28,7 @@ import org.jboss.util.Strings;
 import static org.jboss.pnc.api.constants.GenericSettingsKeys.ANNOUNCEMENT_BANNER;
 import static org.jboss.pnc.api.constants.GenericSettingsKeys.MAINTENANCE_MODE;
 import static org.jboss.pnc.api.constants.GenericSettingsKeys.PNC_VERSION;
-import static org.jboss.pnc.facade.providers.api.UserRoles.SYSTEM_USER;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_ADMIN;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
@@ -53,7 +53,7 @@ public class GenericSettingProvider {
     public GenericSettingProvider() {
     }
 
-    @RolesAllowed("system-user")
+    @RolesAllowed(USERS_ADMIN)
     public void activateMaintenanceMode(String reason) {
 
         log.info("Activating Maintenance mode, with reason: '{}'", reason);
@@ -66,7 +66,7 @@ public class GenericSettingProvider {
         setAnnouncementBanner(reason);
     }
 
-    @RolesAllowed("system-user")
+    @RolesAllowed(USERS_ADMIN)
     public void deactivateMaintenanceMode() {
 
         log.info("Deactivating Maintenance mode");
@@ -100,7 +100,7 @@ public class GenericSettingProvider {
 
     public boolean isCurrentUserAllowedToTriggerBuilds() {
 
-        boolean isLoggedInUserSystemUser = userService.hasLoggedInUserRole(SYSTEM_USER);
+        boolean isLoggedInUserSystemUser = userService.hasLoggedInUserRole(USERS_ADMIN);
         if (isLoggedInUserSystemUser) {
             log.info("Users with system-role are always allowed to trigger builds");
             return true;
@@ -109,7 +109,7 @@ public class GenericSettingProvider {
         return !isInMaintenanceMode();
     }
 
-    @RolesAllowed("system-user")
+    @RolesAllowed(USERS_ADMIN)
     public void setPNCVersion(String version) {
 
         log.info("PNC System version set to: '{}'", version);
@@ -129,7 +129,7 @@ public class GenericSettingProvider {
         }
     }
 
-    @RolesAllowed("system-user")
+    @RolesAllowed(USERS_ADMIN)
     public void setAnnouncementBanner(String banner) {
 
         log.info("Announcement banner set to: '{}'", banner);

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/GroupBuildProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/GroupBuildProviderImpl.java
@@ -35,7 +35,6 @@ import org.jboss.pnc.mapper.api.GroupConfigurationMapper;
 import org.jboss.pnc.mapper.api.ResultMapper;
 import org.jboss.pnc.model.BuildConfigSetRecord;
 import org.jboss.pnc.model.BuildConfigSetRecord_;
-import org.jboss.pnc.model.User;
 import org.jboss.pnc.spi.coordinator.BuildCoordinator;
 import org.jboss.pnc.spi.coordinator.Result;
 import org.jboss.pnc.spi.datastore.repositories.BuildConfigSetRecordRepository;
@@ -60,7 +59,8 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static org.jboss.pnc.facade.providers.api.UserRoles.SYSTEM_USER;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_ADMIN;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_BUILD_ADMIN;
 import static org.jboss.pnc.spi.datastore.predicates.BuildConfigSetRecordPredicates.withBuildConfigSetId;
 
 @PermitAll
@@ -113,7 +113,7 @@ public class GroupBuildProviderImpl extends AbstractProvider<Long, BuildConfigSe
         throw new UnsupportedOperationException("Direct GroupBuilds creation is not available.");
     }
 
-    @RolesAllowed(SYSTEM_USER)
+    @RolesAllowed({ USERS_BUILD_ADMIN, USERS_ADMIN })
     @Override
     public GroupBuild update(String id, GroupBuild restEntity) {
         return super.update(id, restEntity);

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/OperationProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/OperationProviderImpl.java
@@ -50,7 +50,7 @@ import java.sql.Date;
 import java.time.Instant;
 import java.util.Map;
 
-import static org.jboss.pnc.facade.providers.api.UserRoles.SYSTEM_USER;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_ADMIN;
 import static org.jboss.pnc.spi.datastore.predicates.OperationPredicates.withMilestoneId;
 
 @PermitAll
@@ -73,7 +73,7 @@ public abstract class OperationProviderImpl<DB extends org.jboss.pnc.model.Opera
     }
 
     @Override
-    @RolesAllowed(SYSTEM_USER)
+    @RolesAllowed(USERS_ADMIN)
     public DTO update(String operationId, DTO restEntity) {
         return super.update(operationId, restEntity);
     }

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/TargetRepositoryProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/TargetRepositoryProviderImpl.java
@@ -33,7 +33,9 @@ import javax.inject.Inject;
 import java.util.Collections;
 import java.util.Set;
 
-import static org.jboss.pnc.facade.providers.api.UserRoles.SYSTEM_USER;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_ADMIN;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_ARTIFACT_ADMIN;
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_BUILD_ADMIN;
 import static org.jboss.pnc.spi.datastore.predicates.TargetRepositoryPredicates.withIdentifierAndPathIn;
 
 @PermitAll
@@ -48,7 +50,7 @@ public class TargetRepositoryProviderImpl
     }
 
     @Override
-    @RolesAllowed(SYSTEM_USER)
+    @RolesAllowed({ USERS_BUILD_ADMIN, USERS_ARTIFACT_ADMIN, USERS_ADMIN })
     public TargetRepository store(TargetRepository restEntity) throws DTOValidationException {
         return super.store(restEntity);
     }

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/api/UserRoles.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/api/UserRoles.java
@@ -22,7 +22,20 @@ package org.jboss.pnc.facade.providers.api;
  */
 public class UserRoles {
 
-    public static final String SYSTEM_USER = "system-user";
+    /** Role used by all PNC human admins */
+    public static final String USERS_ADMIN = "pnc-users-admin";
+
+    /** Role used by humans / service accounts that modify artifacts */
+    public static final String USERS_ARTIFACT_ADMIN = "pnc-users-artifact-admin";
+
+    /** Role used by humans / service accounts to delete temporary builds */
+    public static final String USERS_BUILD_DELETE = "pnc-users-build-delete";
+
+    /** Role used by humans / service accounts to create / change builds (including deletion) */
+    public static final String USERS_BUILD_ADMIN = "pnc-users-build-admin";
+
+    /** Role used by humans / service accounts to create / change environment */
+    public static final String USERS_ENVIRONMENT_ADMIN = "pnc-users-environment-admin";
 
     /**
      * User's with this role are routed to new implementations that usually run in parallel to the old one (blue/green

--- a/integration-test-rex/src/test/resources/WEB-INF/web.xml
+++ b/integration-test-rex/src/test/resources/WEB-INF/web.xml
@@ -30,12 +30,18 @@
     </login-config>
 
     <security-role>
-        <role-name>admin</role-name>
+        <role-name>pnc-users-build-delete</role-name>
     </security-role>
     <security-role>
-        <role-name>user</role-name>
+        <role-name>pnc-users-build-admin</role-name>
     </security-role>
     <security-role>
-        <role-name>system-user</role-name>
+        <role-name>pnc-users-artifact-admin</role-name>
+    </security-role>
+    <security-role>
+        <role-name>pnc-users-environment-admin</role-name>
+    </security-role>
+    <security-role>
+        <role-name>pnc-users-admin</role-name>
     </security-role>
 </web-app>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -292,7 +292,7 @@
                     <echo file="${test.server.unpack.dir}/${app.server}-${jboss.version}/standalone/configuration/application-roles.properties" append="true">user=user${line.separator}</echo>
 
                     <echo file="${test.server.unpack.dir}/${app.server}-${jboss.version}/standalone/configuration/application-users.properties" append="true">system=2a1410b11545f3c5f4f6bfbdefb70eb0${line.separator}</echo> <!-- pass is system.1234 -->
-                    <echo file="${test.server.unpack.dir}/${app.server}-${jboss.version}/standalone/configuration/application-roles.properties" append="true">system=user,system-user${line.separator}</echo>
+                    <echo file="${test.server.unpack.dir}/${app.server}-${jboss.version}/standalone/configuration/application-roles.properties" append="true">system=user,pnc-users-admin${line.separator}</echo>
 
                     <echo file="${test.server.unpack.dir}/${app.server}-${jboss.version}/standalone/configuration/application-users.properties" append="true">demo-user=39af16736bfd4f0430d2351ccf0b108a${line.separator}</echo> <!-- pass is system.1234 -->
                     <echo file="${test.server.unpack.dir}/${app.server}-${jboss.version}/standalone/configuration/application-roles.properties" append="true">demo-user=user${line.separator}</echo>

--- a/integration-test/src/test/resources/WEB-INF/web.xml
+++ b/integration-test/src/test/resources/WEB-INF/web.xml
@@ -30,12 +30,18 @@
     </login-config>
 
     <security-role>
-        <role-name>admin</role-name>
+        <role-name>pnc-users-build-delete</role-name>
     </security-role>
     <security-role>
-        <role-name>user</role-name>
+        <role-name>pnc-users-build-admin</role-name>
     </security-role>
     <security-role>
-        <role-name>system-user</role-name>
+        <role-name>pnc-users-artifact-admin</role-name>
+    </security-role>
+    <security-role>
+        <role-name>pnc-users-environment-admin</role-name>
+    </security-role>
+    <security-role>
+        <role-name>pnc-users-admin</role-name>
     </security-role>
 </web-app>

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ArtifactEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ArtifactEndpoint.java
@@ -221,7 +221,7 @@ public interface ArtifactEndpoint {
      * @return
      */
     @Operation(
-            summary = "[role:admin] " + CREATE_DESC,
+            summary = "[role:pnc-users-artifact-admin, pnc-users-admin] " + CREATE_DESC,
             tags = SwaggerConstants.TAG_INTERNAL,
             responses = {
                     @ApiResponse(
@@ -253,7 +253,7 @@ public interface ArtifactEndpoint {
      * @param artifact
      */
     @Operation(
-            summary = "[role:admin] " + UPDATE_DESC,
+            summary = "[role:pnc-users-artifact-admin, pnc-users-admin] " + UPDATE_DESC,
             tags = SwaggerConstants.TAG_INTERNAL,
             responses = { @ApiResponse(responseCode = ENTITY_UPDATED_CODE, description = ENTITY_UPDATED_DESCRIPTION),
                     @ApiResponse(
@@ -272,7 +272,7 @@ public interface ArtifactEndpoint {
     @Path("/{id}")
     void update(@PathParam("id") String id, @NotNull Artifact artifact);
 
-    static final String CREATE_ARTIFACT_QUALITY_REVISION = "Add a new quality level revision for this artifact. Accepted values from standard users are NEW, VERIFIED, TESTED, DEPRECATED. Users with system-user role can also specify BLACKLISTED and DELETED quality levels.";
+    static final String CREATE_ARTIFACT_QUALITY_REVISION = "Add a new quality level revision for this artifact. Accepted values from standard users are NEW, VERIFIED, TESTED, DEPRECATED. Users with pnc-users-artifact-admin, pnc-users-build-admin, pnc-users-admin role can also specify BLACKLISTED and DELETED quality levels.";
     static final String ARTIFACT_QUALITY = "Quality level of the artifact.";
     static final String ARTIFACT_QUALITY_REASON = "The reason for adding a new quality level for this artifact.";
 

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/BuildEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/BuildEndpoint.java
@@ -173,7 +173,7 @@ public interface BuildEndpoint {
      * @param callback {@value SwaggerConstants#CALLBACK_URL}
      */
     @Operation(
-            summary = "[role:admin] " + DELETE_DESC,
+            summary = "[role:pnc-users-build-delete, pnc-users-build-admin, pnc-users-admin] " + DELETE_DESC,
             description = DELETE_DESC2,
             tags = SwaggerConstants.TAG_INTERNAL,
             responses = { @ApiResponse(responseCode = ACCEPTED_CODE, description = ACCEPTED_DESCRIPTION),
@@ -198,7 +198,7 @@ public interface BuildEndpoint {
      * @param build
      */
     @Operation(
-            summary = "[role:admin] " + UPDATE_DESC,
+            summary = "[role:pnc-users-build-admin, pnc-users-admin] " + UPDATE_DESC,
             tags = SwaggerConstants.TAG_INTERNAL,
             responses = { @ApiResponse(responseCode = ENTITY_UPDATED_CODE, description = ENTITY_UPDATED_DESCRIPTION),
                     @ApiResponse(
@@ -257,7 +257,7 @@ public interface BuildEndpoint {
      * @param artifactIds {@value ARTIFACT_IDS}
      */
     @Operation(
-            summary = "[role:admin] " + SET_BUILT_ARTIFACTS,
+            summary = "[role:pnc-users-build-admin, pnc-users-admin] " + SET_BUILT_ARTIFACTS,
             tags = SwaggerConstants.TAG_INTERNAL,
             responses = {
                     @ApiResponse(
@@ -278,7 +278,7 @@ public interface BuildEndpoint {
             @Parameter(description = B_ID) @PathParam("id") String id,
             @Parameter(description = ARTIFACT_IDS) List<String> artifactIds);
 
-    static final String CREATE_BUILT_ARTIFACTS_QUALITY_REVISION = "Add a new quality level revision for the built artifacts of this build. Accepted values from standard users are NEW, VERIFIED, TESTED, DEPRECATED. Users with system-user role can also specify BLACKLISTED and DELETED quality levels.";
+    static final String CREATE_BUILT_ARTIFACTS_QUALITY_REVISION = "Add a new quality level revision for the built artifacts of this build. Accepted values from standard users are NEW, VERIFIED, TESTED, DEPRECATED. Users with pnc-users-artifact-admin, pnc-users-build-admin, pnc-users-admin role can also specify BLACKLISTED and DELETED quality levels.";
     static final String ARTIFACT_QUALITY = "Quality level of the artifact.";
     static final String ARTIFACT_QUALITY_REASON = "The reason for adding a new quality level for this artifact.";
 
@@ -351,7 +351,7 @@ public interface BuildEndpoint {
      * @param artifactIds {@value ARTIFACT_IDS}
      */
     @Operation(
-            summary = "[role:admin] " + SET_DEPENDANT_ARTIFACTS_DESC,
+            summary = "[role:pnc-users-build-admin, pnc-users-admin] " + SET_DEPENDANT_ARTIFACTS_DESC,
             tags = SwaggerConstants.TAG_INTERNAL,
             responses = {
                     @ApiResponse(

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/EnvironmentEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/EnvironmentEndpoint.java
@@ -126,7 +126,7 @@ public interface EnvironmentEndpoint {
      * @return
      */
     @Operation(
-            summary = "[role:admin] " + CREATE_NEW_DESC,
+            summary = "[role:pnc-users-environment-admin, pnc-users-admin] " + CREATE_NEW_DESC,
             responses = {
                     @ApiResponse(
                             responseCode = ENTITY_CREATED_CODE,
@@ -153,7 +153,7 @@ public interface EnvironmentEndpoint {
      *
      */
     @Operation(
-            summary = "[role:admin] " + DEPRECATE_DESC,
+            summary = "[role:pnc-users-environment-admin, pnc-users-admin] " + DEPRECATE_DESC,
             responses = {
                     @ApiResponse(
                             responseCode = SUCCESS_CODE,

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/GenericSettingEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/GenericSettingEndpoint.java
@@ -175,7 +175,7 @@ public interface GenericSettingEndpoint {
     @Path("in-maintenance-mode")
     Boolean isInMaintenanceMode();
 
-    static final String IS_USER_ALLOWED_TO_TRIGGER_BUILDS_DESC = "Provides information whether the current user is allowed to trigger builds (system-users are always allowed, other users only if maintenance mode is off)";
+    static final String IS_USER_ALLOWED_TO_TRIGGER_BUILDS_DESC = "Provides information whether the current user is allowed to trigger builds (pnc-users-admin are always allowed, other users only if maintenance mode is off)";
 
     /**
      * {@value IS_USER_ALLOWED_TO_TRIGGER_BUILDS_DESC}
@@ -210,7 +210,7 @@ public interface GenericSettingEndpoint {
      * @param reason {@value MAINTENANCE_REASON}
      */
     @Operation(
-            summary = "[role:admin] " + ACTIVATE_MAINTENANCE_MODE_DESC,
+            summary = "[role:pnc-users-admin] " + ACTIVATE_MAINTENANCE_MODE_DESC,
             responses = { @ApiResponse(responseCode = ENTITY_UPDATED_CODE, description = ENTITY_UPDATED_DESCRIPTION),
                     @ApiResponse(
                             responseCode = INVALID_CODE,
@@ -230,7 +230,7 @@ public interface GenericSettingEndpoint {
      * {@value DEACTIVATE_MAINTENANCE_MODE_DESC} {@value SwaggerConstants#REQUIRES_ADMIN}
      */
     @Operation(
-            summary = "[role:admin] " + DEACTIVATE_MAINTENANCE_MODE_DESC,
+            summary = "[role:pnc-users-admin] " + DEACTIVATE_MAINTENANCE_MODE_DESC,
             responses = { @ApiResponse(responseCode = ENTITY_UPDATED_CODE, description = ENTITY_UPDATED_DESCRIPTION),
                     @ApiResponse(
                             responseCode = INVALID_CODE,

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/OperationEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/OperationEndpoint.java
@@ -111,7 +111,7 @@ public interface OperationEndpoint {
      * @return
      */
     @Operation(
-            summary = "[role:admin] " + UPDATE_DEL_ANALYZER_DESC,
+            summary = "[role:pnc-users-admin] " + UPDATE_DEL_ANALYZER_DESC,
             tags = SwaggerConstants.TAG_INTERNAL,
             responses = { @ApiResponse(responseCode = ENTITY_UPDATED_CODE, description = ENTITY_UPDATED_DESCRIPTION),
                     @ApiResponse(

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/TargetRepositoryEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/TargetRepositoryEndpoint.java
@@ -136,7 +136,7 @@ public interface TargetRepositoryEndpoint {
      * @return created target repository
      */
     @Operation(
-            summary = "[role:admin] " + CREATE_NEW_DESC,
+            summary = "[role:pnc-users-build-admin, pnc-users-artifact-admin, pnc-users-admin] " + CREATE_NEW_DESC,
             responses = {
                     @ApiResponse(
                             responseCode = ENTITY_CREATED_CODE,

--- a/rest/src/main/webconfig/auth/web.xml
+++ b/rest/src/main/webconfig/auth/web.xml
@@ -29,14 +29,19 @@
         <auth-method>KEYCLOAK</auth-method>
         <realm-name>this is ignored currently</realm-name>
     </login-config>
-
     <security-role>
-        <role-name>admin</role-name>
+        <role-name>pnc-users-build-delete</role-name>
     </security-role>
     <security-role>
-        <role-name>user</role-name>
+        <role-name>pnc-users-build-admin</role-name>
     </security-role>
     <security-role>
-        <role-name>system-user</role-name>
+        <role-name>pnc-users-artifact-admin</role-name>
+    </security-role>
+    <security-role>
+        <role-name>pnc-users-environment-admin</role-name>
+    </security-role>
+    <security-role>
+        <role-name>pnc-users-admin</role-name>
     </security-role>
 </web-app>


### PR DESCRIPTION
The roles are:
- pnc-users-artifact-admin: can do any actions with artifact endpoint
- pnc-users-build-admin: can do any actions with build enpodint
- pnc-users-build-delete: can delete temporary builds only
- pnc-users-environment-admin: can do any actions with environment endpoint
- pnc-users-admin: pnc human admins

### Checklist:

* [ ] Have you added unit tests for your change?
