### PR TITLE
Consider using the JWT 'sub' field for the other SSO

### DIFF
--- a/auth/src/main/java/org/jboss/pnc/auth/ElytronLoggedInUser.java
+++ b/auth/src/main/java/org/jboss/pnc/auth/ElytronLoggedInUser.java
@@ -150,6 +150,9 @@ public class ElytronLoggedInUser implements LoggedInUser {
             userInfo.roles = new HashSet<>(accessToken.getRealmAccessClaim().getRoles());
         } else {
             // for the other SSO server at the other company
+            // preferred_username for the other SSO is just a random id, sub contains the email address which is
+            // more readable. Could also have used 'emailAddress'.
+            userInfo.username = accessToken.getClaimValueAsString("sub");
             userInfo.roles = new HashSet<>(accessToken.getStringListClaimValue("groups"));
         }
 


### PR DESCRIPTION
The other SSO server's preferredUsername is just a random string where it's hard to identify the user. Instead, consider using 'sub' which is the email address of the user.

The field 'emailAddress' could also have been used.

### Checklist:

* [ ] Have you added unit tests for your change?
