### PR TITLE
Fix integer overflow error in TimeUtils

### DIFF
--- a/common/src/main/java/org/jboss/pnc/common/util/TimeUtils.java
+++ b/common/src/main/java/org/jboss/pnc/common/util/TimeUtils.java
@@ -125,8 +125,7 @@ public class TimeUtils {
      * @return New Date object representing a timestamp X days before now
      */
     public static Date getDateXDaysAgo(int numberOfDays) {
-        long unixMilisecondsExpirationThreshold = new Date().getTime() - (1000 * 60 * 60 * 24 * numberOfDays);
-        return new Date(unixMilisecondsExpirationThreshold);
+        return new Date(Instant.now().minus(numberOfDays, ChronoUnit.DAYS).toEpochMilli());
     }
 
     public static Instant toInstant(Date date) {

--- a/common/src/test/java/org/jboss/pnc/common/util/TimeUtilsTest.java
+++ b/common/src/test/java/org/jboss/pnc/common/util/TimeUtilsTest.java
@@ -1,0 +1,40 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.common.util;
+
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TimeUtilsTest {
+
+    @Test
+    public void testGetDateXDaysAgo() {
+
+        Date oldDate = TimeUtils.getDateXDaysAgo(200);
+        Date current = new Date();
+        assertThat(oldDate.before(current)).isTrue();
+
+        long diffInMillies = Math.abs(current.getTime() - oldDate.getTime());
+        long diff = TimeUnit.DAYS.convert(diffInMillies, TimeUnit.MILLISECONDS);
+        assertThat(diff).isEqualTo(200L);
+    }
+}


### PR DESCRIPTION
In TimeUtils.getDateXDaysAgo, there's a bug where a big int number is multiplied by another number. The final int overflows if the "other number" is greater than 21 and the getDateXDaysAgo returns a wrong date.

This commit fixes this.

### Checklist:

* [ ] Have you added unit tests for your change?
