### PR TITLE
Remove old closeMilestone method from milestone endpoint

### DIFF
--- a/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/ProductMilestoneEndpointTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/ProductMilestoneEndpointTest.java
@@ -289,7 +289,8 @@ public class ProductMilestoneEndpointTest {
         ProductMilestone created = client.createNew(newMilestone);
         assertThat(created.getId()).isNotEmpty();
         ProductMilestone retrieved = client.getSpecific(created.getId());
-        assertThatThrownBy(() -> client.closeMilestone(retrieved.getId())).cause()
+        assertThatThrownBy(() -> client.closeMilestone(retrieved.getId(), MilestoneCloseRequest.builder().build()))
+                .cause()
                 .isInstanceOfSatisfying(
                         ClientErrorException.class,
                         e -> assertThat(e.getResponse().getStatus()).isEqualTo(409));
@@ -606,7 +607,6 @@ public class ProductMilestoneEndpointTest {
     }
 
     @Test
-    @Ignore // Ignore it for now since this is a flaky test
     public void shouldCloseMilestoneWithoutBuildPush() throws RemoteResourceException {
         ProductMilestoneClient client = new ProductMilestoneClient(RestClientConfiguration.asUser());
 

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductMilestoneEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/ProductMilestoneEndpoint.java
@@ -248,19 +248,6 @@ public interface ProductMilestoneEndpoint {
 
     /**
      * {@value CLOSE_MILESTONE_DESC}
-     *
-     * @param id {@value PM_ID}
-     * @return
-     */
-    @Hidden
-    @POST
-    @RespondWithStatus(Response.Status.ACCEPTED)
-    @Path("/{id}/close")
-    @Deprecated(forRemoval = true, since = "3.2")
-    void closeMilestone(@PathParam("id") String id);
-
-    /**
-     * {@value CLOSE_MILESTONE_DESC}
      * 
      * @param id {@value PM_ID}
      * @return

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoints/ProductMilestoneEndpointImpl.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoints/ProductMilestoneEndpointImpl.java
@@ -118,11 +118,6 @@ public class ProductMilestoneEndpointImpl implements ProductMilestoneEndpoint {
     }
 
     @Override
-    public void closeMilestone(String id) {
-        productMilestoneProvider.closeMilestone(id, false);
-    }
-
-    @Override
     public void cancelMilestoneClose(String id) {
         productMilestoneProvider.cancelMilestoneCloseProcess(id);
     }


### PR DESCRIPTION
BREAKING CHANGE! Breaks java client API. REST API is unbroken. Sadly we can't use default methods as they are unsupported and having two implementations of the same endpoint make RestEasy chose one at random.

### Checklist:

* [ ] Have you added unit tests for your change?
