### PR TITLE
Remove requirement to be authenticated for HEAD requests

### DIFF
--- a/rest/src/main/java/org/jboss/pnc/rest/SecurityConstraintFilter.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/SecurityConstraintFilter.java
@@ -55,13 +55,9 @@ public class SecurityConstraintFilter implements ContainerRequestFilter {
                 && Strings.anyStringEquals(method, HttpMethod.GET) && !userService.isUserLoggedIn()) {
             throw new NotAuthorizedException("Authorization required to access this resource.");
         }
-        if (path.matches("/.*") && Strings.anyStringEquals(
-                method,
-                HttpMethod.POST,
-                HttpMethod.PUT,
-                HttpMethod.DELETE,
-                HttpMethod.HEAD,
-                HttpMethod.PATCH) && !userService.isUserLoggedIn()) {
+        if (path.matches("/.*")
+                && Strings.anyStringEquals(method, HttpMethod.POST, HttpMethod.PUT, HttpMethod.DELETE, HttpMethod.PATCH)
+                && !userService.isUserLoggedIn()) {
             throw new NotAuthorizedException("Authorization required to access this resource.");
         }
     }


### PR DESCRIPTION
Thanks to @michalovan for pointing this out!

HEAD requests will erturn HTTP headers from the server as if the document was requested using the HTTP GET method [1]

Since we don't require authentication in this filter for GET requests, we shouldn't also require authentication for HEAD requests.

[1]: https://reqbin.com/Article/HttpHead

### Checklist:

* [ ] Have you added unit tests for your change?
