### PR TITLE
New causeway untag endpoint omits the /build path

### DIFF
--- a/causeway-client/src/main/java/org/jboss/pnc/causewayclient/DefaultCausewayClient.java
+++ b/causeway-client/src/main/java/org/jboss/pnc/causewayclient/DefaultCausewayClient.java
@@ -53,7 +53,7 @@ public class DefaultCausewayClient implements CausewayClient {
     @Inject
     public DefaultCausewayClient(GlobalModuleGroup globalConfig) {
         String causewayBaseUrl = globalConfig.getExternalCausewayUrl();
-        untagEndpoint = causewayBaseUrl + "/untag/build";
+        untagEndpoint = causewayBaseUrl + "/untag";
     }
 
     boolean post(String url, String jsonMessage, String authToken) {


### PR DESCRIPTION
Proof: https://github.com/project-ncl/pnc-api/blob/8355f7d209f66bcb26d74669be8f69e6c87c4f29/src/main/java/org/jboss/pnc/api/causeway/rest/Causeway.java#L39

### Checklist:

* [ ] Have you added unit tests for your change?
