### PR TITLE
[v3.5.x][NCLSUP-1455] Resolve tempBuildPromotionTarget per build category

### DIFF
--- a/build-coordinator/src/main/java/org/jboss/pnc/coordinator/maintenance/DefaultRemoteBuildsCleaner.java
+++ b/build-coordinator/src/main/java/org/jboss/pnc/coordinator/maintenance/DefaultRemoteBuildsCleaner.java
@@ -36,6 +36,7 @@ import org.jboss.pnc.common.Configuration;
 import org.jboss.pnc.common.json.ConfigurationParseException;
 import org.jboss.pnc.common.json.moduleconfig.IndyRepoDriverModuleConfig;
 import org.jboss.pnc.common.json.moduleprovider.PncConfigProvider;
+import org.jboss.pnc.api.constants.BuildConfigurationParameterKeys;
 import org.jboss.pnc.enums.BuildType;
 import org.jboss.pnc.enums.ResultStatus;
 import org.jboss.pnc.mapper.api.BuildMapper;
@@ -53,6 +54,7 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.Map;
 
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_GENERIC_HTTP;
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
@@ -74,7 +76,7 @@ public class DefaultRemoteBuildsCleaner implements RemoteBuildsCleaner {
 
     private final BuildPushOperationRepository buildPushOperationRepository;
 
-    private final String tempBuildPromotionGroup;
+    private final IndyRepoDriverModuleConfig indyRepoDriverConfig;
 
     @Inject
     public DefaultRemoteBuildsCleaner(
@@ -88,15 +90,14 @@ public class DefaultRemoteBuildsCleaner implements RemoteBuildsCleaner {
         this.causewayClient = causewayClient;
         this.buildPushOperationRepository = buildPushOperationRepository;
 
-        IndyRepoDriverModuleConfig config;
         try {
-            config = configuration.getModuleConfig(new PncConfigProvider<>(IndyRepoDriverModuleConfig.class));
+            this.indyRepoDriverConfig = configuration
+                    .getModuleConfig(new PncConfigProvider<>(IndyRepoDriverModuleConfig.class));
         } catch (ConfigurationParseException e) {
             throw new IllegalStateException(
                     "Cannot read configuration for " + IndyRepoDriverModuleConfig.class.getName() + ".",
                     e);
         }
-        this.tempBuildPromotionGroup = config.getTempBuildPromotionTarget();
     }
 
     @Override
@@ -152,7 +153,8 @@ public class DefaultRemoteBuildsCleaner implements RemoteBuildsCleaner {
                 // delete artifacts from consolidated repository
                 // (failed builds are not promoted and don't have artifacts in consolidated repository)
                 if (buildRecord.getStatus().completedSuccessfully()) {
-                    StoreKey tempHostedKey = new StoreKey(pkgKey, StoreType.hosted, tempBuildPromotionGroup);
+                    String tempBuildPromotionTarget = resolveTempBuildPromotionTarget(buildRecord);
+                    StoreKey tempHostedKey = new StoreKey(pkgKey, StoreType.hosted, tempBuildPromotionTarget);
 
                     BatchDeleteRequest request = new BatchDeleteRequest();
                     request.setTrackingID(buildContentId);
@@ -196,6 +198,18 @@ public class DefaultRemoteBuildsCleaner implements RemoteBuildsCleaner {
             IOUtils.closeQuietly(indy);
         }
         return result;
+    }
+
+    private String resolveTempBuildPromotionTarget(BuildRecord buildRecord) {
+        Map<String, String> genericParameters = buildRecord.getBuildConfigurationAudited().getGenericParameters();
+        String buildCategory = null;
+        if (genericParameters != null) {
+            buildCategory = genericParameters.get(BuildConfigurationParameterKeys.BUILD_CATEGORY.name());
+        }
+        if (buildCategory == null) {
+            buildCategory = "STANDARD";
+        }
+        return indyRepoDriverConfig.getTempBuildPromotionTarget(buildCategory);
     }
 
     /**

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/IndyRepoDriverModuleConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/IndyRepoDriverModuleConfig.java
@@ -23,6 +23,8 @@ import lombok.Setter;
 import lombok.ToString;
 import org.jboss.pnc.common.json.AbstractModuleConfig;
 
+import java.util.Map;
+
 @ToString
 public class IndyRepoDriverModuleConfig extends AbstractModuleConfig {
 
@@ -37,11 +39,19 @@ public class IndyRepoDriverModuleConfig extends AbstractModuleConfig {
     private Integer defaultRequestTimeout = 600;
 
     /**
-     * Name of the target repo to which the build repo of a successful TEMPORARY build should be promoted.
+     * Mapping of {@code BuildCategory} name to the Indy hosted repo used as the temp build promotion target. Keys are
+     * build category names (e.g. {@code "STANDARD"}, {@code "SERVICE"}).
      */
     @Getter
     @Setter
     @JsonProperty(required = false)
-    private String tempBuildPromotionTarget = "temporary-builds";
+    private Map<String, String> tempBuildPromotionTargets = Map.of();
+
+    public String getTempBuildPromotionTarget(String buildCategory) {
+        if (buildCategory != null && tempBuildPromotionTargets != null) {
+            return tempBuildPromotionTargets.get(buildCategory);
+        }
+        return null;
+    }
 
 }

--- a/remote-build-coordinator/src/main/java/org/jboss/pnc/remotecoordinator/maintenance/DefaultRemoteBuildsCleaner.java
+++ b/remote-build-coordinator/src/main/java/org/jboss/pnc/remotecoordinator/maintenance/DefaultRemoteBuildsCleaner.java
@@ -37,6 +37,7 @@ import org.jboss.pnc.common.Configuration;
 import org.jboss.pnc.common.json.ConfigurationParseException;
 import org.jboss.pnc.common.json.moduleconfig.IndyRepoDriverModuleConfig;
 import org.jboss.pnc.common.json.moduleprovider.PncConfigProvider;
+import org.jboss.pnc.api.constants.BuildConfigurationParameterKeys;
 import org.jboss.pnc.enums.BuildStatus;
 import org.jboss.pnc.enums.BuildType;
 import org.jboss.pnc.enums.ResultStatus;
@@ -55,6 +56,7 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.Map;
 
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_GENERIC_HTTP;
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
@@ -74,7 +76,7 @@ public class DefaultRemoteBuildsCleaner implements RemoteBuildsCleaner {
 
     private final BuildPushOperationRepository buildPushOperationRepository;
 
-    private final String tempBuildPromotionGroup;
+    private final IndyRepoDriverModuleConfig indyRepoDriverConfig;
 
     private final Indy indy;
 
@@ -94,15 +96,14 @@ public class DefaultRemoteBuildsCleaner implements RemoteBuildsCleaner {
         this.buildPushOperationRepository = buildPushOperationRepository;
         this.refreshingIndyAuthenticator = refreshingIndyAuthenticator;
 
-        IndyRepoDriverModuleConfig config;
         try {
-            config = configuration.getModuleConfig(new PncConfigProvider<>(IndyRepoDriverModuleConfig.class));
+            this.indyRepoDriverConfig = configuration
+                    .getModuleConfig(new PncConfigProvider<>(IndyRepoDriverModuleConfig.class));
         } catch (ConfigurationParseException e) {
             throw new IllegalStateException(
                     "Cannot read configuration for " + IndyRepoDriverModuleConfig.class.getName() + ".",
                     e);
         }
-        this.tempBuildPromotionGroup = config.getTempBuildPromotionTarget();
     }
 
     @Override
@@ -160,7 +161,8 @@ public class DefaultRemoteBuildsCleaner implements RemoteBuildsCleaner {
                 // NO_REBUILD_REQUIRED builds also don't have artifacts, but are considered 'completed succesfully'
                 if (buildRecord.getStatus().completedSuccessfully()
                         && !buildRecord.getStatus().equals(BuildStatus.NO_REBUILD_REQUIRED)) {
-                    StoreKey tempHostedKey = new StoreKey(pkgKey, StoreType.hosted, tempBuildPromotionGroup);
+                    String tempBuildPromotionTarget = resolveTempBuildPromotionTarget(buildRecord);
+                    StoreKey tempHostedKey = new StoreKey(pkgKey, StoreType.hosted, tempBuildPromotionTarget);
 
                     BatchDeleteRequest request = new BatchDeleteRequest();
                     request.setTrackingID(buildContentId);
@@ -229,6 +231,18 @@ public class DefaultRemoteBuildsCleaner implements RemoteBuildsCleaner {
         }
 
         return result;
+    }
+
+    private String resolveTempBuildPromotionTarget(BuildRecord buildRecord) {
+        Map<String, String> genericParameters = buildRecord.getBuildConfigurationAudited().getGenericParameters();
+        String buildCategory = null;
+        if (genericParameters != null) {
+            buildCategory = genericParameters.get(BuildConfigurationParameterKeys.BUILD_CATEGORY.name());
+        }
+        if (buildCategory == null) {
+            buildCategory = "STANDARD";
+        }
+        return indyRepoDriverConfig.getTempBuildPromotionTarget(buildCategory);
     }
 
     private boolean doesTrackContentDTOExist(TrackedContentDTO trackedContentDTO) {

--- a/rest-api/pnc-openapi.json
+++ b/rest-api/pnc-openapi.json
@@ -7,7 +7,7 @@
       "name" : "Apache 2.0",
       "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version" : "3.5.8-SNAPSHOT"
+    "version" : "3.5.9-SNAPSHOT"
   },
   "servers" : [ {
     "url" : "/pnc-rest",

--- a/rest-api/pnc-openapi.yaml
+++ b/rest-api/pnc-openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: 3.5.8-SNAPSHOT
+  version: 3.5.9-SNAPSHOT
 servers:
 - url: /pnc-rest
   variables: {}


### PR DESCRIPTION
The temp build promotion target in Indy was previously hardcoded to a single value for all builds. Different build categories (e.g. STANDARD, SERVICE) may need to promote to different Indy hosted repositories.

IndyRepoDriverModuleConfig now has a "tempBuildPromotionTargets" map replacing the old single-value "tempBuildPromotionTarget" field. Keys are BuildCategory names, values are the Indy hosted repo names.

Example configuration for indy:
```
  {
    "tempBuildPromotionTargets": {
      "STANDARD": "temporary-builds",
      "SERVICE": "temporary-builds-service"
    }
  }
```
Both DefaultRemoteBuildsCleaner implementations (build-coordinator and remote-build-coordinator) now read the build category from the build record's generic parameters (defaulting to STANDARD when absent) and resolve the correct promotion target at deletion time.

### Checklist:

* [ ] Have you added unit tests for your change?
