### PR TITLE
[NCL-9931] Restrict keep-pod-alive build trigger option to admins

### DIFF
--- a/integration-test/src/test/java/org/jboss/pnc/integration/BuildTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/BuildTest.java
@@ -27,6 +27,7 @@ import org.jboss.pnc.client.ClientException;
 import org.jboss.pnc.client.GroupBuildClient;
 import org.jboss.pnc.client.GroupConfigurationClient;
 import org.jboss.pnc.client.RemoteCollection;
+import org.jboss.pnc.client.RemoteResourceException;
 import org.jboss.pnc.client.RemoteResourceNotFoundException;
 import org.jboss.pnc.dto.Build;
 import org.jboss.pnc.dto.BuildConfiguration;
@@ -35,6 +36,7 @@ import org.jboss.pnc.dto.BuildConfigurationRevisionRef;
 import org.jboss.pnc.dto.GroupBuild;
 import org.jboss.pnc.dto.GroupConfiguration;
 import org.jboss.pnc.dto.requests.GroupBuildRequest;
+import org.jboss.pnc.dto.response.ErrorResponse;
 import org.jboss.pnc.enums.BuildStatus;
 import org.jboss.pnc.integration.utils.ResponseUtils;
 import org.jboss.pnc.integration.setup.Deployments;
@@ -60,7 +62,9 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.jboss.pnc.integration.setup.RestClientConfiguration.asSystem;
 import static org.jboss.pnc.integration.setup.RestClientConfiguration.asUser;
+import static org.junit.Assert.assertThrows;
 
 @RunAsClient
 @RunWith(Arquillian.class)
