### PR TITLE
Rename brewBuildId -> brewId in delAn RSQL Mapper

### DIFF
--- a/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
+++ b/demo-data/src/main/java/org/jboss/pnc/demo/data/DatabaseDataInitializer.java
@@ -1488,7 +1488,7 @@ public class DatabaseDataInitializer {
                 .report(report1)
                 .artifact(importedArtifact2)
                 .builtFromSource(false)
-                .brewBuildId(null)
+                .brewBuildId(42L)
                 .build();
         DeliverableArtifact analyzedArtifact8 = DeliverableArtifact.builder()
                 .report(report2)

--- a/facade/src/main/java/org/jboss/pnc/facade/rsql/mapper/DeliverableArtifactRSQLMapper.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/rsql/mapper/DeliverableArtifactRSQLMapper.java
@@ -51,7 +51,7 @@ public class DeliverableArtifactRSQLMapper extends AbstractRSQLMapper<Deliverabl
     @Override
     protected SingularAttribute<? super DeliverableArtifact, ?> toAttribute(String name) {
         switch (name) {
-            case "brewBuildId":
+            case "brewId":
                 return DeliverableArtifact_.brewBuildId;
             case "builtFromSource":
                 return DeliverableArtifact_.builtFromSource;

--- a/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/DeliverableAnalyzerReportEndpointTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/DeliverableAnalyzerReportEndpointTest.java
@@ -43,6 +43,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -112,8 +113,27 @@ public class DeliverableAnalyzerReportEndpointTest {
 
         AnalyzedArtifact analyzedArtifact1 = it.next();
         assertThat(analyzedArtifact1.isBuiltFromSource()).isFalse();
-        assertThat(analyzedArtifact1.getBrewId()).isNull();
+        assertThat(analyzedArtifact1.getBrewId()).isEqualTo(42L);
         assertThat(analyzedArtifact1.getArtifact().getIdentifier()).isEqualTo("demo:imported-artifact2:jar:1.0");
+    }
+
+    @Test
+    public void testGetAnalyzedArtifactsByBrewId() throws ClientException {
+        // given
+        Long brewId = 42L;
+        DeliverableAnalyzerReportClient client = new DeliverableAnalyzerReportClient(
+                RestClientConfiguration.asAnonymous());
+
+        // when
+        RemoteCollection<AnalyzedArtifact> analyzedArtifacts = client
+                .getAnalyzedArtifacts(operationId, Optional.empty(), Optional.of("brewId==" + brewId.toString()));
+
+        // then
+        assertThat(analyzedArtifacts.size()).isEqualTo(1); // analyzedArtifact7 (from DatabaseDataInitializer)
+
+        Iterator<AnalyzedArtifact> it = analyzedArtifacts.iterator();
+        AnalyzedArtifact analyzedArtifact0 = it.next();
+        assertThat(analyzedArtifact0.getBrewId()).isEqualTo(brewId);
     }
 
     @Test


### PR DESCRIPTION
This change was made to make the name consistent with DTO field, not model field

### Checklist:

* [ ] Have you added unit tests for your change?
