### PR TITLE
[v3.5.x] Enforce pnc-users-admin in-app for GenericSettingProvider

### DIFF
--- a/facade/src/main/java/org/jboss/pnc/facade/providers/GenericSettingProvider.java
+++ b/facade/src/main/java/org/jboss/pnc/facade/providers/GenericSettingProvider.java
@@ -27,7 +27,7 @@ import org.jboss.pnc.spi.notifications.Notifier;
 import org.jboss.util.Strings;
 
 import javax.annotation.security.PermitAll;
-import javax.annotation.security.RolesAllowed;
+import javax.ejb.EJBAccessException;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import java.time.Instant;
@@ -56,8 +56,8 @@ public class GenericSettingProvider {
     public GenericSettingProvider() {
     }
 
-    @RolesAllowed(USERS_ADMIN)
     public void activateMaintenanceMode() {
+        requireAdmin();
 
         log.info("Activating Maintenance mode");
         GenericSetting maintenanceMode = createGenericParameterIfNotFound(MAINTENANCE_MODE);
@@ -66,8 +66,8 @@ public class GenericSettingProvider {
         genericSettingRepository.save(maintenanceMode);
     }
 
-    @RolesAllowed(USERS_ADMIN)
     public void deactivateMaintenanceMode() {
+        requireAdmin();
 
         log.info("Deactivating Maintenance mode");
         GenericSetting maintenanceMode = genericSettingRepository.queryByKey(MAINTENANCE_MODE);
@@ -103,8 +103,8 @@ public class GenericSettingProvider {
         return !isInMaintenanceMode();
     }
 
-    @RolesAllowed(USERS_ADMIN)
     public void setPNCVersion(String version) {
+        requireAdmin();
 
         log.info("PNC System version set to: '{}'", version);
         GenericSetting pncVersion = createGenericParameterIfNotFound(PNC_VERSION);
@@ -123,8 +123,8 @@ public class GenericSettingProvider {
         }
     }
 
-    @RolesAllowed(USERS_ADMIN)
     public void setAnnouncementBanner(String banner) {
+        requireAdmin();
 
         log.info("Announcement banner set to: '{}'", banner);
         GenericSetting announcementBanner = createGenericParameterIfNotFound(ANNOUNCEMENT_BANNER);
@@ -143,8 +143,8 @@ public class GenericSettingProvider {
         }
     }
 
-    @RolesAllowed(USERS_ADMIN)
     public void clearAnnouncementBanner() {
+        requireAdmin();
         clearByKey(ANNOUNCEMENT_BANNER);
     }
 
@@ -159,21 +159,34 @@ public class GenericSettingProvider {
                 .build();
     }
 
-    @RolesAllowed(USERS_ADMIN)
     public void setEta(String eta) {
+        requireAdmin();
         log.info("ETA set to: '{}'", eta);
         GenericSetting pncEta = createGenericParameterIfNotFound(ANNOUNCEMENT_ETA);
         pncEta.setValue(eta);
         genericSettingRepository.save(pncEta);
     }
 
-    @RolesAllowed(USERS_ADMIN)
     public void clearEta() {
+        requireAdmin();
         clearByKey(ANNOUNCEMENT_ETA);
     }
 
     public void notifyListeners() {
         notifier.sendMessage(GenericSettingNotification.pncStatusChanged(getPncStatus()));
+    }
+
+    /**
+     * Authorize the operation at the application level by reading the role from the logged-in user (OIDC token claims
+     * or LDAP-derived roles) rather than relying on the EJB container's {@code @RolesAllowed}. The container identity
+     * does not carry the roles for all SSO providers (e.g. when roles are delivered in the token's "groups" claim),
+     * whereas {@link UserService#hasLoggedInUserRole} resolves them consistently across auth methods.
+     */
+    private void requireAdmin() {
+        if (!userService.hasLoggedInUserRole(USERS_ADMIN)) {
+            throw new EJBAccessException(
+                    "Only users with the " + USERS_ADMIN + " role are allowed to perform this operation");
+        }
     }
 
     private GenericSetting createGenericParameterIfNotFound(String key) {

--- a/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/GenericSettingEndpointTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/GenericSettingEndpointTest.java
@@ -31,11 +31,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.stream.Stream;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 @RunAsClient
 @RunWith(Arquillian.class)
@@ -65,8 +62,6 @@ public class GenericSettingEndpointTest {
         assertThat(errorResponse.getErrorMessage()).isEqualTo(
                 "Insufficient privileges: the required role to access the resource is missing in the provided JWT.");
         String details = (String) errorResponse.getDetails();
-        assertTrue(
-                Stream.of("Invocation on method", "GenericSettingProvider.setAnnouncementBanner", "is not allowed")
-                        .allMatch(details::contains));
+        assertThat(details).isEqualTo("Only users with the pnc-users-admin role are allowed to perform this operation");
     }
 }

--- a/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/PncStatusEndpointTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/integration/endpoints/PncStatusEndpointTest.java
@@ -90,9 +90,7 @@ public class PncStatusEndpointTest {
         assertThat(errorResponse.getErrorMessage()).isEqualTo(
                 "Insufficient privileges: the required role to access the resource is missing in the provided JWT.");
         String details = (String) errorResponse.getDetails();
-        assertTrue(
-                Stream.of("Invocation on method", "GenericSettingProvider.setAnnouncementBanner", "is not allowed")
-                        .allMatch(details::contains));
+        assertThat(details).isEqualTo("Only users with the pnc-users-admin role are allowed to perform this operation");
     }
 
     @Test

--- a/rest-api/pnc-openapi.json
+++ b/rest-api/pnc-openapi.json
@@ -7,7 +7,7 @@
       "name" : "Apache 2.0",
       "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version" : "3.5.14-SNAPSHOT"
+    "version" : "3.5.15-SNAPSHOT"
   },
   "servers" : [ {
     "url" : "/pnc-rest",

--- a/rest-api/pnc-openapi.yaml
+++ b/rest-api/pnc-openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: 3.5.14-SNAPSHOT
+  version: 3.5.15-SNAPSHOT
 servers:
 - url: /pnc-rest
   variables: {}


### PR DESCRIPTION
Replace the EJB @RolesAllowed(pnc-users-admin) checks with an application-level requireAdmin() using UserService.hasLoggedInUserRole.

The container SecurityIdentity does not carry roles for all SSO providers (e.g. IBM SSO delivers them in the token "groups" claim), so @RolesAllowed denied maintenance-mode/banner/ETA changes for otherwise-authorized admins. Denial still throws EJBAccessException (403 via UnauthorizedExceptionMapper).

### Checklist:

* [x] Have you added unit tests for your change?
