### PR TITLE
Set session-timeout to 10 hours to match max-age cookie

### DIFF
--- a/rest/src/main/webconfig/auth/web.xml
+++ b/rest/src/main/webconfig/auth/web.xml
@@ -26,6 +26,7 @@
     <module-name>rest</module-name>
 
     <session-config>
+        <session-timeout>600</session-timeout>
         <cookie-config>
             <http-only>true</http-only>
             <secure>true</secure>


### PR DESCRIPTION
The cookie max-age (10 hours) and the server-side session timeout (default ~30 minutes) were mismatched. The browser kept sending the cookie long after the server had discarded the session and its cached OIDC identity.

### Checklist:

* [ ] Have you added unit tests for your change?
