### PR TITLE
Dingrogu integration: pickup buildType from buildconfiguration

### DIFF
--- a/dingrogu-client/src/main/java/org/jboss/pnc/dingroguclient/DingroguClient.java
+++ b/dingrogu-client/src/main/java/org/jboss/pnc/dingroguclient/DingroguClient.java
@@ -69,7 +69,12 @@ public class DingroguClient {
                 .tempBuild(buildTask.getBuildOptions().isTemporaryBuild())
                 .alignmentPreference(buildTask.getBuildOptions().getAlignmentPreference())
                 .buildContentId(contentId)
-                .buildType(BuildType.valueOf(buildTask.getBuildConfigurationAudited().getBuildType().toString()))
+                .buildType(
+                        BuildType.valueOf(
+                                buildTask.getBuildConfigurationAudited()
+                                        .getBuildConfiguration()
+                                        .getBuildType()
+                                        .toString()))
                 .buildCategory(getBuildCategory(buildTask.getBuildConfigurationAudited().getGenericParameters()))
                 .defaultAlignmentParams(buildTask.getBuildConfigurationAudited().getDefaultAlignmentParams())
                 .brewPullActive(buildTask.getBuildConfigurationAudited().isBrewPullActive())


### PR DESCRIPTION
We were picking it from buildConfigurationAudited and that didn't go well.

### Checklist:

* [ ] Have you added unit tests for your change?
