### PR TITLE
[NCLSUP-1265] Load the licenses in batch size of 50

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/DeliverableArtifact.java
+++ b/model/src/main/java/org/jboss/pnc/model/DeliverableArtifact.java
@@ -31,6 +31,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Type;
 
 import java.util.HashSet;
@@ -98,6 +99,7 @@ public class DeliverableArtifact implements GenericEntity<DeliverableArtifactPK>
      * The set of licenses identified for this deliverable artifact.
      */
     @OneToMany(mappedBy = "artifact", cascade = CascadeType.PERSIST)
+    @BatchSize(size = 50) // added to avoid the N+1 problem when loading licenses
     private Set<DeliverableArtifactLicenseInfo> licenses;
 
     public DeliverableArtifactPK getId() {

--- a/rest-api/pnc-openapi.json
+++ b/rest-api/pnc-openapi.json
@@ -7,7 +7,7 @@
       "name" : "Apache 2.0",
       "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version" : "3.2.6-SNAPSHOT"
+    "version" : "3.2.7-SNAPSHOT"
   },
   "servers" : [ {
     "url" : "/pnc-rest",

--- a/rest-api/pnc-openapi.yaml
+++ b/rest-api/pnc-openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: 3.2.6-SNAPSHOT
+  version: 3.2.7-SNAPSHOT
 servers:
 - url: /pnc-rest
   variables: {}


### PR DESCRIPTION
This is done to avoid the N+1 problem when loading licenses for the list of deliverable artifacts that we fetched.

### Checklist:

* [ ] Have you added unit tests for your change?
