### PR TITLE
[NCL-9852] Remove unique constraint for url on attachment

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/Attachment.java
+++ b/model/src/main/java/org/jboss/pnc/model/Attachment.java
@@ -51,8 +51,7 @@ import java.util.Objects;
                 @Index(name = "idx_attachment_buildrecord", columnList = "buildrecord_id"),
                 @Index(name = "idx_attachment_sha256", columnList = "sha256") },
         uniqueConstraints = {
-                @UniqueConstraint(name = "uk_attachment_recordid_name", columnNames = { "buildrecord_id", "name" }),
-                @UniqueConstraint(name = "uk_attachment_url", columnNames = { "url" }) })
+                @UniqueConstraint(name = "uk_attachment_recordid_name", columnNames = { "buildrecord_id", "name" }) })
 @ToString
 public class Attachment implements GenericEntity<Integer> {
 

--- a/model/src/main/resources/db-update/30505-from-3.5.6-to-3.5.7.sql
+++ b/model/src/main/resources/db-update/30505-from-3.5.6-to-3.5.7.sql
@@ -1,0 +1,19 @@
+--
+-- JBoss, Home of Professional Open Source.
+-- Copyright 2014-2022 Red Hat, Inc., and individual contributors
+-- as indicated by the @author tags.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+begin; ALTER TABLE attachment DROP CONSTRAINT uk_attachment_url; commit;


### PR DESCRIPTION
This commit removes the uniqueness constraint on the url for the attachment table.

On NCL-9852, we are required to upload to the attachment the oci registry image+sha which contains the public key to verify the provenance attestation.

Since the public key will stay the same for a while, we'll use the same url for a lot of different builds.

This unique constraint right now forbids us from doing it.

### Checklist:

* [ ] Have you added unit tests for your change?
