### PR TITLE
[NCL-9487] Make allowed redirect hosts configurable

### DIFF
--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/UIModuleConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/UIModuleConfig.java
@@ -26,7 +26,10 @@ import org.jboss.pnc.common.json.AbstractModuleConfig;
 import org.jboss.pnc.common.util.StringUtils;
 
 import javax.ws.rs.DefaultValue;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -47,9 +50,13 @@ public class UIModuleConfig extends AbstractModuleConfig {
     private final Integer ssoTokenLifespan;
     private final KeycloakConfig keycloak;
     private final Map<String, String> grafana;
+    private final List<String> allowedRedirectHosts;
 
     // all toplevel key/values which are not specified in constructor
     private final Map<String, Object> unspecifiedFields;
+
+    private static final List<String> DEFAULT_ALLOWED_REDIRECT_HOSTS = Collections
+            .unmodifiableList(Arrays.asList("localhost", "127.0.0.1"));
 
     public UIModuleConfig(
             @JsonProperty("pncNotificationsUrl") String pncNotificationsUrl,
@@ -58,7 +65,8 @@ public class UIModuleConfig extends AbstractModuleConfig {
             @JsonProperty("userSupportUrl") String userSupportUrl,
             @JsonProperty("ssoTokenLifespan") String ssoTokenLifespan,
             @JsonProperty("keycloak") KeycloakConfig keycloak,
-            @JsonProperty("grafana") @DefaultValue("{}") Map<String, String> grafana) {
+            @JsonProperty("grafana") @DefaultValue("{}") Map<String, String> grafana,
+            @JsonProperty("allowedRedirectHosts") List<String> allowedRedirectHosts) {
         this.pncNotificationsUrl = pncNotificationsUrl;
         this.bifrostWsUrl = bifrostWsUrl;
         this.userGuideUrl = userGuideUrl;
@@ -66,6 +74,8 @@ public class UIModuleConfig extends AbstractModuleConfig {
         this.ssoTokenLifespan = StringUtils.parseInt(ssoTokenLifespan, 86400000); // default to 24h
         this.keycloak = keycloak;
         this.grafana = grafana;
+        this.allowedRedirectHosts = allowedRedirectHosts != null ? allowedRedirectHosts
+                : DEFAULT_ALLOWED_REDIRECT_HOSTS;
         this.unspecifiedFields = new HashMap<>();
     }
 
@@ -117,6 +127,11 @@ public class UIModuleConfig extends AbstractModuleConfig {
     @JsonProperty("grafana")
     public Map<String, String> getGrafana() {
         return grafana;
+    }
+
+    @JsonProperty("allowedRedirectHosts")
+    public List<String> getAllowedRedirectHosts() {
+        return allowedRedirectHosts;
     }
 
     @JsonAnyGetter

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleprovider/ModuleConfigFactory.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleprovider/ModuleConfigFactory.java
@@ -26,6 +26,7 @@ import org.jboss.pnc.common.json.moduleconfig.DemoDataConfig;
 import org.jboss.pnc.common.json.moduleconfig.IndyRepoDriverModuleConfig;
 import org.jboss.pnc.common.json.moduleconfig.SchedulerConfig;
 import org.jboss.pnc.common.json.moduleconfig.SystemConfig;
+import org.jboss.pnc.common.json.moduleconfig.UIModuleConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoints/UserEndpointImpl.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoints/UserEndpointImpl.java
@@ -18,9 +18,12 @@
 package org.jboss.pnc.rest.endpoints;
 
 import org.jboss.pnc.auth.OidcDiscoveryService;
+import org.jboss.pnc.common.Configuration;
 import org.jboss.pnc.common.json.ConfigurationParseException;
 import org.jboss.pnc.common.json.moduleconfig.KeycloakClientConfig;
 import org.jboss.pnc.common.json.moduleconfig.SystemConfig;
+import org.jboss.pnc.common.json.moduleconfig.UIModuleConfig;
+import org.jboss.pnc.common.json.moduleprovider.PncConfigProvider;
 import org.jboss.pnc.dto.Build;
 import org.jboss.pnc.dto.User;
 import org.jboss.pnc.dto.response.Page;
@@ -42,6 +45,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 @ApplicationScoped
 public class UserEndpointImpl implements UserEndpoint {
@@ -59,6 +63,20 @@ public class UserEndpointImpl implements UserEndpoint {
 
     @Inject
     private OidcDiscoveryService oidcDiscoveryService;
+
+    private List<String> allowedRedirectHosts;
+
+    @Inject
+    public void loadUIModuleConfig(Configuration configuration) {
+        try {
+            UIModuleConfig uiModuleConfig = configuration
+                    .getModuleConfig(new PncConfigProvider<>(UIModuleConfig.class));
+            this.allowedRedirectHosts = uiModuleConfig.getAllowedRedirectHosts();
+        } catch (ConfigurationParseException e) {
+            logger.warn("Unable to load UIModuleConfig, using default allowed redirect hosts", e);
+            this.allowedRedirectHosts = List.of("localhost", "127.0.0.1");
+        }
+    }
 
     @Context
     private HttpServletRequest servletRequest;
@@ -375,12 +393,7 @@ public class UserEndpointImpl implements UserEndpoint {
             return true;
         }
 
-        // Allow localhost and 127.0.0.1
-        if (targetHostWithoutPort.equals("localhost") || targetHostWithoutPort.equals("127.0.0.1")) {
-            return true;
-        }
-
-        return false;
+        return allowedRedirectHosts.contains(targetHostWithoutPort);
     }
 
     @Override


### PR DESCRIPTION
Add allowedRedirectHosts to UIModuleConfig so the list of permitted redirect hostnames can be set via configuration instead of being hardcoded. Defaults to localhost and 127.0.0.1 when not specified.

### Checklist:

* [ ] Have you added unit tests for your change?
