### PR TITLE
Try to set connection-pool-size to 0

### DIFF
--- a/rest/src/main/webconfig/auth/oidc.json
+++ b/rest/src/main/webconfig/auth/oidc.json
@@ -6,6 +6,7 @@
     "ssl-required" : "EXTERNAL",
     "autodetect-bearer-only": "${env.OIDC_AUTODETECT_BEARER_ONLY:true}",
     "token-minimum-time-to-live": 30,
+    "connection-pool-size": 1,
     "credentials": {
         "secret": "${env.OIDC_CLIENT_SECRET}"
     }


### PR DESCRIPTION
    In our Openshift instance, we think that a firewall somewhere kills the
    pooled connection with our SSO server without telling the client. As
    such, when our client tries to use the pooled connection to refresh a
    token, it fails with connection reset.

    We try to set connection-pool-size to 0 so that hopefully connections
    aren't re-used and we get a new one everytime.


### Checklist:

* [ ] Have you added unit tests for your change?
