### PR TITLE
[NCLSUP-1175] Revert temporary build cleanup commit

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/maintenance/DefaultRemoteBuildsCleaner.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/maintenance/DefaultRemoteBuildsCleaner.java
@@ -65,7 +65,7 @@ public class DefaultRemoteBuildsCleaner implements RemoteBuildsCleaner {
 
     private Logger logger = LoggerFactory.getLogger(DefaultRemoteBuildsCleaner.class);
 
-    private IndyFactory indyFactory;
+    private final Indy indy;
 
     KeycloakServiceClient serviceClient;
 
@@ -78,11 +78,11 @@ public class DefaultRemoteBuildsCleaner implements RemoteBuildsCleaner {
     @Inject
     public DefaultRemoteBuildsCleaner(
             Configuration configuration,
-            IndyFactory indyFactory,
+            Indy indy,
             KeycloakServiceClient serviceClient,
             CausewayClient causewayClient,
             BuildPushOperationRepository buildPushOperationRepository) {
-        this.indyFactory = indyFactory;
+        this.indy = indy;
         this.serviceClient = serviceClient;
         this.causewayClient = causewayClient;
         this.buildPushOperationRepository = buildPushOperationRepository;
@@ -145,7 +145,6 @@ public class DefaultRemoteBuildsCleaner implements RemoteBuildsCleaner {
                     "BuildContentId is null. Nothing to be deleted from Indy.");
         }
 
-        Indy indy = indyFactory.get(authToken);
         try {
             IndyStoresClientModule indyStores = indy.stores();
             if (pkgKey != null) {

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <!--<version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.2.Final-redhat-1</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>-->
     <version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>
     <atlasVersion>1.1.0</atlasVersion>
-    <indyVersion>2.5.4.1</indyVersion>
+    <indyVersion>3.4.1</indyVersion>
     <version.keycloak>18.0.11.redhat-00001</version.keycloak>
     <version.swagger2>2.2.28</version.swagger2>
     <version.buildagent>1.0.0</version.buildagent>

--- a/remote-build-coordinator/src/main/java/org/jboss/pnc/remotecoordinator/maintenance/DefaultRemoteBuildsCleaner.java
+++ b/remote-build-coordinator/src/main/java/org/jboss/pnc/remotecoordinator/maintenance/DefaultRemoteBuildsCleaner.java
@@ -73,19 +73,19 @@ public class DefaultRemoteBuildsCleaner implements RemoteBuildsCleaner {
 
     private final String tempBuildPromotionGroup;
 
-    private final IndyFactory indyFactory;
+    private final Indy indy;
 
     private final RefreshingIndyAuthenticator refreshingIndyAuthenticator;
 
     @Inject
     public DefaultRemoteBuildsCleaner(
             Configuration configuration,
-            IndyFactory indyFactory,
+            Indy indy,
             KeycloakServiceClient serviceClient,
             CausewayClient causewayClient,
             BuildPushOperationRepository buildPushOperationRepository,
             RefreshingIndyAuthenticator refreshingIndyAuthenticator) {
-        this.indyFactory = indyFactory;
+        this.indy = indy;
         this.serviceClient = serviceClient;
         this.causewayClient = causewayClient;
         this.buildPushOperationRepository = buildPushOperationRepository;
@@ -149,7 +149,7 @@ public class DefaultRemoteBuildsCleaner implements RemoteBuildsCleaner {
                     "BuildContentId is null. Nothing to be deleted from Indy.");
         }
 
-        try (Indy indy = indyFactory.get(refreshingIndyAuthenticator)) {
+        try {
             IndyStoresClientModule indyStores = indy.stores();
             if (pkgKey != null) {
                 // delete artifacts from consolidated repository

--- a/rest-api/pnc-openapi.json
+++ b/rest-api/pnc-openapi.json
@@ -11692,6 +11692,9 @@
             "type" : "string",
             "enum" : [ "UNKNOWN", "POM", "POM_XML", "BUNDLE_LICENSE", "TEXT" ]
           },
+          "sourceUrl" : {
+            "type" : "string"
+          },
           "spdxLicenseId" : {
             "type" : "string"
           },

--- a/rest-api/pnc-openapi.yaml
+++ b/rest-api/pnc-openapi.yaml
@@ -8331,6 +8331,8 @@ components:
           - POM_XML
           - BUNDLE_LICENSE
           - TEXT
+        sourceUrl:
+          type: string
         spdxLicenseId:
           type: string
         url:


### PR DESCRIPTION
Commit: https://github.com/project-ncl/pnc/commit/581505d822483a4d1ec1dc89375bcb53d36c2a5b

We had to previously revert the change in remote builds cleaner to use a
shared Indy object for deletion of temporary builds.

On paper, the shared Indy object makes a lot of sense since we can
re-use the underlying threadpool for http requests. In practice, the
resource in the thread pool wasn't cleaned up properly and stayed in the
pool. This eventually caused all the threads in the threadpool to be
unavailable and cause further deletions to hang.

We workaround it by switching back to creating an Indy object for every
request.

This is all fixed now in Indy client 3.4.1, so this commit removes the
workaround.

### Checklist:

* [ ] Have you added unit tests for your change?
