### PR TITLE
[v3.5][NCL-9852] Remove unique constraint for url on attachment

### DIFF
--- a/model/src/main/java/org/jboss/pnc/model/Attachment.java
+++ b/model/src/main/java/org/jboss/pnc/model/Attachment.java
@@ -50,8 +50,7 @@ import java.util.Objects;
                 @Index(name = "idx_attachment_type", columnList = "type"),
                 @Index(name = "idx_attachment_buildrecord", columnList = "buildrecord_id") },
         uniqueConstraints = {
-                @UniqueConstraint(name = "uk_attachment_recordid_name", columnNames = { "buildrecord_id", "name" }),
-                @UniqueConstraint(name = "uk_attachment_url", columnNames = { "url" }) })
+                @UniqueConstraint(name = "uk_attachment_recordid_name", columnNames = { "buildrecord_id", "name" }) })
 @ToString
 public class Attachment implements GenericEntity<Integer> {
 


### PR DESCRIPTION
This commit removes the uniqueness constraint on the url for the attachment table.

On NCL-9852, we are required to upload to the attachment the oci registry image+sha which contains the public key to verify the provenance attestation.

Since the public key will stay the same for a while, we'll use the same url for a lot of different builds.

This unique constraint right now forbids us from doing it.

### Checklist:

* [ ] Have you added unit tests for your change?
