### PR TITLE
Reuse operation's user when storing scratch Deliverables Analysis

### DIFF
--- a/facade/src/main/java/org/jboss/pnc/facade/deliverables/DeliverableAnalyzerManagerImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/deliverables/DeliverableAnalyzerManagerImpl.java
@@ -143,8 +143,6 @@ public class DeliverableAnalyzerManagerImpl implements org.jboss.pnc.facade.Deli
     private ArtifactMapper artifactMapper;
     @Inject
     private OperationsManager operationsManager;
-    @Inject
-    private UserService userService;
 
     @Inject
     private KeycloakServiceClient keycloakServiceClient;
@@ -407,15 +405,6 @@ public class DeliverableAnalyzerManagerImpl implements org.jboss.pnc.facade.Deli
                 .build();
         deliverableAnalyzerLabelEntryRepository.save(labelHistoryEntry);
         report.getLabelHistory().add(labelHistoryEntry);
-    }
-
-    public Consumer<org.jboss.pnc.model.Artifact> artifactUpdater(String message) {
-        User user = userService.currentUser();
-        return a -> {
-            a.setQualityLevelReason(message);
-            a.setModificationUser(user);
-            a.setModificationTime(new Date());
-        };
     }
 
     private Optional<org.jboss.pnc.model.Artifact> getBestMatchingArtifact(

--- a/facade/src/main/java/org/jboss/pnc/facade/deliverables/DeliverableAnalyzerManagerImpl.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/deliverables/DeliverableAnalyzerManagerImpl.java
@@ -400,7 +400,7 @@ public class DeliverableAnalyzerManagerImpl implements org.jboss.pnc.facade.Deli
                 .report(report)
                 .changeOrder(1)
                 .entryTime(Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant()))
-                .user(userService.currentUser())
+                .user(report.getOperation().getUser())
                 .reason("Analysis run as scratch.")
                 .change(LabelOperation.ADDED)
                 .label(DeliverableAnalyzerReportLabel.SCRATCH)


### PR DESCRIPTION
This is run in async code and executed with BPM's system user, so calling UserService is both wrong and broken.

### Checklist:

* [ ] Have you added unit tests for your change?
