### PR TITLE
Preserve Java 11 compatibility for json-schema-validator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <version.commons-collections>3.2.2</version.commons-collections>
     <version.commons-validator>1.10.1</version.commons-validator>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
-    <version.json-schema-validator>3.0.6</version.json-schema-validator>
+    <version.json-schema-validator>2.0.7</version.json-schema-validator>
 
     <!-- OTEL Dependencies for Instrumentation -->
     <version.io.opentelemetry.instrumentation>2.24.0</version.io.opentelemetry.instrumentation>


### PR DESCRIPTION
## Summary

- select `json-schema-validator` 2.0.7, the latest Java-11-compatible 2.x release
- preserve PNC's Java 11 baseline while still advancing the dependency from 2.0.1

## Why

The Dependabot-selected 3.0.6 artifact is compiled for Java 17 (class-file version 61), so PNC's Java 11 build (maximum class-file version 55) cannot compile `SlsaProvenanceUtils`.

Version 2.0.7 declares Java 8, its classes use class-file version 52, and the public signatures PNC uses in `SchemaRegistryConfig`, `SchemaRegistry`, `Schema`, `SpecificationVersion`, `InputFormat`, and `Error` are unchanged from 2.0.1. The API delta across those classes is additive only.

## Verification

- `mvn --batch-mode --no-transfer-progress clean install -DskipTests` on Java 11 — all 32 modules passed
- `mvn --batch-mode --no-transfer-progress -pl :facade -Dtest=SlsaProvenanceProviderHelperTest test` on Java 11 — 13 tests passed
- resolved `:facade` dependency tree contains `com.networknt:json-schema-validator:2.0.7`

A stronger full `mvn clean install` also passed the facade and SLSA suites, then encountered an unrelated 50 ms reconnect race in `WebSocketClientTest`; that early assertion prevented Undertow cleanup and cascaded into four port-bind errors. An isolated rerun of `WebSocketClientTest` passed all 9 tests.

### Checklist

- [ ] Have you added unit tests for your change?
  - No production code changed; the existing 13-test SLSA provenance suite covers the affected API path and passed.

## AI assistance

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):

- `jaipilot-maintainer-intent`
- `jaipilot-fast-execution`
- `jaipilot-review-diff`
- Execution profile: gpt-5.6-sol · xhigh · fast
