### PR TITLE
[NCLSUP-1278] Remove query that accidentally mass-updated operation

### DIFF
--- a/model/src/main/resources/db-update/30200-build-push.sql
+++ b/model/src/main/resources/db-update/30200-build-push.sql
@@ -160,11 +160,5 @@ BEGIN; -- Data migration
     FROM buildrecordpushresult bpr
     WHERE status = 'SUCCESS' AND bpr.brewbuildid IS NOT NULL AND bpr.brewbuildurl IS NOT NULL;
 
-    -- mark successful operations that did not create report (because of missing brew build ID or URL) as SYSTEM_ERROR
-    UPDATE operation
-    SET result = 'SYSTEM_ERROR'
-    FROM operation o FULL OUTER JOIN buildpushreport r ON o.id = r.operation_id
-    WHERE r.operation_id IS NULL AND o.result = 'SUCCESSFUL' AND o.operation_type = 'BuildPush' ;
-
 COMMIT;
 


### PR DESCRIPTION
This query accidentally updated the entire operation table if only 1 row matched the where clause. We remove it to not create more damage.

### Checklist:

* [ ] Have you added unit tests for your change?
