### PR TITLE
Drop unique constrain on User's email

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/User.java
+++ b/model/src/main/java/org/jboss/pnc/model/User.java
@@ -64,7 +64,6 @@ public class User implements GenericEntity<Integer> {
     private Integer id;
 
     // [NCLSUP-598] Do not use email validation @Email since emails used for Krb service account are malformed emails
-    @Column(unique = true)
     @Size(max = 255)
     private String email;
 

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/UserPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/UserPredicates.java
@@ -30,8 +30,4 @@ public class UserPredicates {
         return (root, query, cb) -> cb.equal(root.get(User_.username), name);
     }
 
-    public static Predicate<User> withEmail(String email) {
-        return (root, query, cb) -> cb.equal(root.get(User_.email), email);
-    }
-
 }


### PR DESCRIPTION
We use several account like `service-account-pnc-one` and `service-account-pnc-two` which all use the same email e.g. `pnc-service@example.com`.

Alternatively, we could use accounts with emails like `pnc-service+one@example.com` and `pnc-service+two@example.com`, but that would mean changing bunch of accounts. 
