### PR TITLE
Implement /pnc-rest/v2/users/login/<redirect path> endpoint

### DIFF
--- a/rest-api/pnc-openapi.json
+++ b/rest-api/pnc-openapi.json
@@ -10405,6 +10405,37 @@
         }
       }
     },
+    "/users/login/{redirectPath}" : {
+      "get" : {
+        "tags" : [ "Users" ],
+        "summary" : "Triggers authentication and redirects to the specified path after successful login.",
+        "operationId" : "loginAndRedirect",
+        "parameters" : [ {
+          "name" : "redirectPath",
+          "in" : "path",
+          "description" : "Path to redirect to after login",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "302" : {
+            "description" : "Redirect to the specified path after successful authentication"
+          },
+          "500" : {
+            "description" : "Server error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/users/{id}/builds" : {
       "get" : {
         "tags" : [ "Users" ],

--- a/rest-api/pnc-openapi.yaml
+++ b/rest-api/pnc-openapi.yaml
@@ -7251,6 +7251,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /users/login/{redirectPath}:
+    get:
+      tags:
+      - Users
+      summary: Triggers authentication and redirects to the specified path after successful
+        login.
+      operationId: loginAndRedirect
+      parameters:
+      - name: redirectPath
+        in: path
+        description: Path to redirect to after login
+        required: true
+        schema:
+          type: string
+      responses:
+        "302":
+          description: Redirect to the specified path after successful authentication
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /users/{id}/builds:
     get:
       tags:

--- a/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/UserEndpoint.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/api/endpoints/UserEndpoint.java
@@ -41,6 +41,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import static org.jboss.pnc.rest.configuration.SwaggerConstants.INVALID_CODE;
 import static org.jboss.pnc.rest.configuration.SwaggerConstants.INVALID_DESCRIPTION;
@@ -78,6 +79,29 @@ public interface UserEndpoint {
     @GET
     @Path("/current")
     User getCurrentUser();
+
+    static final String LOGIN_REDIRECT_DESC = "Triggers authentication and redirects to the specified path after successful login.";
+
+    /**
+     * {@value LOGIN_REDIRECT_DESC}
+     *
+     * @param redirectPath The path to redirect to after authentication
+     * @return HTTP 302 redirect response
+     */
+    @Operation(
+            summary = LOGIN_REDIRECT_DESC,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "302",
+                            description = "Redirect to the specified path after successful authentication"),
+                    @ApiResponse(
+                            responseCode = SERVER_ERROR_CODE,
+                            description = SERVER_ERROR_DESCRIPTION,
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))) })
+    @GET
+    @Path("/login/{redirectPath:.+}")
+    Response loginAndRedirect(
+            @Parameter(description = "Path to redirect to after login") @PathParam("redirectPath") String redirectPath);
 
     static final String GET_BUILDS = "Gets all builds triggered by specific user.";
 

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoints/UserEndpointImpl.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoints/UserEndpointImpl.java
@@ -29,6 +29,10 @@ import org.jboss.pnc.rest.api.parameters.PageParameters;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import java.net.URI;
 
 @ApplicationScoped
 public class UserEndpointImpl implements UserEndpoint {
@@ -39,9 +43,36 @@ public class UserEndpointImpl implements UserEndpoint {
     @Inject
     private BuildProvider buildProvider;
 
+    @Context
+    private HttpServletRequest servletRequest;
+
     @Override
     public User getCurrentUser() {
         return userProvider.getCurrentUser();
+    }
+
+    @Override
+    public Response loginAndRedirect(String redirectPath) {
+        // Ensure path starts with / to make it an absolute path
+        if (redirectPath == null || redirectPath.trim().isEmpty()) {
+            redirectPath = "/";
+        } else if (!redirectPath.startsWith("/")) {
+            redirectPath = "/" + redirectPath;
+        }
+
+        // Build an absolute URI to avoid relative path resolution issues
+        String scheme = servletRequest.getScheme();
+        String serverName = servletRequest.getServerName();
+        int serverPort = servletRequest.getServerPort();
+
+        String absoluteUrl;
+        if ((scheme.equals("http") && serverPort == 80) || (scheme.equals("https") && serverPort == 443)) {
+            absoluteUrl = scheme + "://" + serverName + redirectPath;
+        } else {
+            absoluteUrl = scheme + "://" + serverName + ":" + serverPort + redirectPath;
+        }
+
+        return Response.status(Response.Status.FOUND).location(URI.create(absoluteUrl)).build();
     }
 
     @Override

--- a/rest/src/main/webconfig/auth/web.xml
+++ b/rest/src/main/webconfig/auth/web.xml
@@ -51,4 +51,28 @@
     <security-role>
         <role-name>pnc-users-admin</role-name>
     </security-role>
+
+    <!-- make sure interceptor sees this and redirect user to sso server -->
+    <!-- the rest is handled inside the SecurityConstraintFilter -->
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Access to login</web-resource-name>
+            <url-pattern>/v2/users/current</url-pattern>
+            <http-method>GET</http-method>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Login with redirect</web-resource-name>
+            <url-pattern>/v2/users/login/*</url-pattern>
+            <http-method>GET</http-method>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
 </web-app>


### PR DESCRIPTION
This endpoint can potentially be used when the user clicks the 'login' button that points to this url. The user will be redirected to the SSO server to authenticate, then do a HTTP 302 to the redirect path with a cookie set.

An example is: /pnc-rest/v2/users/login/pnc-rest/v2/users/current , which upon successful authentication, will redirect to:

/pnc-rest/v2/users/current .

The backend will associate the cookie with the actual access token to do the request. This allows the UI to just have to send the cookie to the backend to get the request "authenticated", without having to store any access token.

This approach should work irrespective on whether we are using Keycloak or another OIDC server.

### Checklist:

* [ ] Have you added unit tests for your change?
