### PR TITLE
[NCLSUP-1175] Fix temporary build cleanup

### DIFF
--- a/remote-build-coordinator/src/main/java/org/jboss/pnc/remotecoordinator/maintenance/DefaultRemoteBuildsCleaner.java
+++ b/remote-build-coordinator/src/main/java/org/jboss/pnc/remotecoordinator/maintenance/DefaultRemoteBuildsCleaner.java
@@ -70,19 +70,23 @@ public class DefaultRemoteBuildsCleaner implements RemoteBuildsCleaner {
 
     private final String tempBuildPromotionGroup;
 
-    private final Indy indy;
+    private final IndyFactory indyFactory;
+
+    private final RefreshingIndyAuthenticator refreshingIndyAuthenticator;
 
     @Inject
     public DefaultRemoteBuildsCleaner(
             Configuration configuration,
-            Indy indy,
+            IndyFactory indyFactory,
             KeycloakServiceClient serviceClient,
             CausewayClient causewayClient,
-            BuildRecordPushResultRepository buildRecordPushResultRepository) {
-        this.indy = indy;
+            BuildRecordPushResultRepository buildRecordPushResultRepository,
+            RefreshingIndyAuthenticator refreshingIndyAuthenticator) {
+        this.indyFactory = indyFactory;
         this.serviceClient = serviceClient;
         this.causewayClient = causewayClient;
         this.buildRecordPushResultRepository = buildRecordPushResultRepository;
+        this.refreshingIndyAuthenticator = refreshingIndyAuthenticator;
 
         IndyRepoDriverModuleConfig config;
         try {
@@ -141,7 +145,7 @@ public class DefaultRemoteBuildsCleaner implements RemoteBuildsCleaner {
                     "BuildContentId is null. Nothing to be deleted from Indy.");
         }
 
-        try {
+        try (Indy indy = indyFactory.get(refreshingIndyAuthenticator)) {
             IndyStoresClientModule indyStores = indy.stores();
             if (pkgKey != null) {
                 // delete artifacts from consolidated repository

--- a/remote-build-coordinator/src/main/java/org/jboss/pnc/remotecoordinator/maintenance/IndyFactory.java
+++ b/remote-build-coordinator/src/main/java/org/jboss/pnc/remotecoordinator/maintenance/IndyFactory.java
@@ -46,7 +46,6 @@ public class IndyFactory {
 
     private Integer defaultRequestTimeout;
     private String baseUrl;
-    private Indy indy;
 
     @Deprecated // CDI workaround
     public IndyFactory() {
@@ -65,17 +64,9 @@ public class IndyFactory {
 
     @PreDestroy
     void clean() {
-        if (indy != null) {
-            indy.close();
-        }
     }
 
-    @Produces
     public Indy get(IndyClientAuthenticator authenticator) {
-        if (indy != null) {
-            return indy;
-        }
-
         try {
             IndyClientModule[] modules = new IndyClientModule[] { new IndyFoloAdminClientModule(),
                     new IndyPromoteClientModule(), new IndyPromoteAdminClientModule() };
@@ -86,14 +77,13 @@ public class IndyFactory {
                     .withMaxConnections(IndyClientHttp.GLOBAL_MAX_CONNECTIONS)
                     .build();
 
-            this.indy = new Indy(
+            return new Indy(
                     siteConfig,
                     authenticator,
                     new IndyObjectMapper(true),
                     MDCUtils.HEADER_KEY_MAPPING,
                     modules);
 
-            return this.indy;
         } catch (IndyClientException e) {
             throw new IllegalStateException("Failed to create Indy client: " + e.getMessage(), e);
         }


### PR DESCRIPTION
BuildCleaner couldn't delete temporary builds properly since PNC 3.0.x deployment in prod. This is caused because the delete endpoint in PNC would eventually get stuck after some time and not delete anything.

Background
==========
In PNC 2.7.6 and prior, we requested a fresh Indy client object to delete stuff in Indy, as part of the temporary build cleanup. The Indy client object came with its own connection pool
([proof](https://github.com/project-ncl/pnc/blob/7228e8d2af6a6da4bcf23f5c7496dea125c43dab/build-coordinator/src/main/java/org/jboss/pnc/coordinator/maintenance/DefaultRemoteBuildsCleaner.java#L144)).

In PNC 3.0.x, we wanted to reuse the same Indy client object for delete requests so that we can reuse the same connection pool, saving both garbage collection and object/connection creation
([proof](https://github.com/project-ncl/pnc/blob/master/remote-build-coordinator/src/main/java/org/jboss/pnc/remotecoordinator/maintenance/DefaultRemoteBuildsCleaner.java#L82)).

Bug
===
With us properly reusing the same connection pool, it is important to properly close the http resource so that the connection is released back into the pool. Unfortunately, some Indy client requests didn't properly close the http resource and caused the connection pool to dry up. This eventually caused Indy client requests to infinitely wait for a connection to open up.

In PNC 2.7.6, since we always created a new Indy client (with a new connection pool) for each deletion, that meant that even though some connections were never released back to the connection pool after a request, we still luckily had enough leftover available connections in the pool to process all the requests.

The issue is in the
[IndyFoloAdminClientModule#deleteFilesFromStoreByTrackingID](https://github.com/Commonjava/indy/blob/fae50b59eebfc10dcc20ae4e6e7e5cab4db5f09a/addons/folo/client-java/src/main/java/org/commonjava/indy/folo/client/IndyFoloAdminClientModule.java#L115), which uses [IndyClientHttp's postRaw
method](https://github.com/Commonjava/indy/blob/indy-parent-2.5.4.1/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientHttp.java#L503) (I couldn't find it in the master branch, so I'm listing the one in tag 2.5.4.1).

The `postRaw` method doesn't cleanup and hands off the cleanup to the [caller](https://github.com/Commonjava/indy/blob/indy-parent-2.5.4.1/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientHttp.java#L503). Unfortunately, the IndyFoloAdminClientModule doesn't cleanup, which means the http resource is not cleaned up properly, and the connection is not returned to the pool.

I believe there should be an audit of the Indy client codebase to see the usage of *Raw methods and if the http resources are cleaned up afterwards.

Proof
=====
I was able to find this out by enabling debug line code for "org.apache.http.impl" in our EAP server.

```
[2024-11-15T17:49:49.906Z] DEBUG [org.apache.http.impl.execchain.MainClientExec] Connection can be kept alive indefinitely
[2024-11-15T17:49:49.906Z] DEBUG [org.apache.http.impl.conn.PoolingHttpClientConnectionManager] Connection [id: 165][route: {s}->https://<indy url>:443] can be kept alive indefinitely 
[2024-11-15T17:49:49.906Z] DEBUG [org.apache.http.impl.conn.DefaultManagedHttpClientConnection] http-outgoing-165: set socket timeout to 0
[2024-11-15T17:49:49.906Z] DEBUG [org.apache.http.impl.conn.PoolingHttpClientConnectionManager] Connection released: [id: 165][route: {s}->https://<indy url>:443][total available: 1; route allocated: 20 of 20; total allocated: 20 of 20]
```

is the normal output when the http resource is cleaned up properly and returned to the pool.

For the request to POST /api/folo/admin/batch/delete HTTP/1.1, we never see the "Connection released" log, which indicates that each request to that endpoint holds a connection forever. At some point, all the 20 max connections in the pool get stuck and nothing happens anymore.

Fix
===
Go back to the PNC behaviour in PNC 2.7.6 for now, give the Indy team some time to fix those connection leaks, and retry to use the same connection pool in the future.

### Checklist:

* [ ] Have you added unit tests for your change?