@@ -97,6 +101,43 @@ public class BuildTest {
 
         EnumSet<BuildStatus> isIn = EnumSet.of(BuildStatus.SUCCESS);
         ResponseUtils.waitSynchronouslyFor(() -> buildToFinish(build.getId(), isIn, null), 15, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void shouldTriggerBuildWithKeepPodOnFailureAsAdmin() throws ClientException {
+        // with
+        BuildConfiguration buildConfiguration = buildConfigurationClient.getAll().iterator().next();
+        BuildParameters buildParameters = getPersistentParameters(true);
+        buildParameters.setKeepPodOnFailure(true);
+
+        // when
+        Build build = new BuildConfigurationClient(asSystem()).trigger(buildConfiguration.getId(), buildParameters);
+
+        // then
+        assertThat(build).isNotNull().extracting("id").isNotNull().isNotEqualTo("");
+        EnumSet<BuildStatus> isIn = EnumSet.of(BuildStatus.SUCCESS);
+        ResponseUtils.waitSynchronouslyFor(() -> buildToFinish(build.getId(), isIn, null), 15, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void shouldRejectBuildWithKeepPodOnFailureAsNonAdmin() throws ClientException {
+        // with
+        BuildConfiguration buildConfiguration = buildConfigurationClient.getAll().iterator().next();
+        BuildParameters buildParameters = getPersistentParameters();
+        buildParameters.setKeepPodOnFailure(true);
+
+        // when
+        RemoteResourceException exception = assertThrows(
+                RemoteResourceException.class,
+                () -> buildConfigurationClient.trigger(buildConfiguration.getId(), buildParameters));
+
+        // then
+        assertThat(exception.getStatus()).isEqualTo(403);
+        ErrorResponse errorResponse = exception.getResponse().get();
+        assertThat(errorResponse.getErrorType()).isEqualTo("EJBAccessException");
+        String details = (String) errorResponse.getDetails();
+        assertThat(details)
+                .isEqualTo("Only users with the pnc-users-admin role are allowed to set keep-pod-alive feature");
     }
 
     @Test

--- a/rest-api/pnc-openapi.json
+++ b/rest-api/pnc-openapi.json
@@ -1524,7 +1524,7 @@
         }, {
           "name" : "keepPodOnFailure",
           "in" : "query",
-          "description" : "Should we keep the build container running, if the build fails?",
+          "description" : "Should we keep the build container running, if the build fails? Requires the pnc-users-admin role.",
           "schema" : {
             "type" : "boolean",
             "default" : false
@@ -2312,7 +2312,7 @@
         }, {
           "name" : "keepPodOnFailure",
           "in" : "query",
-          "description" : "Should we keep the build container running, if the build fails?",
+          "description" : "Should we keep the build container running, if the build fails? Requires the pnc-users-admin role.",
           "schema" : {
             "type" : "boolean",
             "default" : false

--- a/rest-api/pnc-openapi.yaml
+++ b/rest-api/pnc-openapi.yaml
@@ -1091,7 +1091,8 @@ paths:
           default: true
       - name: keepPodOnFailure
         in: query
-        description: "Should we keep the build container running, if the build fails?"
+        description: "Should we keep the build container running, if the build fails?\
+          \ Requires the pnc-users-admin role."
         schema:
           type: boolean
           default: false
@@ -1655,7 +1656,8 @@ paths:
           default: true
       - name: keepPodOnFailure
         in: query
-        description: "Should we keep the build container running, if the build fails?"
+        description: "Should we keep the build container running, if the build fails?\
+          \ Requires the pnc-users-admin role."
         schema:
           type: boolean
           default: false

--- a/rest-api/src/main/java/org/jboss/pnc/rest/configuration/SwaggerConstants.java
+++ b/rest-api/src/main/java/org/jboss/pnc/rest/configuration/SwaggerConstants.java
@@ -83,7 +83,7 @@ public interface SwaggerConstants {
     public static final String REBUILD_MODE_DESC = "What should varant rebuild?";
     public static final String DEFAULT_REBUILD_MODE = "IMPLICIT_DEPENDENCY_CHECK";
     public static final String BUILD_DEPENDENCIES_DESC = "Should we build also dependencies of this Build Config?";
-    public static final String KEEP_POD_ON_FAIL_DESC = "Should we keep the build container running, if the build fails?";
+    public static final String KEEP_POD_ON_FAIL_DESC = "Should we keep the build container running, if the build fails? Requires the pnc-users-admin role.";
     public static final String LATEST_BUILD_DESC = "Should return only latest build?";
     public static final String LATEST_GROUP_BUILD_DESC = "Should return only latest group build?";
     public static final String RUNNING_BUILDS_DESC = "Should return only running builds?";

--- a/rest/src/main/java/org/jboss/pnc/rest/endpoints/BuildConfigurationEndpointImpl.java
+++ b/rest/src/main/java/org/jboss/pnc/rest/endpoints/BuildConfigurationEndpointImpl.java
@@ -38,6 +38,7 @@ import org.jboss.pnc.facade.providers.api.BuildConfigurationSupportedGenericPara
 import org.jboss.pnc.facade.providers.api.BuildPageInfo;
 import org.jboss.pnc.facade.providers.api.BuildProvider;
 import org.jboss.pnc.facade.providers.api.GroupConfigurationProvider;
+import org.jboss.pnc.facade.util.UserService;
 import org.jboss.pnc.facade.validation.AlreadyRunningException;
 import org.jboss.pnc.facade.validation.InvalidEntityException;
 import org.jboss.pnc.facade.validation.InvalidRequestException;
@@ -54,6 +55,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
+import javax.ejb.EJBAccessException;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletResponse;
@@ -65,6 +67,8 @@ import javax.ws.rs.core.Response;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.jboss.pnc.facade.providers.api.UserRoles.USERS_ADMIN;
 
 @ApplicationScoped
 public class BuildConfigurationEndpointImpl implements BuildConfigurationEndpoint {
@@ -91,6 +95,9 @@ public class BuildConfigurationEndpointImpl implements BuildConfigurationEndpoin
 
     @Inject
     private AlignmentConfig alignmentConfig;
+
+    @Inject
+    private UserService userService;
 
     private EndpointHelper<Integer, BuildConfiguration, BuildConfigurationRef> endpointHelper;
 
@@ -329,6 +336,11 @@ public class BuildConfigurationEndpointImpl implements BuildConfigurationEndpoin
     }
 
     private BuildOptions toBuildOptions(BuildParameters buildParams) {
+        if (buildParams.isKeepPodOnFailure() && !userService.hasLoggedInUserRole(USERS_ADMIN)) {
+            throw new EJBAccessException(
+                    "Only users with the " + USERS_ADMIN + " role are allowed to set keep-pod-alive feature");
+        }
+
         BuildOptions buildOptions = new BuildOptions(
                 buildParams.isTemporaryBuild(),
                 buildParams.isBuildDependencies(),


### PR DESCRIPTION
### Checklist:

* [ ] Have you added unit tests for your change?
