### PR TITLE
Artifact: Make ManyToOne lazy and batch loaded

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/Artifact.java
+++ b/model/src/main/java/org/jboss/pnc/model/Artifact.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.model;
 
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.envers.Audited;
@@ -31,6 +32,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -138,7 +140,8 @@ public class Artifact implements GenericEntity<Integer> {
      */
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_artifact_targetRepository"))
     @NotNull
-    @ManyToOne(cascade = CascadeType.REFRESH)
+    @ManyToOne(cascade = CascadeType.REFRESH, fetch = FetchType.LAZY)
+    @BatchSize(size = 50)
     private TargetRepository targetRepository;
 
     @Size(max = 255)
@@ -154,8 +157,9 @@ public class Artifact implements GenericEntity<Integer> {
     /**
      * The record of the build which produced this artifact.
      */
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_artifact_buildrecord"))
+    @BatchSize(size = 50)
     private BuildRecord buildRecord;
 
     /**
@@ -188,16 +192,18 @@ public class Artifact implements GenericEntity<Integer> {
     /**
      * User who created the artifact (either triggering the build or e.g. creating via Deliverable Analyzer)
      */
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_artifact_creation_user"), updatable = false)
+    @BatchSize(size = 50)
     private User creationUser;
 
     /**
      * User who last changed any audited field related to the Quality labels
      */
     @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_artifact_modification_user"), updatable = true)
+    @BatchSize(size = 50)
     private User modificationUser;
 
     @Column(columnDefinition = "timestamp with time zone", updatable = false)


### PR DESCRIPTION
This will be useful when loading a list of artifacts. We need to make the ManyToOne lazy to be able to use the BatchSize optimization.

We cannot really use the Join Fetch optimization because of our use of pagination and max result size.

### Checklist:

* [ ] Have you added unit tests for your change?
