### PR TITLE
[v3.5] Allow a user with no roles to access the endpoint

### DIFF
--- a/rest/src/main/webconfig/auth/web.xml
+++ b/rest/src/main/webconfig/auth/web.xml
@@ -65,7 +65,7 @@
             <http-method>GET</http-method>
         </web-resource-collection>
         <auth-constraint>
-            <role-name>*</role-name>
+            <role-name>**</role-name>
         </auth-constraint>
     </security-constraint>
 


### PR DESCRIPTION
'*' requires at least 1 role.
'**' doesn't require any role, but it'll let you in as long as you are authenticated.

### Checklist:

* [ ] Have you added unit tests for your change?
