### PR TITLE
[stage][NCL-9907] Detect artifact conflict if deployed on the same target repository type and path

### DIFF
--- a/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -111,26 +112,31 @@ public class DefaultDatastore implements Datastore {
 
     @Override
     public Map<Artifact, String> checkForBuiltArtifacts(Collection<Artifact> artifacts) {
-        Map<RepositoryType, Map<String, Artifact>> repoTypes = new HashMap<>();
+        Map<RepositoryType, Map<String, List<Artifact>>> repoTypes = new HashMap<>();
         for (Artifact artifact : artifacts) {
             RepositoryType repoType = artifact.getTargetRepository().getRepositoryType();
-            if (!repoTypes.containsKey(repoType)) {
-                repoTypes.put(repoType, new HashMap<>());
-            }
-            Map<String, Artifact> identifiers = repoTypes.get(repoType);
-            identifiers.put(artifact.getIdentifier(), artifact);
+            repoTypes.computeIfAbsent(repoType, ignored -> new HashMap<>())
+                    .computeIfAbsent(artifact.getIdentifier(), ignored -> Lists.newArrayList())
+                    .add(artifact);
         }
 
         Map<Artifact, String> conflicts = new HashMap<>();
         for (RepositoryType repoType : repoTypes.keySet()) {
-            Map<String, Artifact> identifiers = repoTypes.get(repoType);
+            Map<String, List<Artifact>> identifiers = repoTypes.get(repoType);
             List<Artifact> conflicting = artifactRepository
                     .queryWithPredicates(withIdentifierInAndBuilt(identifiers.keySet()));
             for (Artifact conflict : conflicting) {
                 if (conflict.getTargetRepository().getRepositoryType() == repoType) {
-                    Artifact artifact = identifiers.get(conflict.getIdentifier());
-                    conflicts
-                            .put(artifact, ARTIFACT_ALREADY_BUILT_CONFLICT_MESSAGE + conflict.getBuildRecord().getId());
+                    List<Artifact> candidates = identifiers.get(conflict.getIdentifier());
+                    for (Artifact artifact : candidates) {
+                        if (Objects.equals(
+                                artifact.getTargetRepository().getRepositoryPath(),
+                                conflict.getTargetRepository().getRepositoryPath())) {
+                            conflicts.put(
+                                    artifact,
+                                    ARTIFACT_ALREADY_BUILT_CONFLICT_MESSAGE + conflict.getBuildRecord().getId());
+                        }
+                    }
                 }
             }
         }

--- a/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
+++ b/datastore/src/main/java/org/jboss/pnc/datastore/DefaultDatastore.java
@@ -17,7 +17,6 @@
  */
 package org.jboss.pnc.datastore;
 
-import com.google.common.collect.Lists;
 import org.jboss.pnc.api.enums.AlignmentPreference;
 import org.jboss.pnc.enums.RepositoryType;
 import org.jboss.pnc.model.Artifact;
@@ -112,31 +111,24 @@ public class DefaultDatastore implements Datastore {
 
     @Override
     public Map<Artifact, String> checkForBuiltArtifacts(Collection<Artifact> artifacts) {
-        Map<RepositoryType, Map<String, List<Artifact>>> repoTypes = new HashMap<>();
+        Map<RepositoryType, Map<String, Artifact>> repoTypes = new HashMap<>();
         for (Artifact artifact : artifacts) {
             RepositoryType repoType = artifact.getTargetRepository().getRepositoryType();
-            repoTypes.computeIfAbsent(repoType, ignored -> new HashMap<>())
-                    .computeIfAbsent(artifact.getIdentifier(), ignored -> Lists.newArrayList())
-                    .add(artifact);
+            repoTypes.computeIfAbsent(repoType, ignored -> new HashMap<>()).put(artifact.getIdentifier(), artifact);
         }
 
         Map<Artifact, String> conflicts = new HashMap<>();
         for (RepositoryType repoType : repoTypes.keySet()) {
-            Map<String, List<Artifact>> identifiers = repoTypes.get(repoType);
+            Map<String, Artifact> identifiers = repoTypes.get(repoType);
             List<Artifact> conflicting = artifactRepository
                     .queryWithPredicates(withIdentifierInAndBuilt(identifiers.keySet()));
             for (Artifact conflict : conflicting) {
-                if (conflict.getTargetRepository().getRepositoryType() == repoType) {
-                    List<Artifact> candidates = identifiers.get(conflict.getIdentifier());
-                    for (Artifact artifact : candidates) {
-                        if (Objects.equals(
-                                artifact.getTargetRepository().getRepositoryPath(),
-                                conflict.getTargetRepository().getRepositoryPath())) {
-                            conflicts.put(
-                                    artifact,
-                                    ARTIFACT_ALREADY_BUILT_CONFLICT_MESSAGE + conflict.getBuildRecord().getId());
-                        }
-                    }
+                Artifact artifact = identifiers.get(conflict.getIdentifier());
+                if (conflict.getTargetRepository().getRepositoryType() == repoType && Objects.equals(
+                        artifact.getTargetRepository().getRepositoryPath(),
+                        conflict.getTargetRepository().getRepositoryPath())) {
+                    conflicts
+                            .put(artifact, ARTIFACT_ALREADY_BUILT_CONFLICT_MESSAGE + conflict.getBuildRecord().getId());
                 }
             }
         }

--- a/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
+++ b/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -259,6 +260,37 @@ public class DatastoreTest {
         buildRecord = buildRecordRepository.save(buildRecord);
         builtArtifact1.setBuildRecord(buildRecord);
 
+    }
+
+    @Test
+    @InSequence(3)
+    public void shouldOnlyReportBuiltArtifactConflictForSameRepositoryPath() {
+        TargetRepository sameTargetRepository = TargetRepository.newBuilder()
+                .repositoryType(RepositoryType.MAVEN)
+                .repositoryPath("builds-untested")
+                .identifier(ReposiotryIdentifier.INDY_MAVEN)
+                .temporaryRepo(false)
+                .build();
+        TargetRepository differentTargetRepository = TargetRepository.newBuilder()
+                .repositoryType(RepositoryType.MAVEN)
+                .repositoryPath("lightwell-upstream-temporary-builds")
+                .identifier(ReposiotryIdentifier.INDY_MAVEN)
+                .temporaryRepo(true)
+                .build();
+
+        Artifact sameRepositoryArtifact = Artifact.Builder.newBuilder()
+                .identifier(ARTIFACT_1_IDENTIFIER)
+                .targetRepository(sameTargetRepository)
+                .build();
+        Artifact differentRepositoryArtifact = Artifact.Builder.newBuilder()
+                .identifier(ARTIFACT_1_IDENTIFIER)
+                .targetRepository(differentTargetRepository)
+                .build();
+
+        Map<Artifact, String> conflicts = datastore
+                .checkForBuiltArtifacts(List.of(sameRepositoryArtifact, differentRepositoryArtifact));
+
+        assertThat(conflicts).containsKey(sameRepositoryArtifact).doesNotContainKey(differentRepositoryArtifact);
     }
 
     /**

--- a/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
+++ b/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
@@ -287,10 +287,13 @@ public class DatastoreTest {
                 .targetRepository(differentTargetRepository)
                 .build();
 
-        Map<Artifact, String> conflicts = datastore
-                .checkForBuiltArtifacts(List.of(sameRepositoryArtifact, differentRepositoryArtifact));
+        Map<Artifact, String> sameRepositoryConflicts = datastore
+                .checkForBuiltArtifacts(List.of(sameRepositoryArtifact));
+        Map<Artifact, String> differentRepositoryConflicts = datastore
+                .checkForBuiltArtifacts(List.of(differentRepositoryArtifact));
 
-        assertThat(conflicts).containsKey(sameRepositoryArtifact).doesNotContainKey(differentRepositoryArtifact);
+        assertThat(sameRepositoryConflicts).containsKey(sameRepositoryArtifact);
+        assertThat(differentRepositoryConflicts).isEmpty();
     }
 
     /**

--- a/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
+++ b/datastore/src/test/java/org/jboss/pnc/datastore/DatastoreTest.java
@@ -263,7 +263,7 @@ public class DatastoreTest {
     }
 
     @Test
-    @InSequence(3)
+    @InSequence(7)
     public void shouldOnlyReportBuiltArtifactConflictForSameRepositoryPath() {
         TargetRepository sameTargetRepository = TargetRepository.newBuilder()
                 .repositoryType(RepositoryType.MAVEN)

--- a/rest-api/pnc-openapi.json
+++ b/rest-api/pnc-openapi.json
@@ -7,7 +7,7 @@
       "name" : "Apache 2.0",
       "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version" : "3.5.9-SNAPSHOT"
+    "version" : "3.5.10-SNAPSHOT"
   },
   "servers" : [ {
     "url" : "/pnc-rest",

--- a/rest-api/pnc-openapi.yaml
+++ b/rest-api/pnc-openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: 3.5.9-SNAPSHOT
+  version: 3.5.10-SNAPSHOT
 servers:
 - url: /pnc-rest
   variables: {}


### PR DESCRIPTION
This is to fix LW builds in temporary and persistent mode, that have same identifiers across different target repositories.