### PR TITLE
[NCL-8487] Use the tokenSupplier to get token

### DIFF
--- a/processor/src/main/java/org/jboss/pnc/processor/ClientGenerator.java
+++ b/processor/src/main/java/org/jboss/pnc/processor/ClientGenerator.java
@@ -362,7 +362,7 @@ public class ClientGenerator extends AbstractProcessor {
         methodBuilder = methodBuilder.nextControlFlow("catch ($T e)", NotAuthorizedException.class)
                 .beginControlFlow("if (configuration.getBearerTokenSupplier() != null)")
                 .beginControlFlow("try")
-                .addStatement("bearerAuthentication.setToken(configuration.getBearerTokenSupplier().get())");
+                .addStatement("bearerAuthentication.setTokenSupplier(configuration.getBearerTokenSupplier())");
 
         coreStatementConsumer.accept(methodBuilder);
 

--- a/rest-api/src/main/java/org/jboss/pnc/client/BearerAuthentication.java
+++ b/rest-api/src/main/java/org/jboss/pnc/client/BearerAuthentication.java
@@ -21,6 +21,7 @@ import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.core.HttpHeaders;
 import java.io.IOException;
+import java.util.function.Supplier;
 
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
@@ -28,18 +29,38 @@ import java.io.IOException;
  */
 public class BearerAuthentication implements ClientRequestFilter {
 
-    private String token;
+    private Supplier<String> tokenSupplier;
 
+    /**
+     * Not used anymore in pnc-rest-client. Candidate for removal in PNC 3.0+
+     * 
+     * @param token
+     */
+    @Deprecated
     public BearerAuthentication(String token) {
-        this.token = token;
+        this.tokenSupplier = () -> token;
     }
 
+    public BearerAuthentication(Supplier<String> tokenSupplier) {
+        this.tokenSupplier = tokenSupplier;
+    }
+
+    /**
+     * Not used anymore in pnc-rest-client. Candidate for removal in PNC 3.0+
+     * 
+     * @param token
+     */
+    @Deprecated
     public void setToken(String token) {
-        this.token = token;
+        this.tokenSupplier = () -> token;
+    }
+
+    public void setTokenSupplier(Supplier<String> tokenSupplier) {
+        this.tokenSupplier = tokenSupplier;
     }
 
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
-        requestContext.getHeaders().putSingle(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        requestContext.getHeaders().putSingle(HttpHeaders.AUTHORIZATION, "Bearer " + tokenSupplier.get());
     }
 }

--- a/rest-api/src/main/java/org/jboss/pnc/client/ClientBase.java
+++ b/rest-api/src/main/java/org/jboss/pnc/client/ClientBase.java
@@ -87,12 +87,12 @@ public abstract class ClientBase<T> implements Closeable {
             target.register(new BasicAuthentication(basicAuth.getUsername(), basicAuth.getPassword()));
         } else {
             if (configuration.getBearerTokenSupplier() != null) {
-                bearerAuthentication = new BearerAuthentication(configuration.getBearerTokenSupplier().get());
+                bearerAuthentication = new BearerAuthentication(configuration.getBearerTokenSupplier());
                 target.register(bearerAuthentication);
             } else {
                 String bearerToken = configuration.getBearerToken();
                 if (bearerToken != null && !bearerToken.isEmpty()) {
-                    bearerAuthentication = new BearerAuthentication(bearerToken);
+                    bearerAuthentication = new BearerAuthentication(() -> bearerToken);
                     target.register(bearerAuthentication);
                 }
             }

--- a/rest-api/src/test/java/org/jboss/pnc/client/ClientTest.java
+++ b/rest-api/src/test/java/org/jboss/pnc/client/ClientTest.java
@@ -85,20 +85,6 @@ public class ClientTest {
     }
 
     @Test
-    public void shouldGenerateTokenUsingSupplier() {
-        final TokenGenerator tokenGenerator = new TokenGenerator();
-
-        // given
-        Configuration configuration = getBasicConfiguration(8081).bearerTokenSupplier(tokenGenerator::getToken).build();
-
-        // when
-        new BuildClient(configuration);
-
-        // then
-        Assert.assertEquals(1, tokenGenerator.getInvocationCount());
-    }
-
-    @Test
     public void shouldRefreshTokenIfNotAuthorized() throws RemoteResourceException {
         final TokenGenerator tokenGenerator = new TokenGenerator();
 


### PR DESCRIPTION
Use the tokenSupplier to get a token for the PNC REST client on every request. The advantage is that the token supplier has the ability to refresh the token before it expires.

The old method relied on using a hardcoded token string, which will expire if the request takes more than 5 minutes and everything fails afterwards.

The old "hardcoded token string" method is still supported but now deprecated.

### Checklist:

* [ ] Have you added unit tests for your change?
