### PR TITLE
[v2.6][NCL-6729] Update defaultAlignmentParam on BuildType change

### DIFF
--- a/facade/src/main/java/org/jboss/pnc/facade/providers/BuildConfigurationProviderImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/BuildConfigurationProviderImpl.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.facade.providers;
 
+import org.jboss.pnc.common.json.moduleconfig.AlignmentConfig;
 import org.jboss.pnc.common.logging.MDCUtils;
 import org.jboss.pnc.dto.BuildConfiguration;
 import org.jboss.pnc.dto.BuildConfigurationRef;
@@ -157,6 +158,9 @@ public class BuildConfigurationProviderImpl extends
     @Inject
     private UserMapper userMapper;
 
+    @Inject
+    private AlignmentConfig alignmentConfig;
+
     private static final SCMRepository FAKE_REPOSITORY = SCMRepository.builder().id("-1").build();
 
     @Inject
@@ -196,6 +200,12 @@ public class BuildConfigurationProviderImpl extends
             org.jboss.pnc.model.User currentUser = userService.currentUser();
             dbEntity.setLastModificationUser(currentUser);
             dbEntity.setLastModificationTime(new Date());
+        }
+
+        // NCL-6729: Update the alignment parameters if the build type is changed
+        if (restEntity.getBuildType() != dbEntity.getBuildType()) {
+            dbEntity.setDefaultAlignmentParams(
+                    alignmentConfig.getAlignmentParameters().get(restEntity.getBuildType().toString()));
         }
     }
 

--- a/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/BuildConfigurationEndpointTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/BuildConfigurationEndpointTest.java
@@ -200,6 +200,7 @@ public class BuildConfigurationEndpointTest {
 
         assertThat(bc.getCreationTime()).isNotNull();
         assertThat(bc.getModificationTime()).isNotNull();
+        assertThat(bc.getDefaultAlignmentParams()).isNotNull();
     }
 
     @Test
@@ -315,6 +316,72 @@ public class BuildConfigurationEndpointTest {
         assertThat(updatedBC.getEnvironment().getId()).isEqualTo(environmentId);
         assertThat(modificationTime).isNotEqualTo(updatedBC.getModificationTime());
         assertThat(updatedBC.getBrewPullActive()).isTrue();
+    }
+
+    /**
+     * When the build type changes, the default alignment parameters should also change to the specific type
+     *
+     * @throws ClientException
+     */
+    @Test
+    @InSequence(40)
+    public void shouldUpdateBuildConfigurationAndDefaultAlignmentParamsOnBuildTypeUpdate() throws ClientException {
+        BuildConfiguration bc = createBuildConfigurationAndValidateResults(
+                projectId,
+                environmentId,
+                repositoryConfigurationId,
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString());
+
+        // Make sure original bc is for type Maven
+        assertThat(bc.getBuildType()).isEqualTo(BuildType.MVN);
+
+        String oldDefaultAlignmentParams = bc.getDefaultAlignmentParams();
+
+        // we then change the type to Gradle
+        BuildConfiguration bcToUpdate = bc.toBuilder().buildType(BuildType.GRADLE).build();
+
+        // when
+        BuildConfigurationClient client = new BuildConfigurationClient(RestClientConfiguration.asUser());
+        client.update(bc.getId(), bcToUpdate);
+
+        BuildConfiguration updatedBC = client.getSpecific(bc.getId());
+        // then
+        assertThat(updatedBC.getDefaultAlignmentParams()).isNotNull();
+        assertThat(updatedBC.getDefaultAlignmentParams()).isNotBlank();
+        assertThat(oldDefaultAlignmentParams).isNotEqualTo(updatedBC.getDefaultAlignmentParams());
+    }
+
+    /**
+     * Check that if the build type is the same on an update, the default alignment params also will not change
+     *
+     * @throws ClientException
+     */
+    @Test
+    @InSequence(50)
+    public void testUpdateBuildConfigWontChangeDefaultBuildType() throws ClientException {
+        BuildConfiguration bc = createBuildConfigurationAndValidateResults(
+                projectId,
+                environmentId,
+                repositoryConfigurationId,
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString());
+
+        // Make sure original bc is for type Maven
+        assertThat(bc.getBuildType()).isEqualTo(BuildType.MVN);
+
+        String oldDefaultAlignmentParams = bc.getDefaultAlignmentParams();
+
+        // we only update the build script, and keep the build type the same
+        BuildConfiguration bcToUpdate = bc.toBuilder().buildScript("mvn mvn my mvn").build();
+
+        // when
+        BuildConfigurationClient client = new BuildConfigurationClient(RestClientConfiguration.asUser());
+        client.update(bc.getId(), bcToUpdate);
+
+        BuildConfiguration updatedBC = client.getSpecific(bc.getId());
+        // then: since the build type didn't change, the default alignment params should also stay the same
+        assertThat(bc.getDefaultAlignmentParams()).isEqualTo(updatedBC.getDefaultAlignmentParams());
     }
 
     @Test

--- a/integration-test/src/test/resources/pnc-config.json
+++ b/integration-test/src/test/resources/pnc-config.json
@@ -38,9 +38,9 @@
           "@module-config": "alignment-config",
           "alignmentParameters" : {
             "MVN" : "-DdependencySource=REST -DrepoRemovalBackup=repositories-backup.xml -DversionSuffixStrip= -DreportNonAligned=true",
-            "NPM" : "",
+            "NPM" : "-Dnpm=setup",
             "GRADLE": "--info -DdependencySource=REST -DrepoRemovalBackup=repositories-backup.xml -DignoreUnresolvableDependencies=true",
-            "SBT" : ""
+            "SBT" : "-Dsbt=setup"
           }
         },
         {


### PR DESCRIPTION
This refers to updates on the BuildConfiguration entity.

Pre-amble
---------
The flow when creating a new entity in PNC is:

```
Endpoint#createNew -> EndpointHelper#create ->
  Provider#store -> Repository#save
```

For updating an entity, we typically just obtain the entity from the DB and update the field. The `Repository#save` method is not called.

The logic to set the `BuildConfiguration`'s default alignment parameters based on the build type is in `BuildConfigurationRepositoryImpl#save`.

Issue
-----
However, since the `save` method is only called for creating new entities but not for updates, the logic to set the default alignment parameters (and global align strategies) is not called for updates.

Fix
---
The fix is to add the logic to set the proper default alignment parameters on updates in the `preUpdate` method, if the build type changes.

An integration test is also added to make sure the desired action is performed.

### Checklist:

* [ ] Have you added unit tests for your change?
