### PR TITLE
[v3.5.x] Identify cached artifacts by including targetrepository

### DIFF
--- a/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
@@ -154,7 +154,7 @@ public class DefaultDatastore implements Datastore {
         }
 
         Map<TargetRepository.IdentifierPath, TargetRepository> repositoriesCache = new HashMap<>();
-        Map<Artifact.IdentifierSha256, Artifact> artifactCache = new HashMap<>();
+        Map<Artifact.IdentifierSha256TargetRepository, Artifact> artifactCache = new HashMap<>();
 
         /**
          * Built artifacts must be saved before the dependencies. In case an artifact is built and the dependency
@@ -222,32 +222,36 @@ public class DefaultDatastore implements Datastore {
     private Set<Artifact> saveArtifacts(
             Collection<Artifact> artifacts,
             Map<TargetRepository.IdentifierPath, TargetRepository> storedTargetRepositories,
-            Map<Artifact.IdentifierSha256, Artifact> artifactCache) {
+            Map<Artifact.IdentifierSha256TargetRepository, Artifact> artifactCache) {
         logger.debug("Saving {} artifacts.", artifacts.size());
 
         Set<Artifact> savedArtifacts = new HashSet<>();
 
-        Set<Artifact.IdentifierSha256> artifactConstraints = new HashSet<>();
+        fetchOrSaveRequiredTargetRepositories(artifacts, storedTargetRepositories);
+
+        Set<Artifact.IdentifierSha256TargetRepository> artifactConstraints = new HashSet<>();
         for (Artifact artifact : artifacts) {
             // None of the generic proxy artifacts can be in the db because of per-build repos
             if (!isGenericProxy(artifact)) {
-                artifactConstraints.add(new Artifact.IdentifierSha256(artifact.getIdentifier(), artifact.getSha256()));
+                // link managed targetRepository before creating the constraint
+                artifact.setTargetRepository(
+                        storedTargetRepositories.get(artifact.getTargetRepository().getIdentifierPath()));
+                artifactConstraints.add(artifact.getIdentifierSha256TargetRepository());
             }
         }
 
-        fetchOrSaveRequiredTargetRepositories(artifacts, storedTargetRepositories);
-
         if (artifactConstraints.size() > 0) {
             logger.debug("Searching artifacts by {} constraints.", artifactConstraints.size());
-            Set<Artifact> artifactsInDb = artifactRepository.withIdentifierAndSha256(artifactConstraints);
+            Set<Artifact> artifactsInDb = artifactRepository
+                    .withIdentifierAndSha256AndTargetRepository(artifactConstraints);
             for (Artifact artifact : artifactsInDb) {
                 logger.trace("Found in DB, adding to cache. Artifact {}", artifact);
-                artifactCache.put(artifact.getIdentifierSha256(), artifact);
+                artifactCache.put(artifact.getIdentifierSha256TargetRepository(), artifact);
             }
         }
 
         for (Artifact artifact : artifacts) {
-            // link managed targetRepository
+            // link managed targetRepository (may already be set above for non-generic-proxy artifacts)
             artifact.setTargetRepository(
                     storedTargetRepositories.get(artifact.getTargetRepository().getIdentifierPath()));
 
@@ -316,9 +320,9 @@ public class DefaultDatastore implements Datastore {
 
     private Artifact getOrSaveRepositoryArtifact(
             Artifact artifact,
-            Map<Artifact.IdentifierSha256, Artifact> artifactCache) {
+            Map<Artifact.IdentifierSha256TargetRepository, Artifact> artifactCache) {
         logger.trace("Saving repository artifact {}.", artifact);
-        Artifact artifactFromDb = artifactCache.get(artifact.getIdentifierSha256());
+        Artifact artifactFromDb = artifactCache.get(artifact.getIdentifierSha256TargetRepository());
 
         if (artifactFromDb == null) {
             logger.trace("Artifact is not in DB. Saving artifact {}.", artifact);
@@ -326,6 +330,10 @@ public class DefaultDatastore implements Datastore {
             // Relation owner (BuildRecord) must be saved first, the relation is saved when the BR is saved
             artifact.setDependantBuildRecords(Collections.emptySet());
             artifactFromDb = artifactRepository.save(artifact);
+
+            // Add newly saved artifact to cache to prevent duplicate saves when same artifact
+            // appears in both builtArtifacts and dependencies
+            artifactCache.put(artifactFromDb.getIdentifierSha256TargetRepository(), artifactFromDb);
 
             logger.trace("Saved new artifact {}.", artifactFromDb);
         } else {

--- a/datastore/src/main/java/org/jboss/pnc/datastore/repositories/ArtifactRepositoryImpl.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/repositories/ArtifactRepositoryImpl.java
@@ -70,6 +70,20 @@ public class ArtifactRepositoryImpl extends AbstractRepository<Artifact, Integer
     }
 
     @Override
+    public Set<Artifact> withIdentifierAndSha256AndTargetRepository(
+            Collection<Artifact.IdentifierSha256TargetRepository> identifierSha256TargetRepositorySet) {
+        List<List<Artifact.IdentifierSha256TargetRepository>> partitionedList = Lists
+                .partition(new ArrayList<>(identifierSha256TargetRepositorySet), QUERY_ARTIFACT_PARITION_SIZE);
+        HashSet<Artifact> artifacts = new HashSet<>();
+        for (List<Artifact.IdentifierSha256TargetRepository> partition : partitionedList) {
+            List<Artifact> artifactsInDb = queryWithPredicates(
+                    ArtifactPredicates.withIdentifierAndSha256AndTargetRepository(partition));
+            artifacts.addAll(artifactsInDb);
+        }
+        return artifacts;
+    }
+
+    @Override
     public List<Artifact> withIdentifierAndSha256(String identifier, String sha256) {
         return queryWithPredicates(ArtifactPredicates.withIdentifierAndSha256(identifier, sha256));
     }

--- a/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
+++ b/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
@@ -385,7 +385,9 @@ public class DatastoreTest {
         Assert.assertEquals(3, buildRecord.getBuiltArtifacts().size());
         Assert.assertEquals(2, buildRecord.getDependencies().size());
         Assert.assertEquals(1, buildRecord.getAttachments().size());
-        Assert.assertEquals(5, artifactRepository.queryAll().size());
+        // With targetRepository now part of uniqueness, builtDuplicateArtifact and importedDuplicateArtifact
+        // are stored as separate artifacts (6 total instead of 5)
+        Assert.assertEquals(6, artifactRepository.queryAll().size());
         Assert.assertEquals(1, attachmentRepository.queryAll().size());
 
         Set<Artifact.IdentifierSha256> identifiersAndSha = new HashSet<>();
@@ -395,10 +397,14 @@ public class DatastoreTest {
                         importedDuplicateArtifact.getSha256()));
         List<Artifact> artifactsFromDb = artifactRepository
                 .queryWithPredicates(ArtifactPredicates.withIdentifierAndSha256(identifiersAndSha));
-        Assert.assertEquals(1, artifactsFromDb.size());
-        Assert.assertEquals(
-                buildsUntestedRepoPath,
-                artifactsFromDb.stream().findFirst().get().getTargetRepository().getRepositoryPath());
+        // Both builtDuplicateArtifact and importedDuplicateArtifact have the same identifier/sha256
+        Assert.assertEquals(2, artifactsFromDb.size());
+        // Verify both target repositories are present
+        Set<String> repoPaths = artifactsFromDb.stream()
+                .map(a -> a.getTargetRepository().getRepositoryPath())
+                .collect(java.util.stream.Collectors.toSet());
+        Assert.assertTrue(repoPaths.contains(buildsUntestedRepoPath));
+        Assert.assertTrue(repoPaths.contains("shared-imports"));
     }
 
     @Test

--- a/model/src/main/java/org/jboss/pnc/model/Artifact.java
+++ b/model/src/main/java/org/jboss/pnc/model/Artifact.java
@@ -220,6 +220,11 @@ public class Artifact implements GenericEntity<Integer> {
         return new IdentifierSha256(identifier, sha256);
     }
 
+    @Transient
+    public IdentifierSha256TargetRepository getIdentifierSha256TargetRepository() {
+        return new IdentifierSha256TargetRepository(identifier, sha256, targetRepository.getId());
+    }
+
     /**
      * Try to use the {@link Artifact.Builder} instead.
      *
@@ -842,6 +847,58 @@ public class Artifact implements GenericEntity<Integer> {
         public int hashCode() {
             int result = identifier.hashCode();
             result = 31 * result + sha256.hashCode();
+            return result;
+        }
+    }
+
+    public static class IdentifierSha256TargetRepository {
+        private String identifier;
+        private String sha256;
+        private Integer targetRepositoryId;
+
+        public IdentifierSha256TargetRepository(String identifier, String sha256, Integer targetRepositoryId) {
+            this.identifier = identifier;
+            this.sha256 = sha256;
+            this.targetRepositoryId = targetRepositoryId;
+        }
+
+        public String getSha256() {
+            return sha256;
+        }
+
+        public String getIdentifier() {
+            return identifier;
+        }
+
+        public Integer getTargetRepositoryId() {
+            return targetRepositoryId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof IdentifierSha256TargetRepository)) {
+                return false;
+            }
+
+            IdentifierSha256TargetRepository that = (IdentifierSha256TargetRepository) o;
+
+            if (!identifier.equals(that.identifier)) {
+                return false;
+            }
+            if (!sha256.equals(that.sha256)) {
+                return false;
+            }
+            return targetRepositoryId.equals(that.targetRepositoryId);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = identifier.hashCode();
+            result = 31 * result + sha256.hashCode();
+            result = 31 * result + targetRepositoryId.hashCode();
             return result;
         }
     }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/ArtifactRepositoryMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/repository/ArtifactRepositoryMock.java
@@ -39,6 +39,12 @@ public class ArtifactRepositoryMock extends IntIdRepositoryMock<Artifact> implem
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public Set<Artifact> withIdentifierAndSha256AndTargetRepository(
+            Collection<Artifact.IdentifierSha256TargetRepository> identifierSha256TargetRepositorySet) {
+        throw new UnsupportedOperationException();
+    }
+
     public List<Artifact> withIdentifierAndSha256(String identifier, String sha256) {
         throw new UnsupportedOperationException("Unimplemented method 'withIdentifierAndSha256'");
     }

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/ArtifactPredicates.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/predicates/ArtifactPredicates.java
@@ -34,6 +34,8 @@ import org.jboss.pnc.model.DeliverableArtifact;
 import org.jboss.pnc.model.DeliverableArtifact_;
 import org.jboss.pnc.model.ProductMilestone;
 import org.jboss.pnc.model.ProductMilestone_;
+import org.jboss.pnc.model.TargetRepository;
+import org.jboss.pnc.model.TargetRepository_;
 import org.jboss.pnc.spi.datastore.repositories.api.Predicate;
 
 import javax.persistence.criteria.CriteriaBuilder;
@@ -45,8 +47,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
-import org.jboss.pnc.model.TargetRepository_;
 
 import static org.jboss.pnc.spi.datastore.predicates.DeliverableAnalyzerReportPredicates.notFromDeletedAnalysis;
 import static org.jboss.pnc.spi.datastore.predicates.DeliverableAnalyzerReportPredicates.notFromScratchAnalysis;
@@ -186,6 +186,24 @@ public class ArtifactPredicates {
                         cb.and(
                                 cb.equal(root.get(Artifact_.identifier), identifierSha256.getIdentifier()),
                                 cb.equal(root.get(Artifact_.sha256), identifierSha256.getSha256())));
+            }
+            return cb.or(predicates.toArray(new javax.persistence.criteria.Predicate[0]));
+        });
+    }
+
+    public static Predicate<Artifact> withIdentifierAndSha256AndTargetRepository(
+            Iterable<Artifact.IdentifierSha256TargetRepository> identifierSha256TargetRepositorySet) {
+        return ((root, query, cb) -> {
+            Join<Artifact, TargetRepository> targetRepositoryJoin = root.join(Artifact_.targetRepository);
+            List<javax.persistence.criteria.Predicate> predicates = new ArrayList<>();
+            for (Artifact.IdentifierSha256TargetRepository idSha256Repo : identifierSha256TargetRepositorySet) {
+                predicates.add(
+                        cb.and(
+                                cb.equal(root.get(Artifact_.identifier), idSha256Repo.getIdentifier()),
+                                cb.equal(root.get(Artifact_.sha256), idSha256Repo.getSha256()),
+                                cb.equal(
+                                        targetRepositoryJoin.get(TargetRepository_.id),
+                                        idSha256Repo.getTargetRepositoryId())));
             }
             return cb.or(predicates.toArray(new javax.persistence.criteria.Predicate[0]));
         });

--- a/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/ArtifactRepository.java
+++ b/spi/src/main/java/org/jboss/pnc/spi/datastore/repositories/ArtifactRepository.java
@@ -33,6 +33,9 @@ public interface ArtifactRepository extends Repository<Artifact, Integer> {
 
     Set<Artifact> withIdentifierAndSha256(Collection<Artifact.IdentifierSha256> identifierSha256Set);
 
+    Set<Artifact> withIdentifierAndSha256AndTargetRepository(
+            Collection<Artifact.IdentifierSha256TargetRepository> identifierSha256TargetRepositorySet);
+
     List<Artifact> withIdentifierAndSha256(String identifier, String sha256);
 
     List<Artifact> withSha256In(Set<String> sha256);


### PR DESCRIPTION
This prevents Lightwell type builds from re-using community artifacts already imported in PNC DB, into the built-artifacts section with the wrong target repository.

### Checklist:

* [ ] Have you added unit tests for your change?
