### PR TITLE
[NCL-9215] Fix equality/hash comparison for DeliverableArtifact

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/DeliverableArtifact.java
+++ b/model/src/main/java/org/jboss/pnc/model/DeliverableArtifact.java
@@ -38,7 +38,14 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
+ *
  * Join table between {@link DeliverableAnalyzerReport} and {@link Artifact} with some additional information.
+ *
+ * NOTE: UPDATE the equals and hashCode method for equality check A Report (aka deliverable analysis run) can contain
+ * one or more distributions (archives to analyze). There can be multiple DeliverableArtifacts in a report which contain
+ * the same artifact and (obviously) belong to the same report, but also found in different distributions. We need to
+ * take this into account for the equals and hashCode method, since DeliverableAnalyzerReport stores DeliverableArtifact
+ * inside a set.
  *
  * @author Adam Kridl &lt;akridl@redhat.com&gt;
  */
@@ -115,6 +122,12 @@ public class DeliverableArtifact implements GenericEntity<DeliverableArtifactPK>
         licenses.remove(licenseInfo);
     }
 
+    /**
+     * Take into account the report, artifact, and distribution
+     * 
+     * @param o
+     * @return
+     */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -124,12 +137,18 @@ public class DeliverableArtifact implements GenericEntity<DeliverableArtifactPK>
             return false;
         }
         DeliverableArtifact that = (DeliverableArtifact) o;
-        return Objects.equals(report, that.report) && Objects.equals(artifact, that.artifact);
+        return Objects.equals(report, that.report) && Objects.equals(artifact, that.artifact)
+                && Objects.equals(distribution, that.distribution);
     }
 
+    /**
+     * Take into account the report, artifact, and distribution
+     * 
+     * @return hashcode
+     */
     @Override
     public int hashCode() {
-        return Objects.hash(report, artifact);
+        return Objects.hash(report, artifact, distribution);
     }
 
     @Override

