### PR TITLE
Require 'pnc-users' role for create/update/delete operations

### DIFF
--- a/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/BuildCoordinatorFactory.java
+++ b/build-coordinator/src/test/java/org/jboss/pnc/coordinator/test/BuildCoordinatorFactory.java
@@ -121,6 +121,7 @@ public class BuildCoordinatorFactory {
                 null,
                 "false",
                 null,
+                null,
                 null);
     }
 

--- a/facade/src/main/java/org/jboss/pnc/facade/providers/api/UserRoles.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/api/UserRoles.java
@@ -22,6 +22,9 @@ package org.jboss.pnc.facade.providers.api;
  */
 public class UserRoles {
 
+    /** Role for regular PNC users (required for creation/update operations) */
+    public static final String USERS = "pnc-users";
+
     /** Role used by all PNC human admins */
     public static final String USERS_ADMIN = "pnc-users-admin";
 

--- a/messaging/src/test/java/org/jboss/pnc/messaging/SysConfigProducer.java
+++ b/messaging/src/test/java/org/jboss/pnc/messaging/SysConfigProducer.java
@@ -65,6 +65,7 @@ public class SysConfigProducer {
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 }

--- a/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/SystemConfig.java
+++ b/moduleconfig/src/main/java/org/jboss/pnc/common/json/moduleconfig/SystemConfig.java
@@ -111,6 +111,8 @@ public class SystemConfig extends AbstractModuleConfig {
 
     private final int bifrostLogUploadRetryDelay;
 
+    private final boolean requirePncUsersRoleForMutating;
+
     public SystemConfig(
             @JsonProperty("authenticationProviderId") String authenticationProviderId,
             @JsonProperty("coordinatorThreadPoolSize") String coordinatorThreadPoolSize,
@@ -142,7 +144,8 @@ public class SystemConfig extends AbstractModuleConfig {
             @JsonProperty("recordUpdateJobMillisDelay") String recordUpdateJobMillisDelay,
             @JsonProperty("recordUpdateJobEnabled") String recordUpdateJobEnabled,
             @JsonProperty("bifrostLogUploadMaxRetries") String bifrostLogUploadMaxRetries,
-            @JsonProperty("bifrostLogUploadRetryDelay") String bifrostLogUploadRetryDelay) {
+            @JsonProperty("bifrostLogUploadRetryDelay") String bifrostLogUploadRetryDelay,
+            @JsonProperty("requirePncUsersRoleForMutating") String requirePncUsersRoleForMutating) {
         this.authenticationProviderId = authenticationProviderId;
         this.coordinatorThreadPoolSize = toIntWithDefault("coordinatorThreadPoolSize", coordinatorThreadPoolSize, 1);
         this.coordinatorMaxConcurrentBuilds = toIntWithDefault(
@@ -188,6 +191,8 @@ public class SystemConfig extends AbstractModuleConfig {
         this.recordUpdateJobEnabled = Boolean.parseBoolean(recordUpdateJobEnabled);
         this.bifrostLogUploadMaxRetries = toIntWithDefault("bifrostLogUploadMaxRetries", bifrostLogUploadMaxRetries, 3);
         this.bifrostLogUploadRetryDelay = toIntWithDefault("bifrostLogUploadRetryDelay", bifrostLogUploadRetryDelay, 2);
+        this.requirePncUsersRoleForMutating = requirePncUsersRoleForMutating != null
+                && Boolean.parseBoolean(requirePncUsersRoleForMutating);
     }
 
     public static Properties readProperties(String file) {
@@ -382,6 +387,10 @@ public class SystemConfig extends AbstractModuleConfig {
                 + recordUpdateJobMillisDelay + ", recordUpdateJobEnabled=" + recordUpdateJobEnabled
                 + ", bifrostLogUploadMaxRetries=" + bifrostLogUploadMaxRetries + ", bifrostLogUploadRetryDelay="
                 + bifrostLogUploadRetryDelay + '}';
+    }
+
+    public boolean isRequirePncUsersRoleForMutating() {
+        return requirePncUsersRoleForMutating;
     }
 
     public boolean isRecordUpdateJobEnabled() {

--- a/notifications/src/test/java/org/jboss/pnc/notification/DefaultObserverTest.java
+++ b/notifications/src/test/java/org/jboss/pnc/notification/DefaultObserverTest.java
@@ -109,6 +109,7 @@ public class DefaultObserverTest {
                 null,
                 "false",
                 null,
+                null,
                 null);
     }
 
@@ -144,6 +145,7 @@ public class DefaultObserverTest {
                 null,
                 "false",
                 null,
+                null,
                 null);
     }
 
@@ -178,6 +180,7 @@ public class DefaultObserverTest {
                 "true",
                 null,
                 "false",
+                null,
                 null,
                 null);
     }

--- a/pnc-mock/src/main/java/org/jboss/pnc/mock/common/SystemConfigMock.java
+++ b/pnc-mock/src/main/java/org/jboss/pnc/mock/common/SystemConfigMock.java
@@ -70,6 +70,7 @@ public class SystemConfigMock {
                 null,
                 "false",
                 null,
+                null,
                 null);
     }
 }

--- a/rest/src/main/java/org/jboss/pnc/rest/SecurityConstraintFilter.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/SecurityConstraintFilter.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.rest;
 
 import org.jboss.pnc.common.Strings;
+import org.jboss.pnc.common.json.moduleconfig.SystemConfig;
 import org.jboss.pnc.facade.util.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,12 +26,15 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Priority;
 import javax.inject.Inject;
 import javax.ws.rs.HttpMethod;
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.ext.Provider;
 import java.io.IOException;
+
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS;
 
 /**
  * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
@@ -46,6 +50,9 @@ public class SecurityConstraintFilter implements ContainerRequestFilter {
     @Inject
     UserService userService;
 
+    @Inject
+    SystemConfig systemConfig;
+
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
         String method = requestContext.getRequest().getMethod().toUpperCase();
@@ -60,5 +67,16 @@ public class SecurityConstraintFilter implements ContainerRequestFilter {
                 && !userService.isUserLoggedIn()) {
             throw new NotAuthorizedException("Authorization required to access this resource.");
         }
+        if (systemConfig.isRequirePncUsersRoleForMutating()
+                && Strings.anyStringEquals(method, HttpMethod.POST, HttpMethod.PUT, HttpMethod.DELETE, HttpMethod.PATCH)
+                && !isInternalPath(path) && userService.isUserLoggedIn() && !userService.hasLoggedInUserRole(USERS)) {
+            throw new ForbiddenException("You must have the " + USERS + " role to perform this operation.");
+        }
+    }
+
+    private static boolean isInternalPath(String path) {
+        return path.startsWith("/build-tasks/") || path.startsWith("/bpm/") || path.startsWith("/debug/")
+                || path.startsWith("/health") || path.matches("/deliverable-analyses/complete")
+                || path.matches("/builds/[^/]+/brew-push/complete") || path.matches("/operations/[^/]+/complete");
     }
 }

--- a/rest/src/main/webconfig/auth/web.xml
+++ b/rest/src/main/webconfig/auth/web.xml
@@ -41,6 +41,9 @@
         <listener-class>org.wildfly.security.http.oidc.OidcConfigurationServletListener</listener-class>
     </listener>
     <security-role>
+        <role-name>pnc-users</role-name>
+    </security-role>
+    <security-role>
         <role-name>pnc-app-build-delete</role-name>
     </security-role>
     <security-role>


### PR DESCRIPTION
If the systemconfig contains 'requirePncUsersForMutating' = 'true', we'll now require users to have the 'pnc-users' role to do any create/update/delete operations.

### Checklist:

* [ ] Have you added unit tests for your change?
