### PR TITLE
Improve GitSCPUrl parsing and error message

### DIFF
--- a/common/src/main/java/org/jboss/pnc/common/net/GitSCPUrl.java
+++ b/common/src/main/java/org/jboss/pnc/common/net/GitSCPUrl.java
@@ -33,8 +33,21 @@ public class GitSCPUrl {
     private final String owner;
     private final String repositoryName;
 
+    /**
+     * Gitlab naming convention:
+     *
+     * Must start with a lowercase or uppercase letter, digit, emoji, or underscore. Can also contain dots, pluses,
+     * dashes, or spaces.
+     *
+     * Java's \w covers [a-zA-Z_0-9] : lower, uppercase letter, digit, underscore
+     *
+     * We're not going to "support" emoji in our regex because it's a landmine. I don't think we'll have repos using
+     * emojis :)
+     *
+     * We're also not adding space on the regex. Maybe we should in the future?
+     */
     private static Pattern scpPattern = Pattern.compile(
-            "^((?<user>\\w+)@)?(?<host>[-.\\w]+)[:/]{1,2}(?<path>((?<owner>[-\\w]+)/)*((?<reponame>[-\\w]+)(.git)?))[/]?$");
+            "^((?<user>\\w+)@)?(?<host>[-.+\\w]+)[:/]{1,2}(?<path>((?<owner>[-.+\\w]+)/)*(?<reponame>[-.+\\w]+))[/]?$");
 
     private GitSCPUrl(String user, String host, String path, String owner, String repositoryName) {
         this.user = user;
@@ -59,7 +72,7 @@ public class GitSCPUrl {
                 matcher.group("host"),
                 matcher.group("path"),
                 matcher.group("owner"),
-                matcher.group("reponame"));
+                matcher.group("reponame").replaceAll(".git$", ""));
     }
 
     public String getUser() {

--- a/common/src/main/java/org/jboss/pnc/common/util/UrlUtils.java
+++ b/common/src/main/java/org/jboss/pnc/common/util/UrlUtils.java
@@ -95,18 +95,21 @@ public final class UrlUtils {
         return map;
     }
 
-    public static String keepHostAndPathOnly(String url) {
+    public static String keepHostAndPathOnly(String originalUrl) {
+
+        String urlWithScheme = originalUrl;
+
         // workaround to properly parse url. Without schema and available port, URI.create fails to parse
-        if (!url.contains("://")) {
-            url = "http://" + url;
+        if (!urlWithScheme.contains("://")) {
+            urlWithScheme = "http://" + urlWithScheme;
         }
 
         // if the url ends with slash, delete it
-        if (url.endsWith("/")) {
-            url = url.substring(0, url.length() - 1);
+        if (urlWithScheme.endsWith("/")) {
+            urlWithScheme = urlWithScheme.substring(0, urlWithScheme.length() - 1);
         }
 
-        URI uri = URI.create(url);
+        URI uri = URI.create(urlWithScheme);
         String host = uri.getHost();
         String path = uri.getPath();
 
@@ -115,10 +118,10 @@ public final class UrlUtils {
         // of urls. (NCL-5990)
         if (host == null) {
             try {
-                return GitSCPUrl.parse(StringUtils.stripProtocol(url)).getHostWithPath();
+                return GitSCPUrl.parse(originalUrl).getHostWithPath();
             } catch (MalformedURLException e) {
                 throw new IllegalArgumentException(
-                        "Supplied URL:" + url + " is neither regular URI nor in Git SCP-style format.",
+                        "Supplied URL:" + originalUrl + " is neither regular URI nor in Git SCP-style format.",
                         e);
             }
         }

--- a/common/src/test/java/org/jboss/pnc/common/net/GitSCPUrlTest.java
+++ b/common/src/test/java/org/jboss/pnc/common/net/GitSCPUrlTest.java
@@ -153,4 +153,18 @@ public class GitSCPUrlTest {
         assertThatThrownBy(() -> GitSCPUrl.parse("git://lots.of.domains.github.com/gerrit/c3p0.git"))
                 .isInstanceOf(MalformedURLException.class);
     }
+
+    /**
+     * Gitlab naming convention:
+     *
+     * Must start with a lowercase or uppercase letter, digit, emoji, or underscore. Can also contain dots, pluses,
+     * dashes, or spaces.
+     */
+    @Test
+    public void testSpecialCases() throws Exception {
+
+        GitSCPUrl url = GitSCPUrl.parse("git@gitlab:pnc-here/Ecli+p_se/vert5.x.git");
+        assertThat(url.getOwner()).isEqualTo("Ecli+p_se");
+        assertThat(url.getRepositoryName()).isEqualTo("vert5.x");
+    }
 }


### PR DESCRIPTION
Improve GitSCPUrl parsing
=========================
This is done by adapting the regex for GitSCPUrl to satisfy the naming requirements for Gitlab.

Improve error message
=====================
If there was an error with the internal repository url, and it was in SCP format, the error message on the UI would say:

```
Supplied URL:http://git@gitlab:work/owner1/repo.git is neither regular URI nor in Git SCP-style format.""
```

Instead, this is changed to show the original url in scp-style:

```
Supplied URL:git@gitlab:work/owner1/repo.git is neither regular URI nor in Git SCP-style format.""
```

### Checklist:

* [x] Have you added unit tests for your change?