--- a/model/src/test/java/org/jboss/pnc/model/DeliverableArtifactTest.java
+++ b/model/src/test/java/org/jboss/pnc/model/DeliverableArtifactTest.java
@@ -1,0 +1,140 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014-2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class DeliverableArtifactTest {
+
+    /**
+     * Make sure that a DeliverableArtifact with the same artifact and report but different distributions are considered
+     * unique
+     */
+    @Test
+    public void testEquals() {
+        Artifact artifact = new Artifact();
+        artifact.setId(1234);
+
+        DeliverableAnalyzerReport report = new DeliverableAnalyzerReport();
+        report.setId(new Base32LongID(1235));
+
+        DeliverableAnalyzerDistribution distribution1 = new DeliverableAnalyzerDistribution();
+        distribution1.setDistributionUrl("testme1");
+
+        DeliverableAnalyzerDistribution distribution2 = new DeliverableAnalyzerDistribution();
+        distribution2.setDistributionUrl("testme2");
+
+        DeliverableArtifact deliverableArtifact1 = new DeliverableArtifact();
+        deliverableArtifact1.setArtifact(artifact);
+        deliverableArtifact1.setReport(report);
+        deliverableArtifact1.setDistribution(distribution1);
+
+        DeliverableArtifact deliverableArtifact2 = new DeliverableArtifact();
+        deliverableArtifact2.setArtifact(artifact);
+        deliverableArtifact2.setReport(report);
+        deliverableArtifact2.setDistribution(distribution2);
+
+        assertNotEquals(deliverableArtifact1, deliverableArtifact2);
+        assertNotEquals(deliverableArtifact1.hashCode(), deliverableArtifact2.hashCode());
+    }
+
+    @Test
+    public void testEqualsDifferentArtifact() {
+        Artifact artifact1 = new Artifact();
+        artifact1.setId(1234);
+
+        Artifact artifact2 = new Artifact();
+        artifact2.setId(4321);
+
+        DeliverableAnalyzerReport report = new DeliverableAnalyzerReport();
+        report.setId(new Base32LongID(1235));
+
+        DeliverableAnalyzerDistribution distribution1 = new DeliverableAnalyzerDistribution();
+        distribution1.setDistributionUrl("testme1");
+
+        DeliverableArtifact deliverableArtifact1 = new DeliverableArtifact();
+        deliverableArtifact1.setArtifact(artifact1);
+        deliverableArtifact1.setReport(report);
+        deliverableArtifact1.setDistribution(distribution1);
+
+        DeliverableArtifact deliverableArtifact2 = new DeliverableArtifact();
+        deliverableArtifact2.setArtifact(artifact2);
+        deliverableArtifact2.setReport(report);
+        deliverableArtifact2.setDistribution(distribution1);
+
+        assertNotEquals(deliverableArtifact1, deliverableArtifact2);
+        assertNotEquals(deliverableArtifact1.hashCode(), deliverableArtifact2.hashCode());
+    }
+
+    @Test
+    public void testEqualsDifferentReport() {
+        Artifact artifact = new Artifact();
+        artifact.setId(1234);
+
+        DeliverableAnalyzerReport report1 = new DeliverableAnalyzerReport();
+        report1.setId(new Base32LongID(1235));
+
+        DeliverableAnalyzerReport report2 = new DeliverableAnalyzerReport();
+        report2.setId(new Base32LongID(5321));
+
+        DeliverableAnalyzerDistribution distribution1 = new DeliverableAnalyzerDistribution();
+        distribution1.setDistributionUrl("testme1");
+
+        DeliverableArtifact deliverableArtifact1 = new DeliverableArtifact();
+        deliverableArtifact1.setArtifact(artifact);
+        deliverableArtifact1.setReport(report1);
+        deliverableArtifact1.setDistribution(distribution1);
+
+        DeliverableArtifact deliverableArtifact2 = new DeliverableArtifact();
+        deliverableArtifact2.setArtifact(artifact);
+        deliverableArtifact2.setReport(report2);
+        deliverableArtifact2.setDistribution(distribution1);
+
+        assertNotEquals(deliverableArtifact1, deliverableArtifact2);
+        assertNotEquals(deliverableArtifact1.hashCode(), deliverableArtifact2.hashCode());
+    }
+
+    @Test
+    public void testEqualsEverythingSame() {
+        Artifact artifact = new Artifact();
+        artifact.setId(1234);
+
+        DeliverableAnalyzerReport report = new DeliverableAnalyzerReport();
+        report.setId(new Base32LongID(1235));
+
+        DeliverableAnalyzerDistribution distribution = new DeliverableAnalyzerDistribution();
+        distribution.setDistributionUrl("testme1");
+
+        DeliverableArtifact deliverableArtifact1 = new DeliverableArtifact();
+        deliverableArtifact1.setArtifact(artifact);
+        deliverableArtifact1.setReport(report);
+        deliverableArtifact1.setDistribution(distribution);
+
+        DeliverableArtifact deliverableArtifact2 = new DeliverableArtifact();
+        deliverableArtifact2.setArtifact(artifact);
+        deliverableArtifact2.setReport(report);
+        deliverableArtifact2.setDistribution(distribution);
+
+        assertEquals(deliverableArtifact1, deliverableArtifact2);
+        assertEquals(deliverableArtifact1.hashCode(), deliverableArtifact2.hashCode());
+    }
+
+}


### PR DESCRIPTION
A `DeliverableAnalyzerReport` (or a deliverable analysis run) may contain one or more distribution urls, which are urls to zips that we distribute to customers.

A particular artifact can be found in many of those distribution urls. The `DeliverableAnalyzerReport` stores those artifact information (`DeliverableArtifact`) inside a set.

Unfortunately `DeliverableArtifact` equals and hashCode method does not take into account the distribution during comparison. This causes additions into the `DeliverableAnalyzerReport` artifact set to *not* add a second `DeliverableArtifact` which has the same artifact and report, but different distribution urls. The set thinks it's a duplicate entry.

This commit fixes it by considering the distribution in the comparison. A unit test is added to make sure we check for the distribution.

### Checklist:

* [x] Have you added unit tests for your change?
