### PR TITLE
[NCL-6729] Update defaultAlignmentParam on BuildType change

### DIFF
--- a/facade/src/main/java/org/jboss/pnc/facade/providers/BuildConfigurationProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/BuildConfigurationProviderImpl.java
@@ -22,6 +22,7 @@ import org.jboss.pnc.common.alignment.ranking.AlignmentRanking;
 import org.jboss.pnc.common.alignment.ranking.exception.ValidationException;
 import org.jboss.pnc.common.alignment.ranking.tokenizer.QualifierToken;
 import org.jboss.pnc.common.alignment.ranking.tokenizer.Token;
+import org.jboss.pnc.common.json.moduleconfig.AlignmentConfig;
 import org.jboss.pnc.common.logging.MDCUtils;
 import org.jboss.pnc.dto.AlignmentStrategy;
 import org.jboss.pnc.dto.BuildConfiguration;
@@ -193,6 +194,9 @@ public class BuildConfigurationProviderImpl extends
     @Inject
     private UserMapper userMapper;
 
+    @Inject
+    private AlignmentConfig alignmentConfig;
+
     private static final SCMRepository FAKE_REPOSITORY = SCMRepository.builder().id("-1").build();
 
     @Inject
@@ -232,6 +236,12 @@ public class BuildConfigurationProviderImpl extends
             org.jboss.pnc.model.User currentUser = userService.currentUser();
             dbEntity.setLastModificationUser(currentUser);
             dbEntity.setLastModificationTime(new Date());
+        }
+
+        // NCL-6729: Update the alignment parameters if the build type is changed
+        if (restEntity.getBuildType() != dbEntity.getBuildType()) {
+            dbEntity.setDefaultAlignmentParams(
+                    alignmentConfig.getAlignmentParameters().get(restEntity.getBuildType().toString()));
         }
     }
 

--- a/integration-test/src/test/resources/pnc-config.json
+++ b/integration-test/src/test/resources/pnc-config.json
@@ -42,9 +42,9 @@
           "@module-config": "alignment-config",
           "alignmentParameters" : {
             "MVN" : "-DdependencySource=REST -DrepoRemovalBackup=repositories-backup.xml -DversionSuffixStrip= -DreportNonAligned=true",
-            "NPM" : "",
+            "NPM" : "-Dnpm=setup",
             "GRADLE": "--info -DdependencySource=REST -DrepoRemovalBackup=repositories-backup.xml -DignoreUnresolvableDependencies=true",
-            "SBT" : ""
+            "SBT" : "-Dsbt=setup"
           }
         },
         {


### PR DESCRIPTION
This refers to updates on the BuildConfiguration entity.

Pre-amble
---------
The flow when creating a new entity in PNC is:

```
Endpoint#createNew -> EndpointHelper#create ->
  Provider#store -> Repository#save
```

For updating an entity, we typically just obtain the entity from the DB and update the field. The `Repository#save` method is not called.

The logic to set the `BuildConfiguration`'s default alignment parameters based on the build type is in `BuildConfigurationRepositoryImpl#save`.

Issue
-----
However, since the `save` method is only called for creating new entities but not for updates, the logic to set the default alignment parameters (and global align strategies) is not called for updates.

Fix
---
The fix is to add the logic to set the proper default alignment parameters on updates in the `preUpdate` method, if the build type changes.

An integration test is also added to make sure the desired action is performed.

### Checklist:

* [x] Have you added unit tests for your change?
