### PR TITLE
Enable proactive OIDC access token refresh before expiry

### DIFF
--- a/rest/src/main/webconfig/auth/oidc.json
+++ b/rest/src/main/webconfig/auth/oidc.json
@@ -5,6 +5,7 @@
     "principal-attribute" : "preferred_username",
     "ssl-required" : "EXTERNAL",
     "autodetect-bearer-only": "${env.OIDC_AUTODETECT_BEARER_ONLY:true}",
+    "token-minimum-time-to-live": 30,
     "credentials": {
         "secret": "${env.OIDC_CLIENT_SECRET}"
     }


### PR DESCRIPTION
Without token-minimum-time-to-live, the Elytron OIDC adapter does not proactively refresh the access token, causing it to expire while the session cookie is still valid.

### Checklist:

* [ ] Have you added unit tests for your change?
