### PR TITLE
[v3.5.x] Re-add retry loop with backoff to generated REST clients

### DIFF
--- a/processor/src/main/java/org/jboss/pnc/processor/ClientGenerator.java
+++ b/processor/src/main/java/org/jboss/pnc/processor/ClientGenerator.java
@@ -39,12 +39,10 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
-import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.io.InputStream;
@@ -268,6 +266,7 @@ public class ClientGenerator extends AbstractProcessor {
                                 .addException(ClassName.get("org.jboss.pnc.client", "RemoteResourceNotFoundException"))
                                 .returns(TypeName.get(void.class))
                                 .addStatement(coreStatement)
+                                .addStatement("return")
                                 .nextControlFlow("catch ($T e)", NotFoundException.class)
                                 .addStatement("throw new RemoteResourceNotFoundException(e)");
                         MethodSpec methodSpec = completeMethod(methodBuilder, coreStatement);
@@ -343,22 +342,24 @@ public class ClientGenerator extends AbstractProcessor {
     private MethodSpec completeMethod(
             MethodSpec.Builder methodBuilder,
             Consumer<MethodSpec.Builder> coreStatementConsumer) {
-        // Generate retry logic for 401 responses
-        methodBuilder = methodBuilder.nextControlFlow("catch ($T e)", Exception.class)
-                .beginControlFlow("if (shouldRetryOn401(e))")
-                .beginControlFlow("try")
-                .addComment("Retry after refreshing token");
-
-        // Execute the core statement again (retry)
-        coreStatementConsumer.accept(methodBuilder);
-
-        return methodBuilder.nextControlFlow("catch ($T retryException)", Exception.class)
-                .addStatement("throw handleException(retryException)")
+        ClassName remoteResourceException = ClassName.get("org.jboss.pnc.client", "RemoteResourceException");
+        return methodBuilder.nextControlFlow("catch ($T e)", Exception.class)
+                .beginControlFlow("if (!retriedOn401 && shouldRetryOn401(e))")
+                .addStatement("retriedOn401 = true")
+                .addStatement("attempt--")
+                .addStatement("continue")
                 .endControlFlow()
-                .nextControlFlow("else")
+                .beginControlFlow("if (attempt < getMaxRetries() && isRetryableException(e))")
+                .addStatement("waitForRetry(attempt)")
+                .addStatement("continue")
+                .endControlFlow()
                 .addStatement("throw handleException(e)")
                 .endControlFlow()
                 .endControlFlow()
+                .addStatement(
+                        "throw new $T($S, -1)",
+                        remoteResourceException,
+                        "Request failed after exhausting all retries")
                 .build();
     }
 
@@ -366,7 +367,9 @@ public class ClientGenerator extends AbstractProcessor {
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(restApiMethod.getSimpleName().toString())
                 .addModifiers(Modifier.PUBLIC)
                 .addException(ClassName.get("org.jboss.pnc.client", "RemoteResourceException"));
-        methodBuilder.beginControlFlow("try");
+        methodBuilder.addStatement("boolean retriedOn401 = false")
+                .beginControlFlow("for (int attempt = 0; attempt <= getMaxRetries(); attempt++)")
+                .beginControlFlow("try");
         return methodBuilder;
     }
 

--- a/rest-api/pnc-openapi.json
+++ b/rest-api/pnc-openapi.json
@@ -7,7 +7,7 @@
       "name" : "Apache 2.0",
       "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version" : "3.5.13-SNAPSHOT"
+    "version" : "3.5.14-SNAPSHOT"
   },
   "servers" : [ {
     "url" : "/pnc-rest",

--- a/rest-api/pnc-openapi.yaml
+++ b/rest-api/pnc-openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: 3.5.13-SNAPSHOT
+  version: 3.5.14-SNAPSHOT
 servers:
 - url: /pnc-rest
   variables: {}

--- a/rest-api/src/main/java/org/jboss/pnc/client/ClientBase.java
+++ b/rest-api/src/main/java/org/jboss/pnc/client/ClientBase.java
@@ -269,6 +269,31 @@ public abstract class ClientBase<T> implements Closeable {
         return null;
     }
 
+    protected int getMaxRetries() {
+        return Math.max(0, configuration.getMaxRetries());
+    }
+
+    protected boolean isRetryableException(Exception e) {
+        if (e instanceof ProcessingException) {
+            return true;
+        }
+        if (e instanceof WebApplicationException) {
+            int status = ((WebApplicationException) e).getResponse().getStatus();
+            return status >= 500;
+        }
+        return false;
+    }
+
+    protected void waitForRetry(int attempt) {
+        long delay = configuration.getRetryDelayMillis() * (long) Math.pow(2, attempt);
+        logger.debug("Request failed, retrying in {}ms (attempt {}/{})", delay, attempt + 1, getMaxRetries());
+        try {
+            Thread.sleep(delay);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
     protected boolean shouldRetryOn401(Exception e) {
         // Check if it's a 401 error and we have a token supplier to refresh
         if (e instanceof javax.ws.rs.WebApplicationException) {

--- a/rest-api/src/main/java/org/jboss/pnc/client/Configuration.java
+++ b/rest-api/src/main/java/org/jboss/pnc/client/Configuration.java
@@ -62,6 +62,18 @@ public class Configuration {
      */
     private final int pageSize;
 
+    @Builder.Default
+    private final long connectTimeoutMillis = 30_000L;
+
+    @Builder.Default
+    private final long readTimeoutMillis = 60_000L;
+
+    @Builder.Default
+    private final int maxRetries = 5;
+
+    @Builder.Default
+    private final long retryDelayMillis = 500L;
+
     /**
      * Define which values from the logging MDC are added as headers to the request. A key is a MDC key. A value is a
      * header name

--- a/rest-api/src/test/java/org/jboss/pnc/client/ClientTest.java
+++ b/rest-api/src/test/java/org/jboss/pnc/client/ClientTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 
@@ -63,7 +64,9 @@ public class ClientTest {
         }).build();
         server.start();
         try {
-            Configuration configuration = getBasicConfiguration(8080).addDefaultMdcToHeadersMappings().build();
+            Configuration configuration = getBasicConfiguration(8080).maxRetries(0)
+                    .addDefaultMdcToHeadersMappings()
+                    .build();
 
             ProjectClient projectClient = new ProjectClient(configuration);
 
@@ -107,6 +110,52 @@ public class ClientTest {
 
         // then
         Assert.assertEquals(2, tokenGenerator.getInvocationCount());
+    }
+
+    @Test
+    public void shouldRetryOnServerError() throws RemoteResourceException {
+        // given
+        Configuration configuration = getBasicConfiguration(8081).maxRetries(2).retryDelayMillis(100).build();
+
+        wireMockServer.stubFor(
+                get(urlMatching(".*")).willReturn(
+                        aResponse().withStatus(500).withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)));
+
+        BuildClient buildClient = new BuildClient(configuration);
+
+        // when
+        try {
+            buildClient.getSpecific("1");
+            Assert.fail("Expected RemoteResourceException");
+        } catch (RemoteResourceException e) {
+            // expected
+        }
+
+        // then - initial request + 2 retries = 3 total
+        wireMockServer.verify(3, getRequestedFor(urlMatching(".*")));
+    }
+
+    @Test
+    public void shouldNotRetryOnClientError() throws RemoteResourceException {
+        // given
+        Configuration configuration = getBasicConfiguration(8081).maxRetries(2).retryDelayMillis(100).build();
+
+        wireMockServer.stubFor(
+                get(urlMatching(".*")).willReturn(
+                        aResponse().withStatus(400).withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)));
+
+        BuildClient buildClient = new BuildClient(configuration);
+
+        // when
+        try {
+            buildClient.getSpecific("1");
+            Assert.fail("Expected RemoteResourceException");
+        } catch (RemoteResourceException e) {
+            // expected
+        }
+
+        // then - only 1 request, no retries for 4xx
+        wireMockServer.verify(1, getRequestedFor(urlMatching(".*")));
     }
 
     private Configuration.ConfigurationBuilder getBasicConfiguration(int port) {


### PR DESCRIPTION
Replace the single-retry 401 handler with a configurable retry loop that supports both 401 token refresh and retryable exceptions with backoff.

When we switched from PNC 3.4.x to PNC 3.5.x, we removed the Apache Retry Handler from the REST client generation codebase.

This commit attempts to re-add retries to the client, with a default of 5 retries with a retry delay of 500 ms by default.

### Checklist:

* [ ] Have you added unit tests for your change?
