### PR TITLE
Make dingrogu default for build process and add option to configure f…

### DIFF
--- a/common/src/main/java/org/jboss/pnc/common/json/GlobalModuleGroup.java
+++ b/common/src/main/java/org/jboss/pnc/common/json/GlobalModuleGroup.java
@@ -52,6 +52,7 @@ public class GlobalModuleGroup extends AbstractModuleGroup {
      * TODO: remove once we are comfortable with the new process
      */
     public boolean tempUseDingroguRepositoryCreation;
+    public boolean useDingroguBuildProcess;
 
     private String externalEttUrl;
     private String brewContentUrl;
@@ -230,6 +231,14 @@ public class GlobalModuleGroup extends AbstractModuleGroup {
 
     public void setTempUseDingroguRepositoryCreation(boolean tempUseDingroguRepositoryCreation) {
         this.tempUseDingroguRepositoryCreation = tempUseDingroguRepositoryCreation;
+    }
+
+    public boolean isUseDingroguBuildProcess() {
+        return useDingroguBuildProcess;
+    }
+
+    public void setUseDingroguBuildProcess(boolean useDingroguBuildProcess) {
+        this.useDingroguBuildProcess = useDingroguBuildProcess;
     }
 
     public String getExternalLogEventDurationUrl() {

--- a/remote-build-coordinator/src/main/java/org/jboss/pnc/remotecoordinator/builder/RexFacade.java
+++ b/remote-build-coordinator/src/main/java/org/jboss/pnc/remotecoordinator/builder/RexFacade.java
@@ -194,7 +194,7 @@ public class RexFacade implements RexBuildScheduler, BuildTaskRepository {
                                                 temporaryBuild)
                                         .toString());) {
                     CreateTaskDTO create;
-                    if (useDingrogu(buildTask)) {
+                    if (globalConfig.isUseDingroguBuildProcess() && useDingrogu(buildTask)) {
                         create = getCreateNewTaskDingroguDTO(buildTask);
                     } else {
                         create = getCreateNewTaskRHPAMDTO(bpmUrl, buildTask, user);
@@ -503,6 +503,6 @@ public class RexFacade implements RexBuildScheduler, BuildTaskRepository {
 
     private boolean useDingrogu(RemoteBuildTask buildTask) {
         Map<String, String> genericParams = buildTask.getBuildConfigurationAudited().getGenericParameters();
-        return genericParams.containsKey(DINGROGU_PARAMETER_KEY);
+        return !genericParams.containsKey(DINGROGU_PARAMETER_KEY);
     }
 }


### PR DESCRIPTION
…rom pnc config

Until now we used `USE_DINGROGU =  true` (while true is irrelevant) parameter to use dingrogu for build process, this PR introduce switch in pnc-config.json and making dingrogu default while retaining option to switch to BPM using same parameter `USE_DINGROGU = false` (false again irrelevant), this time for deactivating dingrogu as build process manager and running build with old BPM.

### Checklist:

* [ ] Have you added unit tests for your change?
